### PR TITLE
fix: crowdin action if trim results in no changes - WPB-25908

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -58,20 +58,16 @@ jobs:
           xargs swift run --package-path ./scripts TrimStringCatalogs < string-catalogs.txt
           xargs git add < string-catalogs.txt
 
-          # abort if there are no changes after trimming
-          if git diff --quiet && git diff --cached --quiet; then
-          echo "No changes to commit."
-          exit 0
-          fi
-
           # commit and push the changes
-          git commit --no-verify -m "chore: trim string catalogs"
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            git commit --no-verify -m "chore: trim string catalogs"
+          fi
           git push --no-verify origin "$HEAD_BRANCH"
 
           # abort if there no changes to be merged
           if git diff --quiet "origin/$BASE_BRANCH"; then
-          echo "No changes compared to the base branch, aborting."
-          exit 0
+            echo "No changes compared to the base branch, aborting."
+            exit 0
           fi
 
           # abort if the pr already exists
@@ -79,12 +75,12 @@ jobs:
           git lfs install || git lfs update --force
           PR_EXISTS=$(gh pr list --base "$BASE_BRANCH" --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number')
           if [ -n "$PR_EXISTS" ]; then
-          echo "A PR already exists, aborting."
-          exit 0
+            echo "A PR already exists, aborting."
+            exit 0
           fi
 
           gh pr create --fill \
-          --base "$BASE_BRANCH" \
-          --head "$HEAD_BRANCH" \
-          --title "$TITLE" \
-          --body "$BODY" \
+            --base "$BASE_BRANCH" \
+            --head "$HEAD_BRANCH" \
+            --title "$TITLE" \
+            --body "$BODY" \


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25908" title="WPB-25908" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25908</a>  [iOS] Fix string sync with Crowding
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The crowdin action performs a trimming step and aborts if trimming does not result in any changes.
Instead only committing should be skipped.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
