### PR TITLE
fix: re-login on 4.16 branch - WPB-25092

### DIFF
--- a/wire-ios-transport/Source/Authentication/ZMPersistentCookieStorage.m
+++ b/wire-ios-transport/Source/Authentication/ZMPersistentCookieStorage.m
@@ -47,7 +47,6 @@ static dispatch_queue_t isolationQueue(void)
 
 @interface ZMPersistentCookieStorage ()
 
-@property (nonatomic, readonly) NSString *serverName;
 @property (nonatomic, readonly) NSArray<NSHTTPCookie *> *authenticationCookies;
 @property (nonatomic, readonly) BOOL useCache;
 
@@ -84,7 +83,9 @@ static dispatch_queue_t isolationQueue(void)
 {
     self = [super init];
     if (self) {
-        _serverName = [serverName copy];
+        // As a specific fix for https://wearezeta.atlassian.net/browse/WPB-25092 on 4.16 we just ignore `serverName`
+        // and don't change the API of `ZMPersistentCookieStorage` to have minimum impact on the codebase.
+        // In recent code `ZMPersistentCookieStorage` no longer exists.
         _userIdentifier = [userIdentifier copy];
         _useCache = useCache;
     }
@@ -136,11 +137,7 @@ static dispatch_queue_t isolationQueue(void)
 
 - (NSString *)cookieKey
 {
-    if (nil != self.accountName) {
-        return [[self.accountName stringByAppendingString:@"_"] stringByAppendingString:self.serverName];
-    } else {
-        return self.serverName; // Legacy and migration support
-    }
+    return self.accountName;
 }
 
 - (NSString *)accountName
@@ -419,48 +416,5 @@ static dispatch_queue_t isolationQueue(void)
         [request addValue:value forHTTPHeaderField:field];
     }];
 }
-
-@end
-
-#pragma mark – Legacy Storage Migration
-
-
-@interface ZMPersistentCookieStorageMigrator ()
-@property (nonatomic, readonly) NSUUID *userIdentifier;
-@property (nonatomic, readonly) NSString *serverName;
-@end
-
-@implementation ZMPersistentCookieStorageMigrator
-
-+ (instancetype)migratorWithUserIdentifier:(NSUUID *)userIdentifier serverName:(NSString *)serverName
-{
-    return [[self alloc] initWithUserIdentifier:userIdentifier serverName:serverName];
-}
-
-- (instancetype)initWithUserIdentifier:(NSUUID *)userIdentifier serverName:(NSString *)serverName
-{
-    self = [super init];
-    if (self) {
-        _userIdentifier = userIdentifier;
-        _serverName = serverName;
-    }
-    return self;
-}
-
-- (ZMPersistentCookieStorage *)createStoreMigratingLegacyStoreIfNeeded
-{
-    ZMPersistentCookieStorage *oldStorage = [ZMPersistentCookieStorage storageForServerName:self.serverName userIdentifier:(NSUUID *_Nonnull)nil useCache:YES];
-    ZMPersistentCookieStorage *newStorage = [ZMPersistentCookieStorage storageForServerName:self.serverName userIdentifier:self.userIdentifier useCache:YES];
-    NSData *cookieData = oldStorage.authenticationCookieData;
-
-    if (nil != cookieData) {
-        // Migrate cookie data to the new storage
-        newStorage.authenticationCookieData = oldStorage.authenticationCookieData;
-        [oldStorage deleteKeychainItems];
-    }
-
-    return newStorage;
-}
-
 
 @end

--- a/wire-ios-transport/Tests/Source/Authentication/ZMPersistentCookieStorageTests.m
+++ b/wire-ios-transport/Tests/Source/Authentication/ZMPersistentCookieStorageTests.m
@@ -83,24 +83,6 @@
     XCTAssertEqualObjects(self.sut.authenticationCookieData, data2);
 }
 
