### PR TITLE
fix: slow transition with EAR enabled - WPB-24775

### DIFF
--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -425,6 +425,18 @@ extension AppRootRouter: AppStateCalculatorDelegate {
         userSession: UserSession,
         completion: @escaping () -> Void
     ) {
+        // Re-use the existing router when transitioning back from `.locked` (EAR unlock),
+        // so the current zClientViewController and its navigation focus are preserved.
+        if let existingRouter = authenticatedRouter {
+            let existingZClient = existingRouter.zClientViewController
+            if mainWindow.rootViewController === existingZClient {
+                completion()
+            } else {
+                replaceRootViewController(by: existingZClient, completion: completion)
+            }
+            return
+        }
+
         guard let authenticatedRouter = buildAuthenticatedRouter(
             account: userSession.contextProvider.account,
             userSession: userSession,
@@ -532,7 +544,9 @@ extension AppRootRouter {
 
     private func resetAuthenticatedRouterIfNeeded(for appState: AppState) {
         switch appState {
-        case .authenticated: break
+        // Keep the router alive across `.locked` so unlocking restores the
+        // existing zClientViewController instead of rebuilding the whole UI.
+        case .authenticated, .locked: break
         default:
             authenticatedRouter = nil
         }

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -526,6 +526,13 @@ extension AppRootRouter {
             presentAlertForDeletedAccountIfNeeded(error)
             sessionManager.processPendingURLActionDoesNotRequireAuthentication()
         case .authenticated:
+            // Hide the screen curtain proactively: by the time we reach this point
+            // the rootViewController is the unlocked content, so waiting for
+            // `UIApplication.didBecomeActiveNotification` (which can lag behind the
+            // EAR unlock by an entire sync cycle) just keeps the curtain visible
+            // longer than needed. `applicationWillResignActive` will re-show it if
+            // the app resigns active later.
+            screenCurtainWindow.isHidden = true
             // This is needed to display an ongoing call when coming from the background.
             authenticatedRouter?.updateActiveCallPresentationState()
             urlActionRouter.authenticatedRouter = authenticatedRouter

--- a/wire-ios/Wire-iOS/Sources/AuthenticatedRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AuthenticatedRouter.swift
@@ -52,7 +52,7 @@ final class AuthenticatedRouter {
 
     // MARK: - Public Property
 
-    private weak var _zClientViewController: ZClientViewController?
+    private var _zClientViewController: ZClientViewController?
 
     @MainActor var zClientViewController: ZClientViewController {
         let zClientViewController = _zClientViewController ?? zClientControllerBuilder(router: self)


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

When EAR is enabled, and the app is in a conversation, going to background and back to foreground will present the applock. The issue is that the full UI is replaced, focus is lost and takes significant time compared to 3.120 version.

Solution:

Replaced the zClientViewController only if required


### Testing

1. enable EAR
2. go to a conversation
3. Put app in background 
4. resume app
conversation should show

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
