### PR TITLE
fix: remove extra localized strings - WPB-25636

### DIFF
--- a/WireDomain/Sources/WireDomain/Resources/Localization/Localizable.xcstrings
+++ b/WireDomain/Sources/WireDomain/Resources/Localization/Localizable.xcstrings
@@ -10,42 +10,6 @@
             "value" : "قبول"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -56,18 +20,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Annehmen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
           }
         },
         "en" : {
@@ -88,18 +40,6 @@
             "value" : "Vasta"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -110,36 +50,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Accepter"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
           }
         },
         "it" : {
@@ -154,64 +64,10 @@
             "value" : "承諾"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Priimti"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
           }
         },
         "nl" : {
@@ -220,22 +76,10 @@
             "value" : "Neem op"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Odbierz"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
           }
         },
         "pt-BR" : {
@@ -244,28 +88,10 @@
             "value" : "Aceitar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Принять"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
           }
         },
         "sl" : {
@@ -274,70 +100,16 @@
             "value" : "Sprejmi"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kabul et"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Прийняти"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept"
           }
         },
         "zh-Hans" : {
@@ -363,42 +135,6 @@
             "value" : "معاودة الاتصال"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -409,18 +145,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rückruf"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
           }
         },
         "en" : {
@@ -441,18 +165,6 @@
             "value" : "Helist tagasi"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -463,36 +175,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rappeler"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
           }
         },
         "it" : {
@@ -507,64 +189,10 @@
             "value" : "電話をかけ直す"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Perskambnti"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
           }
         },
         "nl" : {
@@ -573,22 +201,10 @@
             "value" : "Bel terug"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oddzwoń"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
           }
         },
         "pt-BR" : {
@@ -597,28 +213,10 @@
             "value" : "Ligue de volta"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Перезвонить"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
           }
         },
         "sl" : {
@@ -627,70 +225,16 @@
             "value" : "Kliči nazaj"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geri Ara"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Передзвонити"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Call Back"
           }
         },
         "zh-Hans" : {
@@ -716,42 +260,6 @@
             "value" : "رفض"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -762,18 +270,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ablehnen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
           }
         },
         "en" : {
@@ -794,18 +290,6 @@
             "value" : "Keeldu"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -816,36 +300,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Refuser"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
           }
         },
         "it" : {
@@ -860,64 +314,10 @@
             "value" : "辞退"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Atmesti"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
           }
         },
         "nl" : {
@@ -926,22 +326,10 @@
             "value" : "Leg op"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Odrzuć"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
           }
         },
         "pt-BR" : {
@@ -950,28 +338,10 @@
             "value" : "Rejeitar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отклонить"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
           }
         },
         "sl" : {
@@ -980,70 +350,16 @@
             "value" : "Zavrni"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reddet"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Скасувати"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decline"
           }
         },
         "zh-Hans" : {
@@ -1069,42 +385,6 @@
             "value" : "كتم الصوت"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1115,18 +395,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stumm"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
           }
         },
         "en" : {
@@ -1147,18 +415,6 @@
             "value" : "Hääletu"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1169,36 +425,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mettre en sourdine"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
           }
         },
         "it" : {
@@ -1213,64 +439,10 @@
             "value" : "ミュート"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Išjungti pranešimus"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
           }
         },
         "nl" : {
@@ -1279,22 +451,10 @@
             "value" : "Dempen"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wycisz"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
           }
         },
         "pt-BR" : {
@@ -1303,28 +463,10 @@
             "value" : "Silenciar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отключить уведомления"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
           }
         },
         "sl" : {
@@ -1333,70 +475,16 @@
             "value" : "Utišaj"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sustur"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вимкнути звук"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mute"
           }
         },
         "zh-Hans" : {
@@ -1422,42 +510,6 @@
             "value" : "Someone added you"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -1468,18 +520,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jemand hat Sie hinzugefügt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
           }
         },
         "en" : {
@@ -1500,18 +540,6 @@
             "value" : "Someone added you"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -1522,36 +550,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quelqu'un vous a ajouté"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
           }
         },
         "it" : {
@@ -1566,61 +564,7 @@
             "value" : "Someone added you"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone added you"
@@ -1632,19 +576,7 @@
             "value" : "Someone added you"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone added you"
@@ -1656,67 +588,13 @@
             "value" : "Alguém adicionou você"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кто-то добавил вас"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone added you"
@@ -1728,25 +606,7 @@
             "value" : "Someone added you"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone added you"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone added you"
@@ -1775,42 +635,6 @@
             "value" : "Incoming call"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -1821,18 +645,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Eingehender Anruf"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
           }
         },
         "en" : {
@@ -1853,18 +665,6 @@
             "value" : "Incoming call"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -1875,36 +675,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Appel entrant"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
           }
         },
         "it" : {
@@ -1919,61 +689,7 @@
             "value" : "Incoming call"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Incoming call"
@@ -1985,19 +701,7 @@
             "value" : "Incoming call"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Incoming call"
@@ -2009,67 +713,13 @@
             "value" : "Chamada recebida"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Входящий вызов"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Incoming call"
@@ -2081,25 +731,7 @@
             "value" : "Incoming call"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming call"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Incoming call"
@@ -2128,42 +760,6 @@
             "value" : "%@ is calling"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -2174,18 +770,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ ruft an"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
           }
         },
         "en" : {
@@ -2206,18 +790,6 @@
             "value" : "%@ is calling"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -2228,36 +800,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ appelle"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
           }
         },
         "it" : {
@@ -2272,61 +814,7 @@
             "value" : "%@ is calling"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ is calling"
@@ -2338,19 +826,7 @@
             "value" : "%@ is calling"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ is calling"
@@ -2362,67 +838,13 @@
             "value" : "%@ está chamando"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ звонит"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ is calling"
@@ -2434,25 +856,7 @@
             "value" : "%@ is calling"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ is calling"
@@ -2481,42 +885,6 @@
             "value" : "%@ new messages"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -2527,18 +895,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ neue Nachrichten"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
           }
         },
         "en" : {
@@ -2559,18 +915,6 @@
             "value" : "%@ new messages"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -2581,36 +925,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ nouveaux messages"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
           }
         },
         "it" : {
@@ -2625,61 +939,7 @@
             "value" : "%@ new messages"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ new messages"
@@ -2691,19 +951,7 @@
             "value" : "%@ new messages"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ new messages"
@@ -2715,67 +963,13 @@
             "value" : "%@ novas mensagens"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ новых сообщений"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ new messages"
@@ -2787,25 +981,7 @@
             "value" : "%@ new messages"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ new messages"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ new messages"
@@ -2834,42 +1010,6 @@
             "value" : "أنت و%@ متصلين الآن"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2880,18 +1020,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sie sind jetzt mit %@ verbunden"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
           }
         },
         "en" : {
@@ -2912,18 +1040,6 @@
             "value" : "%@ on nüüd sinu kontakt."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2934,36 +1050,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous et %@ êtes maintenant connectés"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
           }
         },
         "it" : {
@@ -2978,64 +1064,10 @@
             "value" : "あなたと%@がつながりました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jūs ir %@ nuo šiol galite bendrauti"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
           }
         },
         "nl" : {
@@ -3044,22 +1076,10 @@
             "value" : "Jij en %@ zijn nu verbonden"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ty i %@ jesteście teraz znajomymi"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
           }
         },
         "pt-BR" : {
@@ -3068,28 +1088,10 @@
             "value" : "Você e %@ agora estão conectados"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вы и %@ теперь списках контактов"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
           }
         },
         "sl" : {
@@ -3098,70 +1100,16 @@
             "value" : "%@ in ti sta zdaj povezana"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sen ve %@ artık bağlısınız"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ тепер доданий(-а) до вашого списку контактів"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You and %@ are now connected"
           }
         },
         "zh-Hans" : {
@@ -3187,42 +1135,6 @@
             "value" : "لديك تواصل جديد"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3233,18 +1145,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sie haben einen neuen Kontakt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
           }
         },
         "en" : {
@@ -3265,18 +1165,6 @@
             "value" : "Sul on uus kontakt"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3287,36 +1175,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous avez une nouvelle connexion"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
           }
         },
         "it" : {
@@ -3331,64 +1189,10 @@
             "value" : "あなたは新しい連絡先があります"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Turite naują kontaktą"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
           }
         },
         "nl" : {
@@ -3397,22 +1201,10 @@
             "value" : "Je hebt een nieuw contact"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Masz nowe zaproszenie"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
           }
         },
         "pt-BR" : {
@@ -3421,28 +1213,10 @@
             "value" : "Você tem uma nova conexão"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "У вас есть новый контакт"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
           }
         },
         "sl" : {
@@ -3451,70 +1225,16 @@
             "value" : "Imaš novo povezavo"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yeni bir bağlantın var"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "У вас з'явились нові контакти"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You have a new connection"
           }
         },
         "zh-Hans" : {
@@ -3540,42 +1260,6 @@
             "value" : "يريد %@ التواصل معك"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3586,18 +1270,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ möchte sich mit Ihnen verbinden"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
           }
         },
         "en" : {
@@ -3618,18 +1290,6 @@
             "value" : "%@ soovib sind kontaktiks lisada"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3640,36 +1300,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ souhaite se connecter"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
           }
         },
         "it" : {
@@ -3684,64 +1314,10 @@
             "value" : "%@がつながりをリクエストしています"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ nori užmegzti kontaktą"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
           }
         },
         "nl" : {
@@ -3750,22 +1326,10 @@
             "value" : "%@ wil met jou verbinden"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ chce się połączyć"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
           }
         },
         "pt-BR" : {
@@ -3774,28 +1338,10 @@
             "value" : "%@ quer se conectar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ хочет подключиться"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
           }
         },
         "sl" : {
@@ -3804,70 +1350,16 @@
             "value" : "%@ si želi povezati"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ bağlanmak istiyor"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ хоче бути доданий(-а) до ваших контактів"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ wants to connect"
           }
         },
         "zh-Hans" : {
@@ -3893,42 +1385,6 @@
             "value" : "شخص يريد التواصل معك"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3939,18 +1395,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jemand möchte Sie als Kontakt hinzufügen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
           }
         },
         "en" : {
@@ -3971,18 +1415,6 @@
             "value" : "Keegi soovib sinuga ühenduda"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3993,36 +1425,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quelqu'un souhaite se connecter"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
           }
         },
         "it" : {
@@ -4037,64 +1439,10 @@
             "value" : "つながりをリクエストされています"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kažkas nori užmegzti kontaktą"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
           }
         },
         "nl" : {
@@ -4103,22 +1451,10 @@
             "value" : "Iemand wil met je verbinden"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ktoś chce się połączyć"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
           }
         },
         "pt-BR" : {
@@ -4127,28 +1463,10 @@
             "value" : "Alguém quer se conectar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кто-то хочет подключиться"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
           }
         },
         "sl" : {
@@ -4157,70 +1475,16 @@
             "value" : "Nekdo si želi povezati"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Birisi bağlanmak istiyor"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Хтось був доданий до ваших контактів"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone wants to connect"
           }
         },
         "zh-Hans" : {
@@ -4246,42 +1510,6 @@
             "value" : "انضمّ %@ لـWire"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4292,18 +1520,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ ist jetzt auch bei Wire"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
           }
         },
         "en" : {
@@ -4324,18 +1540,6 @@
             "value" : "%@ liitus just Wire’ga"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4346,36 +1550,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ vient de rejoindre Wire"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
           }
         },
         "it" : {
@@ -4390,64 +1564,10 @@
             "value" : "%@がたったいまWireに参加しました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ ką tik prisijungė prie Wire"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
           }
         },
         "nl" : {
@@ -4456,22 +1576,10 @@
             "value" : "%@ heeft zich aangemeld bij Wire"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ właśnie dołączył do Wire"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
           }
         },
         "pt-BR" : {
@@ -4480,28 +1588,10 @@
             "value" : "%@ entrou no Wire"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ присоединился к Wire"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
           }
         },
         "sl" : {
@@ -4510,70 +1600,16 @@
             "value" : "%@ se je ravnokar pridružil(-a) Wire"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ şimdi Wire'a katıldı"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ тільки що приєднався(-лася) до Wire"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ just joined Wire"
           }
         },
         "zh-Hans" : {
@@ -4599,42 +1635,6 @@
             "value" : "Someone created a conversation"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -4645,18 +1645,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jemand hat eine Unterhaltung erstellt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
           }
         },
         "en" : {
@@ -4677,18 +1665,6 @@
             "value" : "Someone created a conversation"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -4699,36 +1675,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quelqu'un a créé une conversation"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
           }
         },
         "it" : {
@@ -4743,61 +1689,7 @@
             "value" : "Someone created a conversation"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone created a conversation"
@@ -4809,19 +1701,7 @@
             "value" : "Someone created a conversation"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone created a conversation"
@@ -4833,67 +1713,13 @@
             "value" : "Alguém criou uma conversa"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Создана новая беседа"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone created a conversation"
@@ -4905,25 +1731,7 @@
             "value" : "Birisi bir sohbet başlattı"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone created a conversation"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone created a conversation"
@@ -4952,42 +1760,6 @@
             "value" : "Someone deleted the group"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -4998,18 +1770,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jemand hat die Gruppe gelöscht"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
           }
         },
         "en" : {
@@ -5030,18 +1790,6 @@
             "value" : "Someone deleted the group"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -5052,36 +1800,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quelqu'un a supprimé ce groupe"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
           }
         },
         "it" : {
@@ -5096,73 +1814,13 @@
             "value" : "誰かがグループを削除しました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kažkas ištrynė grupę"
           }
         },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
         "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "no" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone deleted the group"
