### PR TITLE
fix: some tests race conditoon for audio files - WPB-25778

### DIFF
--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -342,6 +342,8 @@ class ActiveConversationPage: PageModel {
             recordingTimeLabel.waitForExistence(timeout: 2),
             "Audio recording not started"
         )
+        // Allow minimum recording duration to avoid 0 second audio clips due to quick execution
+        sleep(1)
 
         if stopRecording.waitForExistence(timeout: 2), stopRecording.isHittable {
             stopRecording.tap()

--- a/wire-ios/WireUITests/Pages/FolderPage.swift
+++ b/wire-ios/WireUITests/Pages/FolderPage.swift
@@ -39,16 +39,11 @@ final class FolderPage: PageModel {
             .firstMatch
     }
 
-    func waitForPageToDisappear() {
-        XCTAssertFalse(pageMainElement.waitForExistence(timeout: 3))
-    }
-
-    func enterFolderNameAndValidate(name: String = "Test") -> String {
+    func enterFolderNameAndValidate(name: String) throws -> SharedDriveFilesPage {
         folderNameInputField.tap()
         folderNameInputField.typeText(name)
         createFolderButton.tap()
-        waitForPageToDisappear()
-        return name
+        return try SharedDriveFilesPage()
     }
 
 }

--- a/wire-ios/WireUITests/WireDriveTests.swift
+++ b/wire-ios/WireUITests/WireDriveTests.swift
@@ -266,13 +266,12 @@ final class WireDriveTests: WireUITestCase {
 
         // WHEN
         let activeConversationPage = try loginAndOpenConversation(for: teamOwner)
+
+        let folderName = "Test"
         let sharedDrivePage = try activeConversationPage
             .openSharedDrive()
-
-        let createFolderPage = try sharedDrivePage
             .createFolder()
-
-        let folderName = createFolderPage.enterFolderNameAndValidate()
+            .enterFolderNameAndValidate(name: folderName)
 
         // THEN
         XCTAssertTrue(sharedDrivePage.verifyFolderIsCreated(folderName: folderName))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25778" title="WPB-25778" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25778</a>  [iOS] Critical flow flakiness fixes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…action performed

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Issues:
- Failing to send audio file because it tries to send for a 0.00 second audio which doesn't being sent.
- Corrected a test flow for testCreatingFolder_TC_8961, fails randomly

### Testing

locally ran fine.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
