### PR TITLE
fix: crowdin action follow-up - WPB-25908

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -49,12 +49,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SUBMODULE_PAT }}
         run: |
           set -xEeuo pipefail
+
           BASE_BRANCH=${GITHUB_REF#refs/heads/}
           HEAD_BRANCH="chore/update-localization"
           TITLE="chore: Update localization - WPB-15278"
           BODY="This PR pulls in the latest localization translations from Crowdin."
 
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          # The crowdin action restores the original checkout (develop) after pushing
+          # translations to $HEAD_BRANCH, so switch to it before trimming and diffing.
+          git checkout "$HEAD_BRANCH"
 
           find . -name "*.xcstrings" | tee string-catalogs.txt
           xargs swift run --package-path ./scripts TrimStringCatalogs < string-catalogs.txt


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25908" title="WPB-25908" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25908</a>  [iOS] Fix string sync with Crowding
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Following-up to these PRs
- https://github.com/wireapp/wire-ios/pull/4763 and
- https://github.com/wireapp/wire-ios/pull/4764
since the issue wasn't fixed.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