@@ -5174,22 +1832,10 @@
             "value" : "Someone deleted the group"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alguém excluiu o grupo"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
           }
         },
         "ru" : {
@@ -5198,55 +1844,7 @@
             "value" : "Кто-то удалил группу"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone deleted the group"
@@ -5258,28 +1856,10 @@
             "value" : "Birisi grubu sildi"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Хтось видалив групу"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone deleted the group"
           }
         },
         "zh-Hans" : {
@@ -5305,42 +1885,6 @@
             "value" : "رسالة جديدة"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5351,18 +1895,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Neue Nachricht"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
           }
         },
         "en" : {
@@ -5383,18 +1915,6 @@
             "value" : "Uus sõnum"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5405,36 +1925,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nouveau message"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
           }
         },
         "it" : {
@@ -5449,64 +1939,10 @@
             "value" : "新着メッセージ"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nauja žinutė"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
           }
         },
         "nl" : {
@@ -5515,22 +1951,10 @@
             "value" : "Nieuw bericht"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "nowa wiadomość"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
           }
         },
         "pt-BR" : {
@@ -5539,28 +1963,10 @@
             "value" : "Nova mensagem"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Новое сообщение"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
           }
         },
         "sl" : {
@@ -5569,70 +1975,16 @@
             "value" : "Novo sporočilo"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yeni Mesaj"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нове повідомлення"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New message"
           }
         },
         "zh-Hans" : {
@@ -5658,42 +2010,6 @@
             "value" : "شخص ما أشار لي"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -5704,18 +2020,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jemand hat Sie erwähnt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
           }
         },
         "en" : {
@@ -5736,18 +2040,6 @@
             "value" : "Keegi mainis sind"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -5758,36 +2050,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quelqu'un vous a mentionné"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
           }
         },
         "it" : {
@@ -5802,64 +2064,10 @@
             "value" : "誰かがあなたにメンションしました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kažkas jus paminėjo"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
           }
         },
         "nl" : {
@@ -5868,22 +2076,10 @@
             "value" : "Iemand vermelde jou"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ktoś o Tobie wspomniał"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
           }
         },
         "pt-BR" : {
@@ -5892,67 +2088,13 @@
             "value" : "Alguém mencionou você"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вас упомянули"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone mentioned you"
@@ -5964,28 +2106,10 @@
             "value" : "Birisi sizden bahsetti"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Хтось згадав вас"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone mentioned you"
           }
         },
         "zh-Hans" : {
@@ -6011,42 +2135,6 @@
             "value" : "مكالمة فائتة"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6057,18 +2145,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verpasster Anruf"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
           }
         },
         "en" : {
@@ -6089,18 +2165,6 @@
             "value" : "Vastamata kõne"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6111,36 +2175,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Appel manqué"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
           }
         },
         "it" : {
@@ -6155,64 +2189,10 @@
             "value" : "不在着信"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Praleistas skambutis"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
           }
         },
         "nl" : {
@@ -6221,22 +2201,10 @@
             "value" : "Gemiste oproep"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nieodebrane połączenie"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
           }
         },
         "pt-BR" : {
@@ -6245,28 +2213,10 @@
             "value" : "Chamada não atendida"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пропущенный вызов"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
           }
         },
         "sl" : {
@@ -6275,70 +2225,16 @@
             "value" : "Zgrešen klic"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cevapsız arama"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пропущений дзвінок"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed call"
           }
         },
         "zh-Hans" : {
@@ -6364,42 +2260,6 @@
             "value" : "Pinged you"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -6410,18 +2270,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hat gepingt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
           }
         },
         "en" : {
@@ -6442,18 +2290,6 @@
             "value" : "Pinged you"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -6464,36 +2300,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous a envoyé un ping"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
           }
         },
         "it" : {
@@ -6508,61 +2314,7 @@
             "value" : "Pinged you"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pinged you"
@@ -6574,19 +2326,7 @@
             "value" : "Pinged you"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pinged you"
@@ -6598,67 +2338,13 @@
             "value" : "Chamou sua atenção"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отправил(-а) вам пинг"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pinged you"
@@ -6670,25 +2356,7 @@
             "value" : "Pinged you"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinged you"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pinged you"
@@ -6717,42 +2385,6 @@
             "value" : "Someone removed you"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -6763,18 +2395,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jemand hat Sie entfernt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
           }
         },
         "en" : {
@@ -6795,18 +2415,6 @@
             "value" : "Someone removed you"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -6817,36 +2425,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quelqu'un vous a exclu"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
           }
         },
         "it" : {
@@ -6861,61 +2439,7 @@
             "value" : "Someone removed you"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone removed you"
@@ -6927,19 +2451,7 @@
             "value" : "Someone removed you"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone removed you"
@@ -6951,67 +2463,13 @@
             "value" : "Alguém removeu você"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кто-то удалил вас"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone removed you"
@@ -7023,25 +2481,7 @@
             "value" : "Someone removed you"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone removed you"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone removed you"
@@ -7070,42 +2510,6 @@
             "value" : "Someone replied to you"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -7116,18 +2520,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jemand hat Ihnen geantwortet"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
           }
         },
         "en" : {
@@ -7148,18 +2540,6 @@
             "value" : "Someone replied to you"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -7170,36 +2550,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quelqu'un vous a répondu"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
           }
         },
         "it" : {
@@ -7214,61 +2564,7 @@
             "value" : "Someone replied to you"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone replied to you"
@@ -7280,19 +2576,7 @@
             "value" : "Someone replied to you"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone replied to you"
@@ -7304,67 +2588,13 @@
             "value" : "Alguém respondeu para você"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вам ответили"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone replied to you"
@@ -7376,25 +2606,7 @@
             "value" : "Someone replied to you"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone replied to you"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone replied to you"
@@ -7423,42 +2635,6 @@
             "value" : "%@ أضافك"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7469,18 +2645,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat Sie hinzugefügt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
           }
         },
         "en" : {
@@ -7501,18 +2665,6 @@
             "value" : "%@ lisas sinu"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7523,36 +2675,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ vous a ajouté"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
           }
         },
         "it" : {
@@ -7567,64 +2689,10 @@
             "value" : "%@はあなたを追加しました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ jus pridėjo"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
           }
         },
         "nl" : {
@@ -7633,22 +2701,10 @@
             "value" : "%@ heeft jou toegevoegd"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ dodał Ciebie"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
           }
         },
         "pt-BR" : {
@@ -7657,28 +2713,10 @@
             "value" : "%@ adicionou você"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ добавил(-а) вас"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
           }
         },
         "sl" : {
@@ -7687,70 +2725,16 @@
             "value" : "%@ te je dodal(-a)"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@, seni ekledi"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ додав(-ла) вас"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ added you"
           }
         },
         "zh-Hans" : {
@@ -7776,42 +2760,6 @@
             "value" : "اتصل %@"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7822,18 +2770,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat angerufen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
           }
         },
         "en" : {
@@ -7854,18 +2790,6 @@
             "value" : "%@ helistas"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7876,36 +2800,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ a appelé"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
           }
         },
         "it" : {
@@ -7920,64 +2814,10 @@
             "value" : "%@ からの着信"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ skambino"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
           }
         },
         "nl" : {
@@ -7986,22 +2826,10 @@
             "value" : "%@ belde"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ dzwoni"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
           }
         },
         "pt-BR" : {
@@ -8010,28 +2838,10 @@
             "value" : "%@ ligou"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ звонил(-а)"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
           }
         },
         "sl" : {
@@ -8040,70 +2850,16 @@
             "value" : "%@ je klical(-a)"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ aradı"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ дзвонив(-ла)"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ called"
           }
         },
         "zh-Hans" : {
@@ -8129,42 +2885,6 @@
             "value" : "%@ created a conversation"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -8175,18 +2895,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat eine Unterhaltung erstellt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
           }
         },
         "en" : {
@@ -8207,18 +2915,6 @@
             "value" : "%@ created a conversation"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -8229,36 +2925,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ a créé une conversation"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
           }
         },
         "it" : {
@@ -8273,61 +2939,7 @@
             "value" : "%@ created a conversation"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ created a conversation"
@@ -8339,19 +2951,7 @@
             "value" : "%@ created a conversation"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ created a conversation"
@@ -8363,67 +2963,13 @@
             "value" : "%@ criou uma conversa"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ создал(-а) беседу"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ created a conversation"
@@ -8435,25 +2981,7 @@
             "value" : "%@ created a conversation"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ created a conversation"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ created a conversation"
@@ -8482,42 +3010,6 @@
             "value" : "%@ deleted the group"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -8528,18 +3020,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat die Gruppe gelöscht"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
           }
         },
         "en" : {
@@ -8560,18 +3040,6 @@
             "value" : "%@ deleted the group"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -8582,36 +3050,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ a supprimé le groupe"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
           }
         },
         "it" : {
@@ -8626,61 +3064,7 @@
             "value" : "%@ deleted the group"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ deleted the group"
@@ -8692,19 +3076,7 @@
             "value" : "%@ deleted the group"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ deleted the group"
@@ -8716,67 +3088,13 @@
             "value" : "%@ excluiu o grupo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ удалил(-а) группу"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ deleted the group"
@@ -8788,25 +3106,7 @@
             "value" : "%@ deleted the group"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ deleted the group"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ deleted the group"
@@ -8835,42 +3135,6 @@
             "value" : "%@ pinged you"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -8881,18 +3145,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat gepingt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
           }
         },
         "en" : {
@@ -8913,18 +3165,6 @@
             "value" : "%@ pinged you"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -8935,36 +3175,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ vous a envoyé un ping"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
           }
         },
         "it" : {
@@ -8979,61 +3189,7 @@
             "value" : "%@ pinged you"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ pinged you"
@@ -9045,19 +3201,7 @@
             "value" : "%@ pinged you"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ pinged you"
@@ -9069,67 +3213,13 @@
             "value" : "%@ chamou sua atenção"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ отправил(-а) вам пинг"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ pinged you"
@@ -9141,25 +3231,7 @@
             "value" : "%@ pinged you"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ pinged you"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ pinged you"
@@ -9188,42 +3260,6 @@
             "value" : "قام %@ بإزالتك"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9234,18 +3270,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat Sie entfernt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
           }
         },
         "en" : {
@@ -9266,18 +3290,6 @@
             "value" : "%@ eemaldas sind"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9288,36 +3300,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ vous a exclu"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
           }
         },
         "it" : {
@@ -9332,64 +3314,10 @@
             "value" : "%@はあなたを削除しました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ jus pašalino"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
           }
         },
         "nl" : {
@@ -9398,22 +3326,10 @@
             "value" : "%@ verwijderde jou"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ usunął Ciebie"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
           }
         },
         "pt-BR" : {
@@ -9422,28 +3338,10 @@
             "value" : "%@ removeu você"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ удалил вас"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
           }
         },
         "sl" : {
@@ -9452,70 +3350,16 @@
             "value" : "%@ te je odstranil(-a)"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@, seni sildi"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ видалив(-ла) вас"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ removed you"
           }
         },
         "zh-Hans" : {
@@ -9541,42 +3385,6 @@
             "value" : "%@ turned off the message timer"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -9587,18 +3395,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat selbstlöschende Nachrichten ausgeschaltet"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
           }
         },
         "en" : {
@@ -9619,18 +3415,6 @@
             "value" : "%@ lülitas sõnumi taimeri välja"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -9641,36 +3425,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ a désactivé les messages éphémères"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
           }
         },
         "it" : {
@@ -9685,73 +3439,13 @@
             "value" : "%@ が タイマーメッセージをオフにしました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ išjungė žinutės laikmatį"
           }
         },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
         "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "no" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ turned off the message timer"
