### PR TITLE
fix: ignore ExpiringActivityNotAllowedToRun error - WPB-25714

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -136,6 +136,9 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
                 }
             } catch is CancellationError {
                 // ignore error
+            } catch is ExpiringActivityNotAllowedToRun {
+                // ignore: the system denied or expired background time before
+                // sync could run. Sync resumes when the app returns to the foreground.
             } catch URLError.cancelled {
                 // ignore error, this is a result of cancelling the sync while a `URLSessionDataTask` is in progress,
                 // we treat it the same as a `CancellationError`

--- a/wire-ios-system/Source/ExpiringActivity.swift
+++ b/wire-ios-system/Source/ExpiringActivity.swift
@@ -46,10 +46,14 @@ public func withExpiringActivity(reason: String, block: @escaping () async throw
     try await manager.withExpiringActivity(reason: reason, block: block)
 }
 
+/// Single-use: one instance per activity. The only entry point is the
+/// `withExpiringActivity(reason:block:)` free function above, which creates a
+/// fresh manager every call. Members below are `private` to enforce this — the
+/// actor's idempotency tracking (`didStartWork`) is not designed to reset.
 actor ExpiringActivityManager {
 
     let api: any ExpiringActivityInterface
-    var task: Task<Void, any Error>?
+    private var task: Task<Void, any Error>?
     // Stored as actor state so resumeOnce() is serialised through the actor
     // executor — no lock required, no threads blocked.
     private var continuation: CheckedContinuation<Void, any Error>?
@@ -115,7 +119,10 @@ actor ExpiringActivityManager {
         continuation = nil
     }
 
-    func startWork(block: @escaping () async throws -> Void, semaphore: DispatchSemaphore) -> Task<Void, any Error> {
+    private func startWork(
+        block: @escaping () async throws -> Void,
+        semaphore: DispatchSemaphore
+    ) -> Task<Void, any Error> {
         didStartWork = true
         let task = Task {
             defer {
@@ -128,7 +135,7 @@ actor ExpiringActivityManager {
         return task
     }
 
-    func stopWork() throws {
+    private func stopWork() throws {
         if let task {
             task.cancel()
             self.task = nil

--- a/wire-ios-system/Source/ExpiringActivity.swift
+++ b/wire-ios-system/Source/ExpiringActivity.swift
@@ -53,6 +53,10 @@ actor ExpiringActivityManager {
     // Stored as actor state so resumeOnce() is serialised through the actor
     // executor — no lock required, no threads blocked.
     private var continuation: CheckedContinuation<Void, any Error>?
+    // Distinguishes "work was never started" from "work started then stopped".
+    // Without this, a second stopWork() (e.g. outer-task cancel followed by
+    // OS expiry) misreports the latter as ExpiringActivityNotAllowedToRun.
+    private var didStartWork = false
 
     init() {
         self.init(api: ProcessInfo.processInfo)
@@ -112,6 +116,7 @@ actor ExpiringActivityManager {
     }
 
     func startWork(block: @escaping () async throws -> Void, semaphore: DispatchSemaphore) -> Task<Void, any Error> {
+        didStartWork = true
         let task = Task {
             defer {
                 WireLogger.backgroundActivity.debug("Releasing semaphore")
@@ -124,8 +129,13 @@ actor ExpiringActivityManager {
     }
 
     func stopWork() throws {
-        guard let task else { throw ExpiringActivityNotAllowedToRun() }
-        task.cancel()
-        self.task = nil
+        if let task {
+            task.cancel()
+            self.task = nil
+            return
+        }
+        if !didStartWork {
+            throw ExpiringActivityNotAllowedToRun()
+        }
     }
 }

--- a/wire-ios-system/Tests/ExpiringActivityTests.swift
+++ b/wire-ios-system/Tests/ExpiringActivityTests.swift
@@ -110,19 +110,12 @@ class ExpiringActivityTests: XCTestCase {
         } catch {}
     }
 
-    // MARK: - Double-resume regression tests (crash: EXC_BREAKPOINT on CheckedContinuation.resume)
+    // MARK: - Regression tests for stop/expiry races
 
-    /// Regression test for the bug where outer-task cancellation and the expiry callback
-    /// both invoked `stopWork()`, and the second call threw `ExpiringActivityNotAllowedToRun`
-    /// because `self.task` had already been nilled by the first call:
-    ///   1. `onCancel` fires → `stopWork()` cancels the inner task, sets `self.task = nil`
-    ///   2. Inner task throws `CancellationError` → first resume
-    ///   3. `expiring = true` fires → `stopWork()` previously found `self.task == nil` and
-    ///      threw, which (before the double-resume fix) crashed on the second resume, and
-    ///      (after) racily surfaced as `ExpiringActivityNotAllowedToRun` to the caller.
-    /// After the idempotency fix, `stopWork()` distinguishes "never started" from "already
-    /// stopped" via `didStartWork`, so the second call is a no-op and the caller always
-    /// sees the inner task's `CancellationError`.
+    /// When outer-task cancellation and OS expiry both fire, `stopWork()` is
+    /// invoked twice. The caller must see the inner task's `CancellationError`
+    /// (not `ExpiringActivityNotAllowedToRun` from the late expiry), and the
+    /// continuation must not be resumed twice.
     func testCancellationErrorIsThrown_WhenExpiryFiresAfterOuterTaskCancellation() async throws {
         let api = MockExpiringActivityAPI()
         let sut = ExpiringActivityManager(api: api)
@@ -163,12 +156,11 @@ class ExpiringActivityTests: XCTestCase {
         }
     }
 
-    /// Regression test for the race where the expiry callback fires *before* the
-    /// `expiring = false` callback has had a chance to call `startWork` on the actor:
-    ///   1. `expiring = true` reaches the actor first → `stopWork()` finds `task == nil`,
-    ///      throws, and previously resumed the continuation with that error
-    ///   2. `expiring = false` then runs `startWork`, work completes, and previously
-    ///      tried to resume the continuation a second time → crash
+    /// When the expiry callback reaches the actor before `startWork` has run,
+    /// the subsequent successful completion of `startWork` must not resume the
+    /// continuation a second time. Both `ExpiringActivityNotAllowedToRun` and
+    /// `CancellationError` are valid outcomes of the race — the only failure
+    /// mode being guarded against here is a crash.
     func testNoCrash_WhenExpiryCallbackFiresBeforeWorkStarts() async throws {
         let api = MockExpiringActivityAPI()
         let sut = ExpiringActivityManager(api: api)

--- a/wire-ios-system/Tests/ExpiringActivityTests.swift
+++ b/wire-ios-system/Tests/ExpiringActivityTests.swift
@@ -112,13 +112,18 @@ class ExpiringActivityTests: XCTestCase {
 
     // MARK: - Double-resume regression tests (crash: EXC_BREAKPOINT on CheckedContinuation.resume)
 
-    /// Regression test for the crash where outer-task cancellation and the expiry callback
-    /// both tried to resume the continuation:
+    /// Regression test for the bug where outer-task cancellation and the expiry callback
+    /// both invoked `stopWork()`, and the second call threw `ExpiringActivityNotAllowedToRun`
+    /// because `self.task` had already been nilled by the first call:
     ///   1. `onCancel` fires → `stopWork()` cancels the inner task, sets `self.task = nil`
     ///   2. Inner task throws `CancellationError` → first resume
-    ///   3. `expiring = true` fires → `stopWork()` finds `self.task == nil`, throws,
-    ///      and previously tried to resume the continuation a second time → crash
-    func testNoCrash_WhenExpiryFires_AfterOuterTaskCancellation() async throws {
+    ///   3. `expiring = true` fires → `stopWork()` previously found `self.task == nil` and
+    ///      threw, which (before the double-resume fix) crashed on the second resume, and
+    ///      (after) racily surfaced as `ExpiringActivityNotAllowedToRun` to the caller.
+    /// After the idempotency fix, `stopWork()` distinguishes "never started" from "already
+    /// stopped" via `didStartWork`, so the second call is a no-op and the caller always
+    /// sees the inner task's `CancellationError`.
+    func testCancellationErrorIsThrown_WhenExpiryFiresAfterOuterTaskCancellation() async throws {
         let api = MockExpiringActivityAPI()
         let sut = ExpiringActivityManager(api: api)
 
@@ -148,8 +153,14 @@ class ExpiringActivityTests: XCTestCase {
         outerTask.cancel()
         await fulfillment(of: [expiryFired], timeout: 1)
 
-        // Must not crash (EXC_BREAKPOINT) regardless of which error is thrown.
-        do { try await outerTask.value } catch {}
+        do {
+            try await outerTask.value
+            XCTFail("Expected CancellationError to be thrown")
+        } catch is CancellationError {
+            // expected
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
     }
 
     /// Regression test for the race where the expiry callback fires *before* the


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25714" title="WPB-25714" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25714</a>  [iOS] Beta reports ExpiringActivityNotAllowedToRun errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

the stopWork() method of ExpiringActivityManager is called at two different points:
1. the task is cancelled via the cancel closure
2. in the expiring condition case when the activity is about to expire

This causes a race condition whichever runs first will cancel and nil the task
The second will raise and error ExpiringActivityNotAllowedToRun

**Solution:**

Differentiate the two cases and ignore the ExpiringActivityNotAllowedToRun error on sync 

### Testing

As it's a race condition difficult to know, it seems looking at the logs, it involves a call.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
