### PR TITLE
fix: load more button/indicator - WPB-25812

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Common/IncrementalListStateController.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Common/IncrementalListStateController.swift
@@ -56,7 +56,7 @@ class IncrementalListStateController<Item: Identifiable & Hashable & Sendable>: 
     @Published var state: State = .pending
     @Published var hasMore = true
 
-    private var loadTask: LoadTask?
+    @Published private var loadTask: LoadTask?
 
     var onFetch: ((Int) async throws -> ItemsData)?
     var onError: ((any Error) -> Void)?


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25812" title="WPB-25812" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25812</a>  [iOS] Replace "load more" button with loading indicator
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

After the refactoring of the FilesViewModel, the "Load More" button is wrongly showing the "load more" text in its non-loading state.

This PR fixes it by making this button appear as a loading spinner again.

The reason why it didn't show as a loading spinner was because the `loadTask` was missing a `@Published` annotation and therefore wasn't triggering the object-changed notification to promote the changes on the `isLoading` variable.

### Testing

* go to a files list with many file items
* scroll down to trigger the loading of the next page
* check if you are seeing the loading spinner