@@ -9763,22 +3457,10 @@
             "value" : "%@ turned off the message timer"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ desligou o tempo da mensagem"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
           }
         },
         "ru" : {
@@ -9787,55 +3469,7 @@
             "value" : "%@ отключил таймер сообщения"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ turned off the message timer"
@@ -9847,28 +3481,10 @@
             "value" : "%@ mesaj zamanlayıcısını kapattı"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ вимкнув(-ла) таймер повідомлень"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ turned off the message timer"
           }
         },
         "zh-Hans" : {
@@ -9894,42 +3510,6 @@
             "value" : "%@ set the message timer to %@"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -9940,18 +3520,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat selbstlöschende Nachrichten auf %@ gestellt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
           }
         },
         "en" : {
@@ -9972,18 +3540,6 @@
             "value" : "%@ määras sõnumi taimeriks: %@"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -9994,36 +3550,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ a réglé la minuterie sur %@"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
           }
         },
         "it" : {
@@ -10038,64 +3564,10 @@
             "value" : "%@ はタイマーメッセージを %@ に設定しました。"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ nustatė žinutės laikmatį į %@"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
           }
         },
         "nl" : {
@@ -10104,19 +3576,7 @@
             "value" : "%@ heeft een bericht timer gezet in %@"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ set the message timer to %@"
@@ -10128,67 +3588,13 @@
             "value" : "%@ definiu o tempo da mensagem para %@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ установил(-а) таймер сообщения на %@"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ set the message timer to %@"
@@ -10200,28 +3606,10 @@
             "value" : "%@, mesaj zamanlayıcısını %@ olarak ayarladı"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ встановив(-ла) таймер повідомлень на %@"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ set the message timer to %@"
           }
         },
         "zh-Hans" : {
@@ -10247,42 +3635,6 @@
             "value" : "%@ shared an audio message"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -10293,18 +3645,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat eine Audionachricht geteilt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
           }
         },
         "en" : {
@@ -10325,18 +3665,6 @@
             "value" : "%@ shared an audio message"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -10347,36 +3675,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ a partagé un message audio"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
           }
         },
         "it" : {
@@ -10391,61 +3689,7 @@
             "value" : "%@ shared an audio message"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared an audio message"
@@ -10457,19 +3701,7 @@
             "value" : "%@ shared an audio message"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared an audio message"
@@ -10481,67 +3713,13 @@
             "value" : "%@ compartilhou uma mensagem de áudio"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ поделился(-лась) звуковым сообщением"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared an audio message"
@@ -10553,25 +3731,7 @@
             "value" : "%@ shared an audio message"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared an audio message"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared an audio message"
@@ -10600,42 +3760,6 @@
             "value" : "%@ shared a file"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -10646,18 +3770,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat eine Datei geteilt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
           }
         },
         "en" : {
@@ -10678,18 +3790,6 @@
             "value" : "%@ shared a file"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -10700,36 +3800,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ a partagé un fichier"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
           }
         },
         "it" : {
@@ -10744,61 +3814,7 @@
             "value" : "%@ shared a file"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a file"
@@ -10810,19 +3826,7 @@
             "value" : "%@ shared a file"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a file"
@@ -10834,67 +3838,13 @@
             "value" : "%@ compartilhou um arquivo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ поделился(-лась) файлом"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a file"
@@ -10906,25 +3856,7 @@
             "value" : "%@ shared a file"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a file"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a file"
@@ -10953,42 +3885,6 @@
             "value" : "%@ shared a location"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -10999,18 +3895,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat einen Standort geteilt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
           }
         },
         "en" : {
@@ -11031,18 +3915,6 @@
             "value" : "%@ shared a location"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -11053,36 +3925,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ a partagé une position"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
           }
         },
         "it" : {
@@ -11097,61 +3939,7 @@
             "value" : "%@ shared a location"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a location"
@@ -11163,19 +3951,7 @@
             "value" : "%@ shared a location"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a location"
@@ -11187,67 +3963,13 @@
             "value" : "%@ compartilhou uma localização"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ поделился(-лась) местоположением"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a location"
@@ -11259,25 +3981,7 @@
             "value" : "%@ shared a location"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a location"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a location"
@@ -11306,42 +4010,6 @@
             "value" : "%@ shared a picture"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -11352,18 +4020,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat ein Bild geteilt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
           }
         },
         "en" : {
@@ -11384,18 +4040,6 @@
             "value" : "%@ shared a picture"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -11406,36 +4050,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ a partagé une image"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
           }
         },
         "it" : {
@@ -11450,61 +4064,7 @@
             "value" : "%@ shared a picture"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a picture"
@@ -11516,19 +4076,7 @@
             "value" : "%@ shared a picture"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a picture"
@@ -11540,67 +4088,13 @@
             "value" : "%@ compartilhou uma imagem"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ поделился(-лась) картинкой"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a picture"
@@ -11612,25 +4106,7 @@
             "value" : "%@ shared a picture"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a picture"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a picture"
@@ -11659,42 +4135,6 @@
             "value" : "%@ shared a video"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -11705,18 +4145,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ hat ein Video geteilt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
           }
         },
         "en" : {
@@ -11737,18 +4165,6 @@
             "value" : "%@ shared a video"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -11759,36 +4175,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ a partagé une vidéo"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
           }
         },
         "it" : {
@@ -11803,61 +4189,7 @@
             "value" : "%@ shared a video"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a video"
@@ -11869,19 +4201,7 @@
             "value" : "%@ shared a video"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a video"
@@ -11893,67 +4213,13 @@
             "value" : "%@ compartilhou um vídeo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ поделился(-лась) видео"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a video"
@@ -11965,25 +4231,7 @@
             "value" : "%@ shared a video"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ shared a video"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ shared a video"
@@ -12012,42 +4260,6 @@
             "value" : "أرسل أحدهم رسالة"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -12058,18 +4270,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jemand hat eine Nachricht gesendet"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
           }
         },
         "en" : {
@@ -12090,18 +4290,6 @@
             "value" : "Keegi saatis sulle sõnumi"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -12112,36 +4300,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quelqu'un a envoyé un message"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
           }
         },
         "it" : {
@@ -12156,64 +4314,10 @@
             "value" : "誰かがメッセージを送信しました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kažkas atsiuntė žinutę"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
           }
         },
         "nl" : {
@@ -12222,22 +4326,10 @@
             "value" : "Iemand heeft een bericht gestuurd"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ktoś wysłał do Ciebie wiadomość"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
           }
         },
         "pt-BR" : {
@@ -12246,67 +4338,13 @@
             "value" : "Alguém mandou uma mensagem"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кто-то прислал сообщение"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone sent a message"
@@ -12318,28 +4356,10 @@
             "value" : "Birisi bir mesaj gönderdi"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Хтось надіслав повідомлення"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone sent a message"
           }
         },
         "zh-Hans" : {
@@ -12365,42 +4385,6 @@
             "value" : "Someone turned off the timer"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -12411,18 +4395,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jemand hat selbstlöschende Nachrichten ausgeschaltet"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
           }
         },
         "en" : {
@@ -12443,18 +4415,6 @@
             "value" : "Someone turned off the timer"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -12465,36 +4425,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quelqu'un a désactivé le timer"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
           }
         },
         "it" : {
@@ -12509,61 +4439,7 @@
             "value" : "Someone turned off the timer"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone turned off the timer"
@@ -12575,19 +4451,7 @@
             "value" : "Someone turned off the timer"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone turned off the timer"
@@ -12599,67 +4463,13 @@
             "value" : "Alguém desligou o temporizador"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кто-то отключил таймер"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone turned off the timer"
@@ -12671,25 +4481,7 @@
             "value" : "Someone turned off the timer"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone turned off the timer"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone turned off the timer"
@@ -12718,42 +4510,6 @@
             "value" : "Someone set the timer to %@"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -12764,18 +4520,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jemand hat selbstlöschende Nachrichten auf %@ gestellt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
           }
         },
         "en" : {
@@ -12796,18 +4540,6 @@
             "value" : "Someone set the timer to %@"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -12818,36 +4550,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quelqu'un a réglé le timer sur %@"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
           }
         },
         "it" : {
@@ -12862,61 +4564,7 @@
             "value" : "Someone set the timer to %@"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone set the timer to %@"
@@ -12928,19 +4576,7 @@
             "value" : "Someone set the timer to %@"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone set the timer to %@"
@@ -12952,67 +4588,13 @@
             "value" : "Alguém definiu o temporizador para %@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кто-то установил таймер на %@"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone set the timer to %@"
@@ -13024,25 +4606,7 @@
             "value" : "Someone set the timer to %@"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Someone set the timer to %@"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Someone set the timer to %@"
@@ -13071,42 +4635,6 @@
             "value" : "شارك رسالة صوتية"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13117,18 +4645,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hat eine Audionachricht geteilt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
           }
         },
         "en" : {
@@ -13149,18 +4665,6 @@
             "value" : "Jagas häälsõnumit"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13171,36 +4675,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "A partagé un message vocal"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
           }
         },
         "it" : {
@@ -13215,64 +4689,10 @@
             "value" : "音声メッセージが共有されました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pasidalino garso žinute"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
           }
         },
         "nl" : {
@@ -13281,22 +4701,10 @@
             "value" : "Deelde een audio bericht"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Udostępnij wiadomość audio"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
           }
         },
         "pt-BR" : {
@@ -13305,28 +4713,10 @@
             "value" : "Compartilhou uma mensagem de áudio"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поделился(-лась) аудиосообщением"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
           }
         },
         "sl" : {
@@ -13335,70 +4725,16 @@
             "value" : "Je delil(-a) zvočno sporočilo"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bir sesli mesaj paylaştı"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поділився(-лась) аудіоповідомленням"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared an audio message"
           }
         },
         "zh-Hans" : {
@@ -13424,42 +4760,6 @@
             "value" : "شارك ملف"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13470,18 +4770,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hat eine Datei geteilt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
           }
         },
         "en" : {
@@ -13502,18 +4790,6 @@
             "value" : "Jagas faili"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13524,36 +4800,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "A partagé un fichier"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
           }
         },
         "it" : {
@@ -13568,64 +4814,10 @@
             "value" : "ファイルが共有されました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pasidalino failu"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
           }
         },
         "nl" : {
@@ -13634,22 +4826,10 @@
             "value" : "Deelde een bestand"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Udostępniany plik"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
           }
         },
         "pt-BR" : {
@@ -13658,28 +4838,10 @@
             "value" : "Compartilhou um arquivo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поделился(-лась) файлом"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
           }
         },
         "sl" : {
@@ -13688,70 +4850,16 @@
             "value" : "Je delil(-a) zbirko"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bir dosya paylaştı"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поділився(-лась) файлом"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a file"
           }
         },
         "zh-Hans" : {
@@ -13777,42 +4885,6 @@
             "value" : "شارك موقع"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13823,18 +4895,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hat einen Standort geteilt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
           }
         },
         "en" : {
@@ -13855,18 +4915,6 @@
             "value" : "Jagas asukohta"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13877,36 +4925,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "A partagé une position"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
           }
         },
         "it" : {
@@ -13921,64 +4939,10 @@
             "value" : "場所を共有しました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pasidalino vieta"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
           }
         },
         "nl" : {
@@ -13987,22 +4951,10 @@
             "value" : "Deel een locatie"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Udostępniana lokalizacja"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
           }
         },
         "pt-BR" : {
@@ -14011,28 +4963,10 @@
             "value" : "Compartilhou uma localização"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поделился(-лась) местоположением"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
           }
         },
         "sl" : {
@@ -14041,70 +4975,16 @@
             "value" : "Je delil(-a) lokacijo"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bir konum paylaştı"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поділився(-лась) розташуванням"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a location"
           }
         },
         "zh-Hans" : {
@@ -14130,42 +5010,6 @@
             "value" : "شارك صورة"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14176,18 +5020,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hat ein Bild geteilt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
           }
         },
         "en" : {
@@ -14208,18 +5040,6 @@
             "value" : "Jagas pilti"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14230,36 +5050,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "A partagé une image"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
           }
         },
         "it" : {
@@ -14274,64 +5064,10 @@
             "value" : "写真が共有されました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pasidalino paveikslu"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
           }
         },
         "nl" : {
@@ -14340,22 +5076,10 @@
             "value" : "Deelde een foto"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Udostępnił obrazek"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
           }
         },
         "pt-BR" : {
@@ -14364,28 +5088,10 @@
             "value" : "Compartilhou uma imagem"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поделился(-лась) картинкой"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
           }
         },
         "sl" : {
@@ -14394,70 +5100,16 @@
             "value" : "Je delil(-a) sliko"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bir resim paylaştı"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поділився(-лась) картинкою"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a picture"
           }
         },
         "zh-Hans" : {
@@ -14483,42 +5135,6 @@
             "value" : "شارك فيديو"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14529,18 +5145,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hat ein Video geteilt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
           }
         },
         "en" : {
@@ -14561,18 +5165,6 @@
             "value" : "Jagas videot"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14583,36 +5175,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "A partagé une vidéo"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
           }
         },
         "it" : {
@@ -14627,64 +5189,10 @@
             "value" : "ビデオを共有しました"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pasidalino vaizdo įrašu"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
           }
         },
         "nl" : {
@@ -14693,22 +5201,10 @@
             "value" : "Deelde een video"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Udostępniane wideo"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
           }
         },
         "pt-BR" : {
@@ -14717,28 +5213,10 @@
             "value" : "Compartilhou um vídeo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поделился(-лась) видео"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
           }
         },
         "sl" : {
@@ -14747,70 +5225,16 @@
             "value" : "Je delil(-a) video"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bir video paylaştı"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поділився(-лась) відео"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shared a video"
           }
         },
         "zh-Hans" : {
@@ -14836,42 +5260,6 @@
             "value" : "Mention: %@"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -14882,18 +5270,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erwähnung: %@"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
           }
         },
         "en" : {
@@ -14914,18 +5290,6 @@
             "value" : "Mention: %@"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -14935,36 +5299,6 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mention: %@"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Mention: %@"
           }
         },
@@ -14980,61 +5314,7 @@
             "value" : "Mention: %@"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mention: %@"
@@ -15046,19 +5326,7 @@
             "value" : "Mention: %@"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mention: %@"
@@ -15070,67 +5338,13 @@
             "value" : "Menção: %@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Упоминание: %@"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mention: %@"
@@ -15142,25 +5356,7 @@
             "value" : "Mention: %@"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention: %@"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mention: %@"
@@ -15189,42 +5385,6 @@
             "value" : "Mention from %@: %@"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -15235,18 +5395,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erwähnung von %@: %@"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
           }
         },
         "en" : {
@@ -15267,18 +5415,6 @@
             "value" : "Mention from %@: %@"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -15289,36 +5425,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mention de %@: %@"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
           }
         },
         "it" : {
@@ -15333,61 +5439,7 @@
             "value" : "Mention from %@: %@"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mention from %@: %@"
@@ -15399,19 +5451,7 @@
             "value" : "Mention from %@: %@"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mention from %@: %@"
@@ -15423,67 +5463,13 @@
             "value" : "Menção de %@: %@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Упоминание от %@: %@"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mention from %@: %@"
@@ -15495,25 +5481,7 @@
             "value" : "Mention from %@: %@"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Mention from %@: %@"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mention from %@: %@"
@@ -15542,42 +5510,6 @@
             "value" : "Reply: %@"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -15588,18 +5520,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Antwort: %@"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
           }
         },
         "en" : {
@@ -15620,18 +5540,6 @@
             "value" : "Reply: %@"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -15642,36 +5550,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Réponse : %@"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
           }
         },
         "it" : {
@@ -15686,61 +5564,7 @@
             "value" : "Reply: %@"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reply: %@"
@@ -15752,19 +5576,7 @@
             "value" : "Reply: %@"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reply: %@"
@@ -15776,67 +5588,13 @@
             "value" : "Resposta: %@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ответ: %@"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reply: %@"
@@ -15848,25 +5606,7 @@
             "value" : "Reply: %@"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply: %@"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reply: %@"
@@ -15895,42 +5635,6 @@
             "value" : "Reply from %@: %@"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -15941,18 +5645,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Antwort von %@: %@"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
           }
         },
         "en" : {
@@ -15973,18 +5665,6 @@
             "value" : "Reply from %@: %@"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -15995,36 +5675,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Réponse de %@: %@"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
           }
         },
         "it" : {
@@ -16039,61 +5689,7 @@
             "value" : "Reply from %@: %@"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reply from %@: %@"
@@ -16105,19 +5701,7 @@
             "value" : "Reply from %@: %@"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reply from %@: %@"
@@ -16129,67 +5713,13 @@
             "value" : "Resposta de %@: %@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ответ от %@:%@"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reply from %@: %@"
@@ -16201,25 +5731,7 @@
             "value" : "Reply from %@: %@"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reply from %@: %@"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reply from %@: %@"
@@ -16248,42 +5760,6 @@
             "value" : "Incoming video call"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -16294,18 +5770,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Eingehender Videoanruf"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
           }
         },
         "en" : {
@@ -16326,18 +5790,6 @@
             "value" : "Incoming video call"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -16348,36 +5800,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Appel vidéo entrant"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
           }
         },
         "it" : {
@@ -16392,61 +5814,7 @@
             "value" : "Incoming video call"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Incoming video call"
@@ -16458,19 +5826,7 @@
             "value" : "Incoming video call"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Incoming video call"
@@ -16482,67 +5838,13 @@
             "value" : "Chamada de vídeo recebida"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Входящий видеозвонок"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Incoming video call"
@@ -16554,25 +5856,7 @@
             "value" : "Incoming video call"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Incoming video call"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Incoming video call"
@@ -16601,42 +5885,6 @@
             "value" : "%@ is calling with video"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -16647,18 +5895,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ ruft mit Video an"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
           }
         },
         "en" : {
@@ -16679,18 +5915,6 @@
             "value" : "%@ is calling with video"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -16701,36 +5925,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "a commencé un appel vidéo"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
           }
         },
         "it" : {
@@ -16745,61 +5939,7 @@
             "value" : "%@ is calling with video"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ is calling with video"
@@ -16811,19 +5951,7 @@
             "value" : "%@ is calling with video"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ is calling with video"
@@ -16835,67 +5963,13 @@
             "value" : "%@ está chamando com vídeo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ вызывает с видео"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ is calling with video"
@@ -16907,25 +5981,7 @@
             "value" : "%@ is calling with video"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ is calling with video"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ is calling with video"
@@ -16954,42 +6010,6 @@
             "value" : "%@ in %@"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -16999,18 +6019,6 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ in %@"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "%@ in %@"
           }
         },
