### PR TITLE
chore: bump AVS 10.3.23 - WPB-25715

### DIFF
--- a/WireAVS/Package.swift
+++ b/WireAVS/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WireAVS",
-            url: "https://github.com/wireapp/wire-avs/releases/download/10.3.19/avs.xcframework.zip",
-            checksum: "612893769856f7ab8f825ef165e0e57daf092a97b395b132b0b4e5f0b8624b08"
+            url: "https://github.com/wireapp/wire-avs/releases/download/10.3.23/avs.xcframework.zip",
+            checksum: "1b93474d2a7b2978674e145d41129c6eb346493b468182a43cb61298f9447f9c"
         )
     ]
 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25715" title="WPB-25715" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25715</a>  [AVS] Quality handler json code crashes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The new AVS version contains the fix of the AVS crash: [Fix quality handler connection hierarchy](https://github.com/wireapp/wire-avs/releases/tag/10.3.23)

### Testing


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