-- (void)testThatItIsUniqueForServerName;
-{
-    ZMPersistentCookieStorage *sut1 = self.sut;
-    ZMPersistentCookieStorage *sut2 = [ZMPersistentCookieStorage storageForServerName:@"2.example.com" userIdentifier:self.userIdentifier useCache:YES];
-
-    XCTAssertNil([sut1 authenticationCookieData]);
-    XCTAssertNil([sut2 authenticationCookieData]);
-    
-    NSData *data1 = [NSData dataWithBytes:(char []){'a'} length:1];
-    [sut1 setAuthenticationCookieData:data1];
-    NSData *data2 = [NSData dataWithBytes:(char []){'b'} length:1];
-    [sut2 setAuthenticationCookieData:data2];
-    
-    XCTAssertEqualObjects([sut1 authenticationCookieData], data1);
-    XCTAssertEqualObjects([sut2 authenticationCookieData], data2);
-    [sut2 deleteKeychainItems];
-}
-
 - (void)testThatItCanDeleteCookies;
 {
     XCTAssertNil(self.sut.authenticationCookieData);
@@ -201,62 +183,6 @@
     // then
     XCTAssertNil(sut1.authenticationCookieData);
     XCTAssertNil(sut2.authenticationCookieData);
-}
-
-- (void)testThatItMigratesAnDeletesOldCookieData
-{
-    // given
-    NSUUID *otherUserIdentifier = NSUUID.createUUID;
-    NSString *serverName = @"z1.example.com";
-    ZMPersistentCookieStorage *legacySut = [ZMPersistentCookieStorage storageForServerName:serverName userIdentifier:(NSUUID *_Nonnull)nil useCache:YES];
-    ZMPersistentCookieStorage *sut2 = [ZMPersistentCookieStorage storageForServerName:serverName userIdentifier:otherUserIdentifier useCache:YES];
-
-    NSData *data1 = [@"This is the first cookie data" dataUsingEncoding:NSUTF8StringEncoding];
-    NSData *data2 = [@"This is the second cookie data" dataUsingEncoding:NSUTF8StringEncoding];
-    [legacySut setAuthenticationCookieData:data1];
-    XCTAssertNotNil(legacySut.authenticationCookieData);
-    [sut2 setAuthenticationCookieData:data2];
-    XCTAssertNotNil(sut2.authenticationCookieData);
-
-    // when
-    ZMPersistentCookieStorageMigrator *migrator = [ZMPersistentCookieStorageMigrator migratorWithUserIdentifier:self.userIdentifier serverName:serverName];
-    ZMPersistentCookieStorage *sut1 = [migrator createStoreMigratingLegacyStoreIfNeeded];
-
-    // then
-    XCTAssertNil(legacySut.authenticationCookieData);
-    XCTAssertEqualObjects(sut1.authenticationCookieData, data1);
-    XCTAssertEqualObjects(sut2.authenticationCookieData, data2);
-}
-
-- (void)testThatItDoesNotMigrateIfThereIsNoOldCookieData
-{
-    // given
-    NSString *serverName = @"z1.example.com";
-    NSUUID *otherUserIdentifier = NSUUID.createUUID;
-    ZMPersistentCookieStorage *sut2 = [ZMPersistentCookieStorage storageForServerName:serverName userIdentifier:otherUserIdentifier useCache:YES];
-    ZMPersistentCookieStorage *legacySut = [ZMPersistentCookieStorage storageForServerName:serverName userIdentifier:(NSUUID *_Nonnull)nil useCache:YES];
-    NSData *data1 = [@"This is the first cookie data" dataUsingEncoding:NSUTF8StringEncoding];
-    NSData *data2 = [@"This is the second cookie data" dataUsingEncoding:NSUTF8StringEncoding];
-
-    {
-        ZMPersistentCookieStorage *sut1 = [ZMPersistentCookieStorage storageForServerName:serverName userIdentifier:self.userIdentifier useCache:YES];
-        [sut1 setAuthenticationCookieData:data1];
-        [sut2 setAuthenticationCookieData:data2];
-        XCTAssertNil(legacySut.authenticationCookieData);
-        XCTAssertEqualObjects(sut1.authenticationCookieData, data1);
-        XCTAssertEqualObjects(sut2.authenticationCookieData, data2);
-    }
-
-    {
-        // when
-        ZMPersistentCookieStorageMigrator *migrator = [ZMPersistentCookieStorageMigrator migratorWithUserIdentifier:self.userIdentifier serverName:serverName];
-        ZMPersistentCookieStorage *sut1 = [migrator createStoreMigratingLegacyStoreIfNeeded];
-
-        // then
-        XCTAssertNil(legacySut.authenticationCookieData);
-        XCTAssertEqualObjects(sut1.authenticationCookieData, data1);
-        XCTAssertEqualObjects(sut2.authenticationCookieData, data2);
-    }
 }
 
 - (void)testThatItHasAccessibleAuthenticationCookieData_WhenAuthenticationCookieDataIsAvailable


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25092" title="WPB-25092" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25092</a>  [iOS] Re-login with E2EI throws something went wrong on verification code and shows infinite loader
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes re-login on 4.16 branch. This was also fixed in https://github.com/wireapp/wire-ios/pull/4596 but rather that cherry picking that significant change, I have done a minimal fix here.

While investigating I realized the underlying cause for this bug was different than I originally thought. This PR fixes the symptoms but doesn't attempt to fix the underlying cause (see https://wearezeta.atlassian.net/browse/WPB-25846) which still requires investigation and is not safe for the scope of 4.16.

The reason for this bug is that a cached cookie is not being deleted. Currently `ZMPersistentCookieStorage` caches cookies using a key that includes the backend server but when instantiating a `ZMPersistentCookieStorage` instance during the logout process we pass in an incorrect backend server URL so the cookie is not deleted.

The workaround is to stop using the server as part of the cache key. Within keychain we don't use the server for the key so it really makes no sense using it for the cached cookie as the account is already very very very likely to be unique.

In this PR I kept changes to a minimum so didn't change the API of `ZMPersistentCookieStorage` even though backend server is no longer used.

### Testing

See ticket.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