@@ -17032,18 +6040,6 @@
             "value" : "%@ in %@"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -17054,36 +6050,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ dans %@"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
           }
         },
         "it" : {
@@ -17098,61 +6064,7 @@
             "value" : "%@ in %@"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ in %@"
@@ -17164,19 +6076,7 @@
             "value" : "%@ in %@"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ in %@"
@@ -17188,67 +6088,13 @@
             "value" : "%@ em %@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ в %@"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ in %@"
@@ -17260,25 +6106,7 @@
             "value" : "%@ in %@"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ in %@"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@ in %@"

--- a/WireUI/Sources/WireFolderPickerUI/Resources/Localization/Accessibility.xcstrings
+++ b/WireUI/Sources/WireFolderPickerUI/Resources/Localization/Accessibility.xcstrings
@@ -9,42 +9,6 @@
             "value" : "Close folder overview"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -55,18 +19,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ordnerübersicht schließen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
           }
         },
         "en" : {
@@ -87,18 +39,6 @@
             "value" : "Close folder overview"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -106,36 +46,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close folder overview"
@@ -153,61 +63,7 @@
             "value" : "Close folder overview"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close folder overview"
@@ -219,19 +75,7 @@
             "value" : "Close folder overview"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close folder overview"
@@ -243,67 +87,13 @@
             "value" : "Fechar visualização da pasta"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть обзор папки"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close folder overview"
@@ -315,25 +105,7 @@
             "value" : "Close folder overview"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close folder overview"

--- a/WireUI/Sources/WireFolderPickerUI/Resources/Localization/Localizable.xcstrings
+++ b/WireUI/Sources/WireFolderPickerUI/Resources/Localization/Localizable.xcstrings
@@ -10,42 +10,6 @@
             "value" : "Add your conversations to folders to stay organized."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -56,18 +20,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fügen Sie Ihre Unterhaltungen Ordnern hinzu, um organisiert zu bleiben."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
           }
         },
         "en" : {
@@ -88,18 +40,6 @@
             "value" : "Add your conversations to folders to stay organized."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -110,36 +50,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ajoutez vos conversations aux dossiers pour rester organisé."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
           }
         },
         "it" : {
@@ -154,61 +64,7 @@
             "value" : "Add your conversations to folders to stay organized."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add your conversations to folders to stay organized."
@@ -220,19 +76,7 @@
             "value" : "Add your conversations to folders to stay organized."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add your conversations to folders to stay organized."
@@ -244,67 +88,13 @@
             "value" : "Adicione suas conversas às pastas para ficar organizado."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Добавляйте беседы в папки, чтобы сохранять их упорядоченность."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add your conversations to folders to stay organized."
@@ -316,25 +106,7 @@
             "value" : "Add your conversations to folders to stay organized."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add your conversations to folders to stay organized."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add your conversations to folders to stay organized."
@@ -363,42 +135,6 @@
             "value" : "معرفة المزيد"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -409,18 +145,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mehr erfahren"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
           }
         },
         "en" : {
@@ -441,18 +165,6 @@
             "value" : "Loe lähemalt"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -463,36 +175,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "En savoir plus"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
           }
         },
         "it" : {
@@ -507,64 +189,10 @@
             "value" : "もっと知る"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sužinoti daugiau"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
           }
         },
         "nl" : {
@@ -573,22 +201,10 @@
             "value" : "Leer meer"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Więcej informacji"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
           }
         },
         "pt-BR" : {
@@ -597,28 +213,10 @@
             "value" : "Mais informação"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Подробнее"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
           }
         },
         "sl" : {
@@ -627,70 +225,16 @@
             "value" : "Nauči se več"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Daha fazla bilgi"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дізнатися більше"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more"
           }
         },
         "zh-Hans" : {
@@ -716,42 +260,6 @@
             "value" : "Folders"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -762,18 +270,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ordner"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
           }
         },
         "en" : {
@@ -794,18 +290,6 @@
             "value" : "Folders"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -816,36 +300,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dossiers"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
           }
         },
         "it" : {
@@ -860,61 +314,7 @@
             "value" : "Folders"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Folders"
@@ -926,19 +326,7 @@
             "value" : "Folders"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Folders"
@@ -950,67 +338,13 @@
             "value" : "Pastas"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папки"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Folders"
@@ -1022,25 +356,7 @@
             "value" : "Folders"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Folders"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Folders"

--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/Resources/Localization/Accessibility.xcstrings
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/Resources/Localization/Accessibility.xcstrings
@@ -10,42 +10,6 @@
             "value" : "Close team created view"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -56,18 +20,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ansicht Team erstellt schließen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
           }
         },
         "en" : {
@@ -88,18 +40,6 @@
             "value" : "Close team created view"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -107,36 +47,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team created view"
@@ -154,61 +64,7 @@
             "value" : "Close team created view"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team created view"
@@ -220,19 +76,7 @@
             "value" : "Close team created view"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team created view"
@@ -244,67 +88,13 @@
             "value" : "Fechar visualização de equipe criada"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть просмотр создания команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team created view"
@@ -316,25 +106,7 @@
             "value" : "Close team created view"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team created view"
@@ -363,42 +135,6 @@
             "value" : "Close confirmation view"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -409,18 +145,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bestätigungsansicht schließen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
           }
         },
         "en" : {
@@ -441,18 +165,6 @@
             "value" : "Close confirmation view"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -460,36 +172,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close confirmation view"
@@ -507,61 +189,7 @@
             "value" : "Close confirmation view"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close confirmation view"
@@ -573,19 +201,7 @@
             "value" : "Close confirmation view"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close confirmation view"
@@ -597,67 +213,13 @@
             "value" : "Fechar visualização de confirmação"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть окно подтверждения"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close confirmation view"
@@ -669,25 +231,7 @@
             "value" : "Close confirmation view"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close confirmation view"
@@ -716,42 +260,6 @@
             "value" : "Close team account overview"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -762,18 +270,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Team-Konto-Übersicht schließen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
           }
         },
         "en" : {
@@ -794,18 +290,6 @@
             "value" : "Close team account overview"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -813,36 +297,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team account overview"
@@ -860,61 +314,7 @@
             "value" : "Close team account overview"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team account overview"
@@ -926,19 +326,7 @@
             "value" : "Close team account overview"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team account overview"
@@ -950,67 +338,13 @@
             "value" : "Fechar visão geral da conta da equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть информацию об аккаунте команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team account overview"
@@ -1022,25 +356,7 @@
             "value" : "Close team account overview"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team account overview"
@@ -1069,42 +385,6 @@
             "value" : "Close team name view"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -1115,18 +395,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ansicht Teamname schließen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
           }
         },
         "en" : {
@@ -1147,18 +415,6 @@
             "value" : "Close team name view"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -1166,36 +422,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team name view"
@@ -1213,61 +439,7 @@
             "value" : "Close team name view"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team name view"
@@ -1279,19 +451,7 @@
             "value" : "Close team name view"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team name view"
@@ -1303,67 +463,13 @@
             "value" : "Fechar visualização do nome da equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть просмотр информации о названии команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team name view"
@@ -1375,25 +481,7 @@
             "value" : "Close team name view"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team name view"
@@ -1422,42 +510,6 @@
             "value" : "جارِ التحميل…"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -1468,18 +520,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wird geladen…"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
           }
         },
         "en" : {
@@ -1500,18 +540,6 @@
             "value" : "Laadimine…"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1522,36 +550,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chargement…"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
           }
         },
         "it" : {
@@ -1566,64 +564,10 @@
             "value" : "読み込み中…"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kraunama…"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
           }
         },
         "nl" : {
@@ -1632,22 +576,10 @@
             "value" : "Laden…"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wczytuje…"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
           }
         },
         "pt-BR" : {
@@ -1656,67 +588,13 @@
             "value" : "Carregando…"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Загрузка…"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading…"
@@ -1728,28 +606,10 @@
             "value" : "Yükleniyor…"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Завантаження…"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
           }
         },
         "zh-Hans" : {

--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/Resources/Localization/Localizable.xcstrings
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/Resources/Localization/Localizable.xcstrings
@@ -9,42 +9,6 @@
             "value" : "Explore extra features for free with the same level of security."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -55,18 +19,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Entdecken Sie zusätzliche Funktionen kostenlos mit dem gleichen Maß an Sicherheit."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
           }
         },
         "en" : {
@@ -87,18 +39,6 @@
             "value" : "Explore extra features for free with the same level of security."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -106,36 +46,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Explore extra features for free with the same level of security."
@@ -153,61 +63,7 @@
             "value" : "Explore extra features for free with the same level of security."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Explore extra features for free with the same level of security."
@@ -219,19 +75,7 @@
             "value" : "Explore extra features for free with the same level of security."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Explore extra features for free with the same level of security."
@@ -243,67 +87,13 @@
             "value" : "Explore recursos extras gratuitamente com o mesmo nível de segurança."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Познакомьтесь с дополнительными возможностями бесплатно, сохранив тот же уровень безопасности."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Explore extra features for free with the same level of security."
@@ -315,25 +105,7 @@
             "value" : "Explore extra features for free with the same level of security."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explore extra features for free with the same level of security."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Explore extra features for free with the same level of security."
@@ -361,42 +133,6 @@
             "value" : "Create Wire Team"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -407,18 +143,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wire Team erstellen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
           }
         },
         "en" : {
@@ -439,18 +163,6 @@
             "value" : "Create Wire Team"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -458,36 +170,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Create Wire Team"
@@ -505,61 +187,7 @@
             "value" : "Create Wire Team"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Create Wire Team"
@@ -571,19 +199,7 @@
             "value" : "Create Wire Team"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Create Wire Team"
@@ -595,67 +211,13 @@
             "value" : "Criar Equipe Wire"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Создать команду Wire"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Create Wire Team"
@@ -667,25 +229,7 @@
             "value" : "Create Wire Team"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create Wire Team"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Create Wire Team"
@@ -713,42 +257,6 @@
             "value" : "Enjoy benefits of a team"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -759,18 +267,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nutzen Sie die Vorteile eines Teams"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
           }
         },
         "en" : {
@@ -791,18 +287,6 @@
             "value" : "Enjoy benefits of a team"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -810,36 +294,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enjoy benefits of a team"
@@ -857,61 +311,7 @@
             "value" : "Enjoy benefits of a team"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enjoy benefits of a team"
@@ -923,19 +323,7 @@
             "value" : "Enjoy benefits of a team"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enjoy benefits of a team"
@@ -947,67 +335,13 @@
             "value" : "Aproveite os benefícios de uma equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Наслаждайтесь преимуществами команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enjoy benefits of a team"
@@ -1019,25 +353,7 @@
             "value" : "Enjoy benefits of a team"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enjoy benefits of a team"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enjoy benefits of a team"
@@ -1066,42 +382,6 @@
             "value" : "العودة"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1112,18 +392,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zurück"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
           }
         },
         "en" : {
@@ -1144,18 +412,6 @@
             "value" : "Tagasi"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1166,36 +422,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Précédent"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
           }
         },
         "it" : {
@@ -1210,64 +436,10 @@
             "value" : "戻る"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Atgal"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
           }
         },
         "nl" : {
@@ -1276,22 +448,10 @@
             "value" : "Vorige"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Powrót"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
           }
         },
         "pt-BR" : {
@@ -1300,28 +460,10 @@
             "value" : "Voltar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Назад"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
           }
         },
         "sl" : {
@@ -1330,70 +472,16 @@
             "value" : "Nazaj"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geri"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Повернутись"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
           }
         },
         "zh-Hans" : {
@@ -1419,42 +507,6 @@
             "value" : "متابعة"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1465,18 +517,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weiter"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
           }
         },
         "en" : {
@@ -1497,18 +537,6 @@
             "value" : "Jätka"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1519,36 +547,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continuer"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
           }
         },
         "it" : {
@@ -1563,64 +561,10 @@
             "value" : "続行"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tęsti"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
           }
         },
         "nl" : {
@@ -1629,22 +573,10 @@
             "value" : "Ga door"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kontynuuj"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
           }
         },
         "pt-BR" : {
@@ -1653,28 +585,10 @@
             "value" : "Continuar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Продолжить"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
           }
         },
         "sl" : {
@@ -1683,70 +597,16 @@
             "value" : "Nadaljuj"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Devam et"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Продовжити"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
           }
         },
         "zh-Hans" : {
@@ -1772,42 +632,6 @@
             "value" : "When you leave now, you lose your progress and need to restart the team creation."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -1818,18 +642,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wenn Sie jetzt aufhören, verlieren Sie Ihren Fortschritt und müssen die Team-Erstellung neu beginnen."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
           }
         },
         "en" : {
@@ -1850,18 +662,6 @@
             "value" : "When you leave now, you lose your progress and need to restart the team creation."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -1869,36 +669,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When you leave now, you lose your progress and need to restart the team creation."
@@ -1916,61 +686,7 @@
             "value" : "When you leave now, you lose your progress and need to restart the team creation."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When you leave now, you lose your progress and need to restart the team creation."
@@ -1982,19 +698,7 @@
             "value" : "When you leave now, you lose your progress and need to restart the team creation."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When you leave now, you lose your progress and need to restart the team creation."
@@ -2006,67 +710,13 @@
             "value" : "Quando você sair agora, você perde seu progresso e precisa reiniciar a criação de equipe."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Если вы выйдете, информация не сохранится и вам придется заново создавать команду."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When you leave now, you lose your progress and need to restart the team creation."
@@ -2078,25 +728,7 @@
             "value" : "When you leave now, you lose your progress and need to restart the team creation."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you leave now, you lose your progress and need to restart the team creation."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When you leave now, you lose your progress and need to restart the team creation."
@@ -2125,42 +757,6 @@
             "value" : "Continue Team Creation"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -2171,18 +767,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Team-Erstellung fortsetzen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
           }
         },
         "en" : {
@@ -2203,18 +787,6 @@
             "value" : "Continue Team Creation"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -2222,36 +794,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Continue Team Creation"
@@ -2269,61 +811,7 @@
             "value" : "Continue Team Creation"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Continue Team Creation"
@@ -2335,19 +823,7 @@
             "value" : "Continue Team Creation"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Continue Team Creation"
@@ -2359,67 +835,13 @@
             "value" : "Continuar Criação de Equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Продолжить создание команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Continue Team Creation"
@@ -2431,25 +853,7 @@
             "value" : "Continue Team Creation"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue Team Creation"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Continue Team Creation"
@@ -2478,42 +882,6 @@
             "value" : "Leave Without Saving"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -2524,18 +892,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schließen ohne zu speichern"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
           }
         },
         "en" : {
@@ -2556,18 +912,6 @@
             "value" : "Leave Without Saving"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -2575,36 +919,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Leave Without Saving"
@@ -2622,61 +936,7 @@
             "value" : "Leave Without Saving"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Leave Without Saving"
@@ -2688,19 +948,7 @@
             "value" : "Leave Without Saving"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Leave Without Saving"
@@ -2712,67 +960,13 @@
             "value" : "Sair sem salvar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Выйти без сохранения"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Leave Without Saving"
@@ -2784,25 +978,7 @@
             "value" : "Leave Without Saving"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave Without Saving"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Leave Without Saving"
@@ -2831,42 +1007,6 @@
             "value" : "Leave without saving?"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -2877,18 +1017,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schließen ohne zu speichern?"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
           }
         },
         "en" : {
@@ -2909,18 +1037,6 @@
             "value" : "Leave without saving?"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -2928,36 +1044,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Leave without saving?"
@@ -2975,61 +1061,7 @@
             "value" : "Leave without saving?"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Leave without saving?"
@@ -3041,19 +1073,7 @@
             "value" : "Leave without saving?"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Leave without saving?"
@@ -3065,67 +1085,13 @@
             "value" : "Sair sem salvar?"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Выйти без сохранения?"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Leave without saving?"
@@ -3137,25 +1103,7 @@
             "value" : "Leave without saving?"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leave without saving?"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Leave without saving?"
@@ -3184,42 +1132,6 @@
             "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -3230,18 +1142,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sie sind jetzt Besitzer des Teams %@.\n\nÖffnen Sie Team-Management, um: \n• Ihre ersten Team-Mitglieder einzuladen und mit der Zusammenarbeit zu beginnen\n• Ihre Team-Einstellungen anzupassen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
           }
         },
         "en" : {
@@ -3262,18 +1162,6 @@
             "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -3281,36 +1169,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
@@ -3328,61 +1186,7 @@
             "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
@@ -3394,19 +1198,7 @@
             "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
@@ -3418,67 +1210,13 @@
             "value" : "Agora você é o dono da equipe %@.\n\nVá para Gerenciamento de Equipe para: \n• convidar seus primeiros membros da equipe e começarem a trabalhar juntos\n• Personalizar suas configurações de equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Теперь вы являетесь владельцем команды %@.\n\nПерейдите в раздел Управление командой, чтобы: \n• Пригласить первых членов команды и начать совместную работу\n• Настроить параметры команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
@@ -3490,25 +1228,7 @@
             "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You’re now the owner of the team %@.\n\nGo to Team Management to: \n• Invite your first team members, and start working together\n• Customize your team settings"
@@ -3537,42 +1257,6 @@
             "value" : "Back To Wire"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -3583,18 +1267,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zurück zu Wire"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
           }
         },
         "en" : {
@@ -3615,18 +1287,6 @@
             "value" : "Back To Wire"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -3634,36 +1294,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Back To Wire"
@@ -3681,61 +1311,7 @@
             "value" : "Back To Wire"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Back To Wire"
@@ -3747,19 +1323,7 @@
             "value" : "Back To Wire"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Back To Wire"
@@ -3771,67 +1335,13 @@
             "value" : "Voltar ao Wire"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вернуться в Wire"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Back To Wire"
@@ -3843,25 +1353,7 @@
             "value" : "Back To Wire"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back To Wire"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Back To Wire"
@@ -3890,42 +1382,6 @@
             "value" : "Go To Team Management"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -3936,18 +1392,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Team-Management öffnen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
           }
         },
         "en" : {
@@ -3968,18 +1412,6 @@
             "value" : "Go To Team Management"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -3987,36 +1419,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Go To Team Management"
@@ -4034,61 +1436,7 @@
             "value" : "Go To Team Management"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Go To Team Management"
@@ -4100,19 +1448,7 @@
             "value" : "Go To Team Management"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Go To Team Management"
@@ -4124,67 +1460,13 @@
             "value" : "Ir para o gerenciamento de equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Перейти к управлению командой"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Go To Team Management"
@@ -4196,25 +1478,7 @@
             "value" : "Go To Team Management"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Go To Team Management"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Go To Team Management"
@@ -4242,42 +1506,6 @@
             "value" : "Close team created view"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -4288,18 +1516,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ansicht Team erstellt schließen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
           }
         },
         "en" : {
@@ -4320,18 +1536,6 @@
             "value" : "Close team created view"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -4339,36 +1543,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team created view"
@@ -4386,61 +1560,7 @@
             "value" : "Close team created view"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team created view"
@@ -4452,19 +1572,7 @@
             "value" : "Close team created view"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team created view"
@@ -4476,67 +1584,13 @@
             "value" : "Fechar visualização de equipe criada"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть просмотр создания команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team created view"
@@ -4548,25 +1602,7 @@
             "value" : "Close team created view"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team created view"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team created view"
@@ -4595,42 +1631,6 @@
             "value" : "You’re now the owner of the team %@."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -4641,18 +1641,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sie sind jetzt Besitzer des Teams %@."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
           }
         },
         "en" : {
@@ -4673,18 +1661,6 @@
             "value" : "You’re now the owner of the team %@."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -4692,36 +1668,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You’re now the owner of the team %@."
@@ -4739,61 +1685,7 @@
             "value" : "You’re now the owner of the team %@."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You’re now the owner of the team %@."
@@ -4805,19 +1697,7 @@
             "value" : "You’re now the owner of the team %@."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You’re now the owner of the team %@."
@@ -4829,67 +1709,13 @@
             "value" : "Agora você é dono da equipe %@."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Теперь вы являетесь владельцем команды %@."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You’re now the owner of the team %@."
@@ -4901,25 +1727,7 @@
             "value" : "You’re now the owner of the team %@."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You’re now the owner of the team %@."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You’re now the owner of the team %@."
@@ -4948,42 +1756,6 @@
             "value" : "Congratulations %@!"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -4994,18 +1766,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Herzlichen Glückwunsch %@!"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
           }
         },
         "en" : {
@@ -5026,18 +1786,6 @@
             "value" : "Congratulations %@!"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -5045,36 +1793,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Congratulations %@!"
@@ -5092,61 +1810,7 @@
             "value" : "Congratulations %@!"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Congratulations %@!"
@@ -5158,19 +1822,7 @@
             "value" : "Congratulations %@!"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Congratulations %@!"
@@ -5182,67 +1834,13 @@
             "value" : "Parabéns, %@!"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поздравляем %@!"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Congratulations %@!"
@@ -5254,25 +1852,7 @@
             "value" : "Congratulations %@!"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Congratulations %@!"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Congratulations %@!"
@@ -5300,42 +1880,6 @@
             "value" : "You create a team and transfer your personal account into a team account"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -5346,18 +1890,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sie erstellen ein Team und übertragen Ihr privates Benutzerkonto in ein Team-Konto"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
           }
         },
         "en" : {
@@ -5378,18 +1910,6 @@
             "value" : "You create a team and transfer your personal account into a team account"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -5397,36 +1917,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You create a team and transfer your personal account into a team account"
@@ -5444,61 +1934,7 @@
             "value" : "You create a team and transfer your personal account into a team account"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You create a team and transfer your personal account into a team account"
@@ -5510,19 +1946,7 @@
             "value" : "You create a team and transfer your personal account into a team account"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You create a team and transfer your personal account into a team account"
@@ -5534,67 +1958,13 @@
             "value" : "Você cria uma equipe e transfere a sua conta pessoal para uma conta de equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вы создаете команду и преобразуете свой персональный аккаунт в командный"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You create a team and transfer your personal account into a team account"
@@ -5606,25 +1976,7 @@
             "value" : "You create a team and transfer your personal account into a team account"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You create a team and transfer your personal account into a team account"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You create a team and transfer your personal account into a team account"
@@ -5652,42 +2004,6 @@
             "value" : "This change is permanent and irrevocable"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -5698,18 +2014,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Diese Änderung ist dauerhaft und unwiderruflich"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
           }
         },
         "en" : {
@@ -5730,18 +2034,6 @@
             "value" : "This change is permanent and irrevocable"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -5749,36 +2041,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This change is permanent and irrevocable"
@@ -5796,61 +2058,7 @@
             "value" : "This change is permanent and irrevocable"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This change is permanent and irrevocable"
@@ -5862,19 +2070,7 @@
             "value" : "This change is permanent and irrevocable"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This change is permanent and irrevocable"
@@ -5886,67 +2082,13 @@
             "value" : "Esta mudança é permanente e irrevogável"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Это изменение является постоянным и необратимым"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This change is permanent and irrevocable"
@@ -5958,25 +2100,7 @@
             "value" : "This change is permanent and irrevocable"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This change is permanent and irrevocable"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This change is permanent and irrevocable"
@@ -6004,42 +2128,6 @@
             "value" : "As the team owner you can invite and remove team members and  manage team settings"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -6050,18 +2138,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Als Team-Besitzer können Sie Team-Mitglieder einladen und entfernen sowie die Einstellungen verwalten"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
           }
         },
         "en" : {
@@ -6082,18 +2158,6 @@
             "value" : "As the team owner you can invite and remove team members and  manage team settings"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -6101,36 +2165,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "As the team owner you can invite and remove team members and  manage team settings"
@@ -6148,61 +2182,7 @@
             "value" : "As the team owner you can invite and remove team members and  manage team settings"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "As the team owner you can invite and remove team members and  manage team settings"
@@ -6214,19 +2194,7 @@
             "value" : "As the team owner you can invite and remove team members and  manage team settings"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "As the team owner you can invite and remove team members and  manage team settings"
@@ -6238,67 +2206,13 @@
             "value" : "Como proprietário da equipe, você pode convidar e remover membros da equipe e gerenciar as configurações da equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Как владелец команды вы можете приглашать и удалять членов команды, а также управлять ее настройками"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "As the team owner you can invite and remove team members and  manage team settings"
@@ -6310,25 +2224,7 @@
             "value" : "As the team owner you can invite and remove team members and  manage team settings"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As the team owner you can invite and remove team members and  manage team settings"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "As the team owner you can invite and remove team members and  manage team settings"
@@ -6356,42 +2252,6 @@
             "value" : "Close confirmation view"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -6402,18 +2262,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bestätigungsansicht schließen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
           }
         },
         "en" : {
@@ -6434,18 +2282,6 @@
             "value" : "Close confirmation view"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -6453,36 +2289,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close confirmation view"
@@ -6500,61 +2306,7 @@
             "value" : "Close confirmation view"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close confirmation view"
@@ -6566,19 +2318,7 @@
             "value" : "Close confirmation view"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close confirmation view"
@@ -6590,67 +2330,13 @@
             "value" : "Fechar visualização de confirmação"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть окно подтверждения"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close confirmation view"
@@ -6662,25 +2348,7 @@
             "value" : "Close confirmation view"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close confirmation view"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close confirmation view"
@@ -6709,42 +2377,6 @@
             "value" : "نسيتَ كلمة المرور؟"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6755,18 +2387,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Passwort vergessen?"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
           }
         },
         "en" : {
@@ -6787,18 +2407,6 @@
             "value" : "Unustasid parooli?"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6809,36 +2417,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mot de passe oublié ?"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
           }
         },
         "it" : {
@@ -6853,64 +2431,10 @@
             "value" : "パスワードをお忘れですか？"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pamiršote slaptažodį?"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
           }
         },
         "nl" : {
@@ -6919,22 +2443,10 @@
             "value" : "Wachtwoord vergeten?"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nie pamiętasz hasła?"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
           }
         },
         "pt-BR" : {
@@ -6943,28 +2455,10 @@
             "value" : "Esqueceu a senha?"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Забыли пароль?"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
           }
         },
         "sl" : {
@@ -6973,70 +2467,16 @@
             "value" : "Pozabljeno geslo?"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Şifrenizi mi unuttunuz?"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Забули пароль?"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Forgot password?"
           }
         },
         "zh-Hans" : {
@@ -7062,42 +2502,6 @@
             "value" : "كلمة المرور"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7108,18 +2512,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Passwort"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
           }
         },
         "en" : {
@@ -7140,18 +2532,6 @@
             "value" : "Parool"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7162,36 +2542,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mot de passe"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
           }
         },
         "it" : {
@@ -7206,64 +2556,10 @@
             "value" : "パスワード"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Slaptažodis"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
           }
         },
         "nl" : {
@@ -7272,22 +2568,10 @@
             "value" : "Wachtwoord"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hasło"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
           }
         },
         "pt-BR" : {
@@ -7296,28 +2580,10 @@
             "value" : "Senha"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пароль"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
           }
         },
         "sl" : {
@@ -7326,70 +2592,16 @@
             "value" : "Geslo"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Parola"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пароль"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password"
           }
         },
         "zh-Hans" : {
@@ -7415,42 +2627,6 @@
             "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -7461,18 +2637,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ich bin mit den Übertragungsbedingungen einverstanden und verstehe, dass diese Änderung unumkehrbar ist."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
           }
         },
         "en" : {
@@ -7493,18 +2657,6 @@
             "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -7512,36 +2664,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
@@ -7559,61 +2681,7 @@
             "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
@@ -7625,19 +2693,7 @@
             "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
@@ -7649,67 +2705,13 @@
             "value" : "Entendo que esta migração de Pessoal para Equipe é permanente e não pode ser desfeita."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Я понимаю, что миграция с личного аккаунта в команду является постоянной и не может быть отменена."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
@@ -7721,25 +2723,7 @@
             "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "I understand that this migration from Personal to Team is permanent and cannot be undone."
@@ -7768,42 +2752,6 @@
             "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -7814,18 +2762,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ich akzeptiere Wires [Nutzungsbedingungen](%@) und [Datenschutzrichtlinien](%@)."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
           }
         },
         "en" : {
@@ -7846,18 +2782,6 @@
             "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -7865,36 +2789,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
@@ -7912,61 +2806,7 @@
             "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
@@ -7978,19 +2818,7 @@
             "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
@@ -8002,67 +2830,13 @@
             "value" : "Aceite nossos [Termos e Condições](%@) e [Política de Privacidade](%@)."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Примите наши [Правила и условия](%@) и [Политику конфиденциальности](%@)."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
@@ -8074,25 +2848,7 @@
             "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Accept our [Terms & Conditions](%@) and [Privacy Policy](%@)."
@@ -8121,42 +2877,6 @@
             "value" : "Confirmation"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -8167,18 +2887,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bestätigung"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
           }
         },
         "en" : {
@@ -8199,18 +2907,6 @@
             "value" : "Confirmation"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -8218,36 +2914,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Confirmation"
@@ -8265,61 +2931,7 @@
             "value" : "Confirmation"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Confirmation"
@@ -8331,19 +2943,7 @@
             "value" : "Confirmation"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Confirmation"
@@ -8355,67 +2955,13 @@
             "value" : "Confirmação"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Подтверждение"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Confirmation"
@@ -8427,25 +2973,7 @@
             "value" : "Confirmation"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirmation"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Confirmation"
@@ -8474,42 +3002,6 @@
             "value" : "Ok"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -8520,18 +3012,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
           }
         },
         "en" : {
@@ -8552,18 +3032,6 @@
             "value" : "Ok"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -8571,36 +3039,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Ok"
@@ -8618,61 +3056,7 @@
             "value" : "Ok"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Ok"
@@ -8684,19 +3068,7 @@
             "value" : "Ok"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Ok"
@@ -8708,67 +3080,13 @@
             "value" : "Ok"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Ok"
@@ -8780,25 +3098,7 @@
             "value" : "Ok"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ok"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Ok"
@@ -8827,42 +3127,6 @@
             "value" : "You've created or joined a team with this email address on another device."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -8873,18 +3137,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sie haben ein Team mit dieser E-Mail-Adresse auf einem anderen Gerät erstellt oder sind einem Team beigetreten."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
           }
         },
         "en" : {
@@ -8905,18 +3157,6 @@
             "value" : "You've created or joined a team with this email address on another device."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -8924,36 +3164,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You've created or joined a team with this email address on another device."
@@ -8971,61 +3181,7 @@
             "value" : "You've created or joined a team with this email address on another device."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You've created or joined a team with this email address on another device."
@@ -9037,19 +3193,7 @@
             "value" : "You've created or joined a team with this email address on another device."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You've created or joined a team with this email address on another device."
@@ -9061,67 +3205,13 @@
             "value" : "Você criou ou juntou-se a uma equipe com este endereço de e-mail em outro dispositivo."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вы создали или присоединились к команде с этим email на другом устройстве."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You've created or joined a team with this email address on another device."
@@ -9133,25 +3223,7 @@
             "value" : "You've created or joined a team with this email address on another device."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You've created or joined a team with this email address on another device."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You've created or joined a team with this email address on another device."
@@ -9180,42 +3252,6 @@
             "value" : "Already part of a team"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -9226,18 +3262,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bereits Teil eines Teams"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
           }
         },
         "en" : {
@@ -9258,18 +3282,6 @@
             "value" : "Already part of a team"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -9277,36 +3289,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Already part of a team"
@@ -9324,61 +3306,7 @@
             "value" : "Already part of a team"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Already part of a team"
@@ -9390,19 +3318,7 @@
             "value" : "Already part of a team"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Already part of a team"
@@ -9414,67 +3330,13 @@
             "value" : "Já faz parte de uma equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Уже в команде"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Already part of a team"
@@ -9486,25 +3348,7 @@
             "value" : "Already part of a team"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Already part of a team"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Already part of a team"
@@ -9533,42 +3377,6 @@
             "value" : "Try Again"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -9579,18 +3387,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erneut versuchen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
           }
         },
         "en" : {
@@ -9611,18 +3407,6 @@
             "value" : "Try Again"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -9630,36 +3414,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Try Again"
@@ -9677,61 +3431,7 @@
             "value" : "Try Again"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Try Again"
@@ -9743,19 +3443,7 @@
             "value" : "Try Again"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Try Again"
@@ -9767,67 +3455,13 @@
             "value" : "Tente novamente"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Повторить попытку"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Try Again"
@@ -9839,25 +3473,7 @@
             "value" : "Try Again"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Try Again"
@@ -9886,42 +3502,6 @@
             "value" : "Wire could not complete your team creation due to an unknown error."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -9932,18 +3512,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wire konnte die Erstellung Ihres Teams aufgrund eines unbekannten Fehlers nicht abschließen."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
           }
         },
         "en" : {
@@ -9964,18 +3532,6 @@
             "value" : "Wire could not complete your team creation due to an unknown error."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -9983,36 +3539,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Wire could not complete your team creation due to an unknown error."
@@ -10030,61 +3556,7 @@
             "value" : "Wire could not complete your team creation due to an unknown error."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Wire could not complete your team creation due to an unknown error."
@@ -10096,19 +3568,7 @@
             "value" : "Wire could not complete your team creation due to an unknown error."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Wire could not complete your team creation due to an unknown error."
@@ -10120,67 +3580,13 @@
             "value" : "O Wire não pôde completar a criação de sua equipe devido a um erro desconhecido."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wire не удалось завершить создание вашей команды из-за неизвестной ошибки."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Wire could not complete your team creation due to an unknown error."
@@ -10192,25 +3598,7 @@
             "value" : "Wire could not complete your team creation due to an unknown error."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wire could not complete your team creation due to an unknown error."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Wire could not complete your team creation due to an unknown error."
@@ -10239,42 +3627,6 @@
             "value" : "Team not created"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -10285,18 +3637,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Team nicht erstellt"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
           }
         },
         "en" : {
@@ -10317,18 +3657,6 @@
             "value" : "Team not created"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -10336,36 +3664,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team not created"
@@ -10383,61 +3681,7 @@
             "value" : "Team not created"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team not created"
@@ -10449,19 +3693,7 @@
             "value" : "Team not created"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team not created"
@@ -10473,67 +3705,13 @@
             "value" : "Equipe não criada"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Команда не создана"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team not created"
@@ -10545,25 +3723,7 @@
             "value" : "Team not created"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team not created"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team not created"
@@ -10591,42 +3751,6 @@
             "value" : "جارِ التحميل…"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -10637,18 +3761,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wird geladen…"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
           }
         },
         "en" : {
@@ -10669,18 +3781,6 @@
             "value" : "Laadimine…"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10691,36 +3791,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chargement…"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
           }
         },
         "it" : {
@@ -10735,64 +3805,10 @@
             "value" : "読み込み中…"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kraunama…"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
           }
         },
         "nl" : {
@@ -10801,22 +3817,10 @@
             "value" : "Laden…"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wczytuje…"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
           }
         },
         "pt-BR" : {
@@ -10825,67 +3829,13 @@
             "value" : "Carregando…"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Загрузка…"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading…"
@@ -10897,28 +3847,10 @@
             "value" : "Yükleniyor…"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Завантаження…"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading…"
           }
         },
         "zh-Hans" : {
@@ -10944,42 +3876,6 @@
             "value" : "Transform your personal account into a team account to get more out of your collaboration."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -10990,18 +3886,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Übertragen Sie Ihr privates Benutzerkonto in ein Team-Konto, um besser zusammenzuarbeiten."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
           }
         },
         "en" : {
@@ -11022,18 +3906,6 @@
             "value" : "Transform your personal account into a team account to get more out of your collaboration."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -11041,36 +3913,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Transform your personal account into a team account to get more out of your collaboration."
@@ -11088,61 +3930,7 @@
             "value" : "Transform your personal account into a team account to get more out of your collaboration."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Transform your personal account into a team account to get more out of your collaboration."
@@ -11154,19 +3942,7 @@
             "value" : "Transform your personal account into a team account to get more out of your collaboration."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Transform your personal account into a team account to get more out of your collaboration."
@@ -11178,67 +3954,13 @@
             "value" : "Transforme sua conta pessoal em uma conta de equipe para obter mais da sua colaboração."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Трансформируйте свой персональный аккаунт в командный, чтобы получить больше пользы от совместной работы."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Transform your personal account into a team account to get more out of your collaboration."
@@ -11250,25 +3972,7 @@
             "value" : "Transform your personal account into a team account to get more out of your collaboration."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Transform your personal account into a team account to get more out of your collaboration."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Transform your personal account into a team account to get more out of your collaboration."
@@ -11296,42 +4000,6 @@
             "value" : "Close team account overview"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -11342,18 +4010,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Team-Konto-Übersicht schließen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
           }
         },
         "en" : {
@@ -11374,18 +4030,6 @@
             "value" : "Close team account overview"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -11393,36 +4037,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team account overview"
@@ -11440,61 +4054,7 @@
             "value" : "Close team account overview"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team account overview"
@@ -11506,19 +4066,7 @@
             "value" : "Close team account overview"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team account overview"
@@ -11530,67 +4078,13 @@
             "value" : "Fechar visão geral da conta da equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть информацию об аккаунте команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team account overview"
@@ -11602,25 +4096,7 @@
             "value" : "Close team account overview"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team account overview"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team account overview"
@@ -11649,42 +4125,6 @@
             "value" : "**Admin Console**: Invite team members and manage settings."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -11695,18 +4135,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Admin-Konsole**: Laden Sie Team-Mitglieder ein und verwalten Sie Einstellungen."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
           }
         },
         "en" : {
@@ -11727,18 +4155,6 @@
             "value" : "**Admin Console**: Invite team members and manage settings."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -11746,36 +4162,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Admin Console**: Invite team members and manage settings."
@@ -11793,61 +4179,7 @@
             "value" : "**Admin Console**: Invite team members and manage settings."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Admin Console**: Invite team members and manage settings."
@@ -11859,19 +4191,7 @@
             "value" : "**Admin Console**: Invite team members and manage settings."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Admin Console**: Invite team members and manage settings."
@@ -11883,67 +4203,13 @@
             "value" : "**Console administrativo**: Convide membros da equipe e gerencie as configurações."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Консоль администратора**: Приглашайте членов команды и управляйте настройками."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Admin Console**: Invite team members and manage settings."
@@ -11955,25 +4221,7 @@
             "value" : "**Admin Console**: Invite team members and manage settings."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Admin Console**: Invite team members and manage settings."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Admin Console**: Invite team members and manage settings."
@@ -12002,42 +4250,6 @@
             "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -12048,18 +4260,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Mühelose Zusammenarbeit**: Kommunizieren Sie mit Gästen und externen Partnern."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
           }
         },
         "en" : {
@@ -12080,18 +4280,6 @@
             "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -12099,36 +4287,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
@@ -12146,61 +4304,7 @@
             "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
@@ -12212,19 +4316,7 @@
             "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
@@ -12236,67 +4328,13 @@
             "value" : "**Colaboração sem esforço**: Comunique-se com convidados e partes externas."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Эффективное сотрудничество**: Общайтесь с гостями и внешними участниками."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
@@ -12308,25 +4346,7 @@
             "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Effortless Collaboration**: Communicate with guests and external parties."
@@ -12355,42 +4375,6 @@
             "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -12401,18 +4385,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Auf Enterprise upgraden**: Erhalten Sie zusätzliche Funktionen und Premium-Support."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
           }
         },
         "en" : {
@@ -12433,18 +4405,6 @@
             "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -12452,36 +4412,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
@@ -12499,61 +4429,7 @@
             "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
@@ -12565,19 +4441,7 @@
             "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
@@ -12589,67 +4453,13 @@
             "value" : "**Atualize para Enterprise**: Obtenha recursos adicionais e suporte premium."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Обновление до Enterprise**: Получите дополнительные возможности и премиум-поддержку."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
@@ -12661,25 +4471,7 @@
             "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Upgrade to Enterprise**: Get additional features and premium support."
@@ -12708,42 +4500,6 @@
             "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -12754,18 +4510,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Größere Meetings**: Nehmen Sie an Videokonferenzen mit bis zu 150 Teilnehmern teil."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
           }
         },
         "en" : {
@@ -12786,18 +4530,6 @@
             "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -12805,36 +4537,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
@@ -12852,61 +4554,7 @@
             "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
@@ -12918,19 +4566,7 @@
             "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
@@ -12942,67 +4578,13 @@
             "value" : "**Reuniões grandes**: Participe de videoconferências de até 150 participantes."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Большие совещания**:Присоединяйтесь к видеоконференциям с участием до 150 человек."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
@@ -13014,25 +4596,7 @@
             "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Larger Meetings**: Join video conferences up to 150 participants."
@@ -13061,42 +4625,6 @@
             "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -13107,18 +4635,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Verfügbarkeitsstatus**: Lassen Sie Ihr Team wissen, ob Sie verfügbar, beschäftigt oder abwesend sind."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
           }
         },
         "en" : {
@@ -13139,18 +4655,6 @@
             "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -13158,36 +4662,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
@@ -13205,61 +4679,7 @@
             "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
@@ -13271,19 +4691,7 @@
             "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
@@ -13295,67 +4703,13 @@
             "value" : "**Status de disponibilidade**: avise sua equipe se você estiver disponível, ocupado ou ausente."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Статус доступности**: Сообщите своей команде, если вы свободны, заняты или отсутствуете."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
@@ -13367,25 +4721,7 @@
             "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "**Availability Status**: Let your team know if you’re available, busy or away."
@@ -13414,42 +4750,6 @@
             "value" : "Team Account"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -13460,18 +4760,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Team-Konto"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
           }
         },
         "en" : {
@@ -13492,18 +4780,6 @@
             "value" : "Team Account"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -13511,36 +4787,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team Account"
@@ -13558,61 +4804,7 @@
             "value" : "Team Account"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team Account"
@@ -13624,19 +4816,7 @@
             "value" : "Team Account"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team Account"
@@ -13648,67 +4828,13 @@
             "value" : "Conta de equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Аккаунт команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team Account"
@@ -13720,25 +4846,7 @@
             "value" : "Team Account"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Account"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team Account"
@@ -13767,42 +4875,6 @@
             "value" : "Learn more about Wire's plans"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -13813,18 +4885,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erfahren Sie mehr über Wires Preise"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
           }
         },
         "en" : {
@@ -13845,18 +4905,6 @@
             "value" : "Learn more about Wire's plans"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -13864,36 +4912,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Learn more about Wire's plans"
@@ -13911,61 +4929,7 @@
             "value" : "Learn more about Wire's plans"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Learn more about Wire's plans"
@@ -13977,19 +4941,7 @@
             "value" : "Learn more about Wire's plans"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Learn more about Wire's plans"
@@ -14001,67 +4953,13 @@
             "value" : "Saiba mais sobre os planos do Wire"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Узнайте больше о тарифах Wire"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Learn more about Wire's plans"
@@ -14073,25 +4971,7 @@
             "value" : "Learn more about Wire's plans"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Learn more about Wire's plans"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Learn more about Wire's plans"
@@ -14120,42 +5000,6 @@
             "value" : "Step %d of %d"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -14166,18 +5010,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schritt %d  von %d"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
           }
         },
         "en" : {
@@ -14198,18 +5030,6 @@
             "value" : "Step %d of %d"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -14217,36 +5037,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Step %d of %d"
@@ -14264,61 +5054,7 @@
             "value" : "Step %d of %d"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Step %d of %d"
@@ -14330,19 +5066,7 @@
             "value" : "Step %d of %d"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Step %d of %d"
@@ -14354,67 +5078,13 @@
             "value" : "Passo %d de %d"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Шаг %d из %d"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Step %d of %d"
@@ -14426,25 +5096,7 @@
             "value" : "Step %d of %d"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step %d of %d"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Step %d of %d"
@@ -14473,42 +5125,6 @@
             "value" : "Select a name for your team. You can change it at any time."
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -14519,18 +5135,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wählen Sie einen Namen für Ihr Team. Sie können ihn jederzeit ändern."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
           }
         },
         "en" : {
@@ -14551,18 +5155,6 @@
             "value" : "Select a name for your team. You can change it at any time."
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -14570,36 +5162,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select a name for your team. You can change it at any time."
@@ -14617,61 +5179,7 @@
             "value" : "Select a name for your team. You can change it at any time."
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select a name for your team. You can change it at any time."
@@ -14683,19 +5191,7 @@
             "value" : "Select a name for your team. You can change it at any time."
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select a name for your team. You can change it at any time."
@@ -14707,67 +5203,13 @@
             "value" : "Selecione um nome para sua equipe. Você pode mudá-lo a qualquer momento."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Выберите название для своей команды. Вы можете изменить его в любое время."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select a name for your team. You can change it at any time."
@@ -14779,25 +5221,7 @@
             "value" : "Select a name for your team. You can change it at any time."
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a name for your team. You can change it at any time."
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select a name for your team. You can change it at any time."
@@ -14825,42 +5249,6 @@
             "value" : "Close team name view"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -14871,18 +5259,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ansicht Teamname schließen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
           }
         },
         "en" : {
@@ -14903,18 +5279,6 @@
             "value" : "Close team name view"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -14922,36 +5286,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team name view"
@@ -14969,61 +5303,7 @@
             "value" : "Close team name view"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team name view"
@@ -15035,19 +5315,7 @@
             "value" : "Close team name view"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team name view"
@@ -15059,67 +5327,13 @@
             "value" : "Fechar visualização do nome da equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть просмотр информации о названии команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team name view"
@@ -15131,25 +5345,7 @@
             "value" : "Close team name view"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close team name view"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close team name view"
@@ -15178,42 +5374,6 @@
             "value" : "Your Team"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -15224,18 +5384,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ihr Team"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
           }
         },
         "en" : {
@@ -15256,18 +5404,6 @@
             "value" : "Your Team"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -15275,36 +5411,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Your Team"
@@ -15322,61 +5428,7 @@
             "value" : "Your Team"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Your Team"
@@ -15388,19 +5440,7 @@
             "value" : "Your Team"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Your Team"
@@ -15412,67 +5452,13 @@
             "value" : "Sua equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ваша команда"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Your Team"
@@ -15484,25 +5470,7 @@
             "value" : "Your Team"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Team"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Your Team"
@@ -15531,42 +5499,6 @@
             "value" : "Team name"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -15577,18 +5509,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Team-Name"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
           }
         },
         "en" : {
@@ -15609,18 +5529,6 @@
             "value" : "Team name"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -15631,36 +5539,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nom de l’équipe"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
           }
         },
         "it" : {
@@ -15675,61 +5553,7 @@
             "value" : "Team name"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team name"
@@ -15741,22 +5565,10 @@
             "value" : "Team name"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nazwa zespołu"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
           }
         },
         "pt-BR" : {
@@ -15765,67 +5577,13 @@
             "value" : "Nome da equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Название команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team name"
@@ -15837,28 +5595,10 @@
             "value" : "Team name"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ім'я команди"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team name"
           }
         },
         "zh-Hans" : {
@@ -15884,42 +5624,6 @@
             "value" : "Team Name"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -15930,18 +5634,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Team-Name"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
           }
         },
         "en" : {
@@ -15962,18 +5654,6 @@
             "value" : "Team Name"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -15981,36 +5661,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team Name"
@@ -16028,61 +5678,7 @@
             "value" : "Team Name"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team Name"
@@ -16094,19 +5690,7 @@
             "value" : "Team Name"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team Name"
@@ -16118,67 +5702,13 @@
             "value" : "Nome da equipe"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Название команды"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team Name"
@@ -16190,25 +5720,7 @@
             "value" : "Team Name"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Team Name"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Team Name"

--- a/WireUI/Sources/WireMainNavigationUI/Resources/Localization/Accessibility.xcstrings
+++ b/WireUI/Sources/WireMainNavigationUI/Resources/Localization/Accessibility.xcstrings
@@ -9,42 +9,6 @@
             "value" : "حفظ في الأرشيف"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55,18 +19,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Archiv"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "en" : {
@@ -87,18 +39,6 @@
             "value" : "Arhiveeri"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -109,36 +49,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Archives"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "it" : {
@@ -153,64 +63,10 @@
             "value" : "アーカイブ"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Archyvuoti"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "nl" : {
@@ -219,22 +75,10 @@
             "value" : "Archiveren"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Archiwum"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "pt-BR" : {
@@ -243,28 +87,10 @@
             "value" : "Arquivar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Архивировать"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "sl" : {
@@ -273,70 +99,16 @@
             "value" : "Arhiviraj"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Arşivle"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Архівувати"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "zh-Hans" : {
@@ -361,42 +133,6 @@
             "value" : "Double tap to open list of archived conversations"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -407,18 +143,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Doppeltippen, um Liste archivierter Unterhaltungen zu öffnen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
           }
         },
         "en" : {
@@ -439,18 +163,6 @@
             "value" : "Double tap to open list of archived conversations"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -458,36 +170,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open list of archived conversations"
@@ -505,61 +187,7 @@
             "value" : "Double tap to open list of archived conversations"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open list of archived conversations"
@@ -571,19 +199,7 @@
             "value" : "Double tap to open list of archived conversations"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open list of archived conversations"
@@ -595,67 +211,13 @@
             "value" : "Toque duas vezes para abrir a lista de conversas arquivadas"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нажмите дважды, чтобы открыть список архивных бесед"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open list of archived conversations"
@@ -667,25 +229,7 @@
             "value" : "Double tap to open list of archived conversations"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of archived conversations"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open list of archived conversations"
@@ -713,42 +257,6 @@
             "value" : "List of recent conversations"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -759,18 +267,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liste der letzten Unterhaltungen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
           }
         },
         "en" : {
@@ -791,18 +287,6 @@
             "value" : "List of recent conversations"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -810,36 +294,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of recent conversations"
@@ -857,61 +311,7 @@
             "value" : "List of recent conversations"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of recent conversations"
@@ -923,19 +323,7 @@
             "value" : "List of recent conversations"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of recent conversations"
@@ -947,67 +335,13 @@
             "value" : "Lista de conversas recentes"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Список недавних бесед"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of recent conversations"
@@ -1019,25 +353,7 @@
             "value" : "List of recent conversations"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of recent conversations"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of recent conversations"
@@ -1065,42 +381,6 @@
             "value" : "Double tap to open list of recent conversations"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -1111,18 +391,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Doppeltippen, um Liste der letzten Unterhaltungen zu öffnen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
           }
         },
         "en" : {
@@ -1143,18 +411,6 @@
             "value" : "Double tap to open list of recent conversations"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -1162,36 +418,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open list of recent conversations"
@@ -1209,61 +435,7 @@
             "value" : "Double tap to open list of recent conversations"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open list of recent conversations"
@@ -1275,19 +447,7 @@
             "value" : "Double tap to open list of recent conversations"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open list of recent conversations"
@@ -1299,67 +459,13 @@
             "value" : "Toque duplo para abrir a lista de conversas recentes"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нажмите дважды, чтобы открыть список последних бесед"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open list of recent conversations"
@@ -1371,25 +477,7 @@
             "value" : "Double tap to open list of recent conversations"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open list of recent conversations"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open list of recent conversations"
@@ -1418,42 +506,6 @@
             "value" : "ملفّات"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1464,18 +516,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dateien"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
           }
         },
         "en" : {
@@ -1496,18 +536,6 @@
             "value" : "Failid"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1518,36 +546,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fichiers"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
           }
         },
         "it" : {
@@ -1562,64 +560,10 @@
             "value" : "ファイル"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Failai"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
           }
         },
         "nl" : {
@@ -1628,22 +572,10 @@
             "value" : "Bestanden"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pliki"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
           }
         },
         "pt-BR" : {
@@ -1652,28 +584,10 @@
             "value" : "Arquivos"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файлы"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
           }
         },
         "sl" : {
@@ -1682,70 +596,16 @@
             "value" : "Zbirke"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dosyalar"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файли"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Files"
           }
         },
         "zh-Hans" : {
@@ -1771,42 +631,6 @@
             "value" : "List of all files"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -1817,18 +641,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liste aller Dateien"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
           }
         },
         "en" : {
@@ -1849,18 +661,6 @@
             "value" : "List of all files"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -1868,36 +668,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of all files"
@@ -1915,61 +685,7 @@
             "value" : "List of all files"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of all files"
@@ -1981,19 +697,7 @@
             "value" : "List of all files"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of all files"
@@ -2005,67 +709,13 @@
             "value" : "List of all files"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Список всех файлов"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of all files"
@@ -2077,25 +727,7 @@
             "value" : "List of all files"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of all files"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of all files"
@@ -2124,42 +756,6 @@
             "value" : "Meetings"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -2169,18 +765,6 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Meetings"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Meetings"
           }
         },
@@ -2202,18 +786,6 @@
             "value" : "Meetings"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -2221,36 +793,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Meetings"
@@ -2268,61 +810,7 @@
             "value" : "Meetings"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Meetings"
@@ -2334,19 +822,7 @@
             "value" : "Meetings"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Meetings"
@@ -2358,67 +834,13 @@
             "value" : "Meetings"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Встречи"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Meetings"
@@ -2430,25 +852,7 @@
             "value" : "Meetings"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Meetings"
@@ -2477,42 +881,6 @@
             "value" : "List of meetings"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -2523,18 +891,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liste der Meetings"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
           }
         },
         "en" : {
@@ -2555,18 +911,6 @@
             "value" : "List of meetings"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -2574,36 +918,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of meetings"
@@ -2621,61 +935,7 @@
             "value" : "List of meetings"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of meetings"
@@ -2687,19 +947,7 @@
             "value" : "List of meetings"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of meetings"
@@ -2711,67 +959,13 @@
             "value" : "List of meetings"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Список встреч"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of meetings"
@@ -2783,25 +977,7 @@
             "value" : "List of meetings"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "List of meetings"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "List of meetings"
@@ -2829,42 +1005,6 @@
             "value" : "الإعدادات"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2875,18 +1015,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Einstellungen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "en" : {
@@ -2907,18 +1035,6 @@
             "value" : "Seaded"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2929,36 +1045,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Paramètres"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "it" : {
@@ -2973,64 +1059,10 @@
             "value" : "設定"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nustatymai"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "nl" : {
@@ -3039,22 +1071,10 @@
             "value" : "Instellingen"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ustawienia"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "pt-BR" : {
@@ -3063,28 +1083,10 @@
             "value" : "Ajustes"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Настройки"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "sl" : {
@@ -3093,70 +1095,16 @@
             "value" : "Nastavitve"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ayarlar"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Налаштування"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "zh-Hans" : {
@@ -3181,42 +1129,6 @@
             "value" : "Double tap to open Settings"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -3227,18 +1139,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Doppeltippen, um Einstellungen zu öffnen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
           }
         },
         "en" : {
@@ -3259,18 +1159,6 @@
             "value" : "Double tap to open Settings"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -3278,36 +1166,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open Settings"
@@ -3325,61 +1183,7 @@
             "value" : "Double tap to open Settings"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open Settings"
@@ -3391,19 +1195,7 @@
             "value" : "Double tap to open Settings"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open Settings"
@@ -3415,67 +1207,13 @@
             "value" : "Toque duas vezes para abrir as configurações"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нажмите дважды, чтобы открыть настройки"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open Settings"
@@ -3487,25 +1225,7 @@
             "value" : "Double tap to open Settings"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Double tap to open Settings"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Double tap to open Settings"

--- a/WireUI/Sources/WireMainNavigationUI/Resources/Localization/Localizable.xcstrings
+++ b/WireUI/Sources/WireMainNavigationUI/Resources/Localization/Localizable.xcstrings
@@ -9,42 +9,6 @@
             "value" : "حفظ في الأرشيف"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55,18 +19,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Archiv"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "en" : {
@@ -87,18 +39,6 @@
             "value" : "Arhiveeri"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -109,36 +49,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Archives"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "it" : {
@@ -153,64 +63,10 @@
             "value" : "アーカイブ"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Archyvuoti"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "nl" : {
@@ -219,22 +75,10 @@
             "value" : "Archiveren"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Archiwum"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "pt-BR" : {
@@ -243,28 +87,10 @@
             "value" : "Arquivar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Архивировать"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "sl" : {
@@ -273,70 +99,16 @@
             "value" : "Arhiviraj"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Arşivle"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Архівувати"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Archive"
           }
         },
         "zh-Hans" : {
@@ -361,42 +133,6 @@
             "value" : "المحادثات"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -407,18 +143,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unterhaltungen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
           }
         },
         "en" : {
@@ -439,18 +163,6 @@
             "value" : "Vestlused"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -460,36 +172,6 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Conversations"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Conversations"
           }
         },
@@ -505,64 +187,10 @@
             "value" : "会話"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Susirašinėjimai"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
           }
         },
         "nl" : {
@@ -571,22 +199,10 @@
             "value" : "Gesprekken"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Konwersacje"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
           }
         },
         "pt-BR" : {
@@ -595,28 +211,10 @@
             "value" : "Conversas"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Беседы"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
           }
         },
         "sl" : {
@@ -625,70 +223,16 @@
             "value" : "Pogovori"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Konuşmalar"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Розмови"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Conversations"
           }
         },
         "zh-Hans" : {
@@ -714,42 +258,6 @@
             "value" : "Drive"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -759,18 +267,6 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Drive"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Drive"
           }
         },
@@ -792,18 +288,6 @@
             "value" : "Drive"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -811,36 +295,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Drive"
@@ -858,61 +312,7 @@
             "value" : "Drive"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Drive"
@@ -924,19 +324,7 @@
             "value" : "Drive"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Drive"
@@ -948,67 +336,13 @@
             "value" : "Drive"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Диск"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Drive"
@@ -1020,25 +354,7 @@
             "value" : "Drive"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Drive"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Drive"
@@ -1067,42 +383,6 @@
             "value" : "Meetings"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -1112,18 +392,6 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Meetings"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Meetings"
           }
         },
@@ -1145,18 +413,6 @@
             "value" : "Meetings"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -1164,36 +420,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Meetings"
@@ -1211,61 +437,7 @@
             "value" : "Meetings"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Meetings"
@@ -1277,19 +449,7 @@
             "value" : "Meetings"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Meetings"
@@ -1301,67 +461,13 @@
             "value" : "Meetings"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Встречи"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Meetings"
@@ -1373,25 +479,7 @@
             "value" : "Meetings"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Meetings"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Meetings"
@@ -1419,42 +507,6 @@
             "value" : "الإعدادات"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1465,18 +517,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Einstellungen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "en" : {
@@ -1497,18 +537,6 @@
             "value" : "Seaded"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1519,36 +547,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Paramètres"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "it" : {
@@ -1563,64 +561,10 @@
             "value" : "設定"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nustatymai"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "nl" : {
@@ -1629,22 +573,10 @@
             "value" : "Instellingen"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ustawienia"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "pt-BR" : {
@@ -1653,28 +585,10 @@
             "value" : "Ajustes"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Настройки"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "sl" : {
@@ -1683,70 +597,16 @@
             "value" : "Nastavitve"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ayarlar"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Налаштування"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings"
           }
         },
         "zh-Hans" : {

--- a/WireUI/Sources/WireMoveToFolderUI/Resources/Localization/Accessibility.xcstrings
+++ b/WireUI/Sources/WireMoveToFolderUI/Resources/Localization/Accessibility.xcstrings
@@ -9,42 +9,6 @@
             "value" : "Close folder overview"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -55,18 +19,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ordnerübersicht schließen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
           }
         },
         "en" : {
@@ -87,18 +39,6 @@
             "value" : "Close folder overview"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -106,36 +46,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close folder overview"
@@ -153,61 +63,7 @@
             "value" : "Close folder overview"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close folder overview"
@@ -219,19 +75,7 @@
             "value" : "Close folder overview"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close folder overview"
@@ -243,67 +87,13 @@
             "value" : "Fechar visualização da pasta"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть обзор папки"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close folder overview"
@@ -315,25 +105,7 @@
             "value" : "Close folder overview"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close folder overview"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close folder overview"

--- a/WireUI/Sources/WireMoveToFolderUI/Resources/Localization/Localizable.xcstrings
+++ b/WireUI/Sources/WireMoveToFolderUI/Resources/Localization/Localizable.xcstrings
@@ -10,42 +10,6 @@
             "value" : "إنشاء"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -56,18 +20,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erstellen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
           }
         },
         "en" : {
@@ -88,18 +40,6 @@
             "value" : "Loo"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -110,36 +50,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Créer"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
           }
         },
         "it" : {
@@ -154,64 +64,10 @@
             "value" : "新規作成"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kurti"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
           }
         },
         "nl" : {
@@ -220,22 +76,10 @@
             "value" : "Aanmaken"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Utwórz"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
           }
         },
         "pt-BR" : {
@@ -244,28 +88,10 @@
             "value" : "Criar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Создать"
-          }
-        },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
           }
         },
         "sl" : {
@@ -274,70 +100,16 @@
             "value" : "Ustvari"
           }
         },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oluştur"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Створити"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create"
           }
         },
         "zh-Hans" : {
@@ -363,42 +135,6 @@
             "value" : "Maximum 64 characters"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -409,18 +145,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximal 64 Zeichen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
           }
         },
         "en" : {
@@ -441,18 +165,6 @@
             "value" : "Maximum 64 characters"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -463,36 +175,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "64 caractères maximum"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
           }
         },
         "it" : {
@@ -507,73 +189,13 @@
             "value" : "最大64文字"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Iki 64 simbolių"
           }
         },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
         "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "no" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Maximum 64 characters"
@@ -585,22 +207,10 @@
             "value" : "Maksymalnie 64 znaki"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Máximo: 64 caracteres"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
           }
         },
         "ru" : {
@@ -609,55 +219,7 @@
             "value" : "Не более 64 символов"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Maximum 64 characters"
@@ -669,28 +231,10 @@
             "value" : "En fazla 64 karakter"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Максимум 64 символи"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum 64 characters"
           }
         },
         "zh-Hans" : {
@@ -716,42 +260,6 @@
             "value" : "Move the conversation %@ to a new folder"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -762,18 +270,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unterhaltung %@ in einen neuen Ordner verschieben"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
           }
         },
         "en" : {
@@ -794,18 +290,6 @@
             "value" : "Move the conversation %@ to a new folder"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -813,36 +297,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Move the conversation %@ to a new folder"
@@ -860,61 +314,7 @@
             "value" : "Move the conversation %@ to a new folder"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Move the conversation %@ to a new folder"
@@ -926,19 +326,7 @@
             "value" : "Move the conversation %@ to a new folder"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Move the conversation %@ to a new folder"
@@ -950,67 +338,13 @@
             "value" : "Mover a conversa %@ para uma nova pasta"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Переместить беседу с %@ в новую папку."
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Move the conversation %@ to a new folder"
@@ -1022,25 +356,7 @@
             "value" : "Move the conversation %@ to a new folder"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move the conversation %@ to a new folder"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Move the conversation %@ to a new folder"
@@ -1069,42 +385,6 @@
             "value" : "Create new folder"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -1115,18 +395,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Neuen Ordner anlegen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
           }
         },
         "en" : {
@@ -1147,18 +415,6 @@
             "value" : "Create new folder"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -1169,36 +425,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Créer un nouveau dossier"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
           }
         },
         "it" : {
@@ -1213,73 +439,13 @@
             "value" : "新規フォルダを作成"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sukurti naują aplanką"
           }
         },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
         "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "no" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Create new folder"
@@ -1291,22 +457,10 @@
             "value" : "Utwórz nowy folder"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Criar nova pasta"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
           }
         },
         "ru" : {
@@ -1315,55 +469,7 @@
             "value" : "Создание новой папки"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Create new folder"
@@ -1375,28 +481,10 @@
             "value" : "Yeni klasör oluştur"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Створити нову теку"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create new folder"
           }
         },
         "zh-Hans" : {
@@ -1422,42 +510,6 @@
             "value" : "انشئ مجلدا جديدا بالضغط على زر +"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -1468,18 +520,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Neuen Ordner durch Drücken der + Taste anlegen"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
           }
         },
         "en" : {
@@ -1500,18 +540,6 @@
             "value" : "Loo uus kaust, vajutades + nuppu"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -1522,36 +550,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Créer un nouveau dossier en cliquant sur the bouton +"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "is" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
           }
         },
         "it" : {
@@ -1566,73 +564,13 @@
             "value" : "＋ボタンを押して、新しいフォルダを作成します。"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
         "lt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Naują aplanką sukursite paspaudę + mygtuką"
           }
         },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
         "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "no" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Create a new folder by pressing the + button"
@@ -1644,22 +582,10 @@
             "value" : "Utwórz nowy folder naciskając przycisk +"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Criar uma nova pasta pressionando o botão +"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
           }
         },
         "ru" : {
@@ -1668,55 +594,7 @@
             "value" : "Создайте новую папку кнопкой +"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Create a new folder by pressing the + button"
@@ -1728,28 +606,10 @@
             "value" : "+ Düğmesine basarak yeni bir klasör oluşturun"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Створити нову теку за допомогою кнопки +"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Create a new folder by pressing the + button"
           }
         },
         "zh-Hans" : {
@@ -1775,42 +635,6 @@
             "value" : "Move To"
           }
         },
-        "be" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "bg" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -1821,18 +645,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verschieben nach"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "el-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
           }
         },
         "en" : {
@@ -1853,18 +665,6 @@
             "value" : "Move To"
           }
         },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
         "fi" : {
           "stringUnit" : {
             "state" : "new",
@@ -1872,36 +672,6 @@
           }
         },
         "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "hr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "is" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Move To"
@@ -1919,61 +689,7 @@
             "value" : "Move To"
           }
         },
-        "ka" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "lb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
         "lt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "lv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "me" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "mk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "mt" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "my" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Move To"
@@ -1985,19 +701,7 @@
             "value" : "Move To"
           }
         },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
         "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "pt" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Move To"
@@ -2009,67 +713,13 @@
             "value" : "Mover para"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Переместить в…"
           }
         },
-        "si" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
         "sl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "sq" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "sr-CS" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "sr-Cyrl-ME" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "sr-SP" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "th" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Move To"
@@ -2081,25 +731,7 @@
             "value" : "Move To"
           }
         },
-        "tr-CY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
         "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Move To"
-          }
-        },
-        "vi" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Move To"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25636" title="WPB-25636" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25636</a>  [iOS] Localization crowdin script caused invalid testflight build
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fixing issue with locales, somehow the TrimStringCatalogs script has been skipped:

<img width="1319" height="419" alt="Screenshot 2026-05-13 at 11 48 46" src="https://github.com/user-attachments/assets/0a3782fa-b7cd-46db-968a-58bc2495dd03" />


```
Setting up git-lfs (3.4.1-1ubuntu0.4) ...
Hook already exists: pre-push

	#!/bin/sh
	command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
	git lfs pre-push "$@"

To resolve this, either:
  1: run `git lfs update --manual` for instructions on how to merge hooks.
  2: run `git lfs update --force` to overwrite your hook.
Updated Git hooks.
Warning: 1 uncommitted change
could not compute title or body defaults: could not find any commits between origin/develop and chore/update-localization
Error: Process completed with exit code 1.
```


**Error from AppStore:**
```
We noticed one or more issues with a recent delivery for the following app:

Although delivery was successful, you may want to correct the following issues in your next delivery. Once you've corrected the issues, upload a new binary to App Store Connect.

ITMS-90176: Unrecognized Locale - - The locale names used in localization directories at [Payload/Wire.app/Frameworks/WireDomain.framework/me.lproj, Payload/Wire.app/Frameworks/WireDomain.framework/sr-SP.lproj, Payload/Wire.app/WireUI_WireFolderPickerUI.bundle/me.lproj, Payload/Wire.app/WireUI_WireFolderPickerUI.bundle/sr-SP.lproj, Payload/Wire.app/WireUI_WireIndividualToTeamMigrationUI.bundle/me.lproj, Payload/Wire.app/WireUI_WireIndividualToTeamMigrationUI.bundle/sr-SP.lproj, Payload/Wire.app/WireUI_WireMainNavigationUI.bundle/me.lproj, Payload/Wire.app/WireUI_WireMainNavigationUI.bundle/sr-SP.lproj, Payload/Wire.app/WireUI_WireMoveToFolderUI.bundle/me.lproj, Payload/Wire.app/WireUI_WireMoveToFolderUI.bundle/sr-SP.lproj] are invalid. iTunes supports BCP47 but not the UN M.49 specification. Refer to the Language and Locale Designations guide at [https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html) for more information on naming your language-specific directories.
```

Solution: run TrimStringCatalogs script

### Testing

Build playground build and check if AppStore complain: https://github.com/wireapp/wire-ios/actions/runs/25791278776

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
