### PR TITLE
fix: missing German translations in debug actions - WPB-24866

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -6133,6 +6133,41 @@ internal enum L10n {
       /// I’m on Wire. Visit get.wire.com to connect with me.
       internal static let text = L10n.tr("Localizable", "send_invitation_no_email.text", fallback: "I’m on Wire. Visit get.wire.com to connect with me.")
     }
+    internal enum Settings {
+      internal enum DebuggingTools {
+        internal enum DebugCommand {
+          /// Command not recognized
+          internal static let commandNotRecognized = L10n.tr("Localizable", "settings.debugging_tools.debug_command.command_not_recognized", fallback: "Command not recognized")
+          /// Debug command
+          internal static let title = L10n.tr("Localizable", "settings.debugging_tools.debug_command.title", fallback: "Debug command")
+        }
+        internal enum RepairMlsRemovalKeys {
+          /// Error: %@
+          internal static func failureMessage(_ p1: Any) -> String {
+            return L10n.tr("Localizable", "settings.debugging_tools.repair_mls_removal_keys.failure_message", String(describing: p1), fallback: "Error: %@")
+          }
+          /// Repair Failed
+          internal static let failureTitle = L10n.tr("Localizable", "settings.debugging_tools.repair_mls_removal_keys.failure_title", fallback: "Repair Failed")
+          /// Found: %d faulty conversation(s)
+          /// Repaired: %d conversation(s)
+          internal static func successMessage(_ p1: Int, _ p2: Int) -> String {
+            return L10n.tr("Localizable", "settings.debugging_tools.repair_mls_removal_keys.success_message", p1, p2, fallback: "Found: %d faulty conversation(s)\nRepaired: %d conversation(s)")
+          }
+          /// Faulty MLS Removal Keys Repair
+          internal static let successTitle = L10n.tr("Localizable", "settings.debugging_tools.repair_mls_removal_keys.success_title", fallback: "Faulty MLS Removal Keys Repair")
+          /// Error: Repair use case not available
+          internal static let useCaseUnavailable = L10n.tr("Localizable", "settings.debugging_tools.repair_mls_removal_keys.use_case_unavailable", fallback: "Error: Repair use case not available")
+        }
+        internal enum UnreadConversations {
+          /// Copy
+          internal static let actionCopy = L10n.tr("Localizable", "settings.debugging_tools.unread_conversations.action_copy", fallback: "Copy")
+          /// Found an unread conversation:
+          internal static let found = L10n.tr("Localizable", "settings.debugging_tools.unread_conversations.found", fallback: "Found an unread conversation:")
+          /// No unread conversation
+          internal static let notFound = L10n.tr("Localizable", "settings.debugging_tools.unread_conversations.not_found", fallback: "No unread conversation")
+        }
+      }
+    }
     internal enum ShareExtension {
       internal enum Voiceover {
         /// All clients verified.

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -1440,6 +1440,20 @@
 "self.settings.technical_report.mail_body.section1" = "Date and Time of the issue occured:";
 "self.settings.technical_report.mail_body.section2" = "What Happened:";
 "self.settings.technical_report.mail_body.section3" = "Steps to reproduce (if relevant):";
+
+// Settings - DebugTools
+
+"settings.debugging_tools.unread_conversations.not_found" = "No unread conversation";
+"settings.debugging_tools.unread_conversations.found" = "Found an unread conversation:";
+"settings.debugging_tools.unread_conversations.action_copy" = "Copy";
+"settings.debugging_tools.debug_command.title" = "Debug command";
+"settings.debugging_tools.debug_command.command_not_recognized" = "Command not recognized";
+"settings.debugging_tools.repair_mls_removal_keys.use_case_unavailable" = "Error: Repair use case not available";
+"settings.debugging_tools.repair_mls_removal_keys.success_title" = "Faulty MLS Removal Keys Repair";
+"settings.debugging_tools.repair_mls_removal_keys.success_message" = "Found: %d faulty conversation(s)\nRepaired: %d conversation(s)";
+"settings.debugging_tools.repair_mls_removal_keys.failure_title" = "Repair Failed";
+"settings.debugging_tools.repair_mls_removal_keys.failure_message" = "Error: %@";
+
 // Password reset
 "self.settings.password_reset_menu.title" = "Reset Password";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
@@ -1440,6 +1440,20 @@
 "self.settings.technical_report.mail_body.section1" = "Datum und Zeit, zu der das Problem auftrat";
 "self.settings.technical_report.mail_body.section2" = "Was passiert ist:";
 "self.settings.technical_report.mail_body.section3" = "Schritte zum Nachstellen des Problems (falls relevant):";
+
+// Settings - DebugTools
+
+"settings.debugging_tools.unread_conversations.not_found" = "Keine ungelesene Unterhaltung";
+"settings.debugging_tools.unread_conversations.found" = "Ungelesene Unterhaltung gefunden:";
+"settings.debugging_tools.unread_conversations.action_copy" = "Kopieren";
+"settings.debugging_tools.debug_command.title" = "Befehl zur Fehlerbehebung";
+"settings.debugging_tools.debug_command.command_not_recognized" = "Befehl nicht erkannt";
+"settings.debugging_tools.repair_mls_removal_keys.use_case_unavailable" = "Fehler: Anwendungsfall Reparatur nicht verfügbar";
+"settings.debugging_tools.repair_mls_removal_keys.success_title" = "Fehlerhaftes MLS Entfernen der Schlüssel Reparatur";
+"settings.debugging_tools.repair_mls_removal_keys.success_message" = "Gefunden: %d fehlerhaft(e) Unterhaltung(en)\nRepariert: %d Unterhaltung(en)";
+"settings.debugging_tools.repair_mls_removal_keys.failure_title" = "Reparatur fehlgeschlagen";
+"settings.debugging_tools.repair_mls_removal_keys.failure_message" = "Fehler: %@";
+
 // Password reset
 "self.settings.password_reset_menu.title" = "Passwort zurücksetzen";
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
@@ -26,16 +26,17 @@ enum DebugActions {
     static func alert(
         _ message: String,
         title: String = "",
-        textToCopy: String? = nil
+        textToCopy: String? = nil,
+        copyActionTitle: String = "Copy"
     ) {
         guard let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) else { return }
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         if let textToCopy {
-            alert.addAction(UIAlertAction(title: "Copy", style: .default) { _ in
+            alert.addAction(UIAlertAction(title: copyActionTitle, style: .default) { _ in
                 UIPasteboard.general.string = textToCopy
             })
         }
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        alert.addAction(UIAlertAction(title: L10n.Localizable.General.ok, style: .default, handler: nil))
         controller.present(alert, animated: false)
     }
 
@@ -48,17 +49,18 @@ enum DebugActions {
         let fetchRequest = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
         let allConversations = uiMOC.fetchOrAssert(request: fetchRequest)
 
+        let unreadStrings = L10n.Localizable.Settings.DebuggingTools.UnreadConversations.self
         if let convo = allConversations.first(where: { predicate.evaluate(with: $0) }) {
 
             let message = [
-                "Found an unread conversation:",
+                unreadStrings.found,
                 "\(String(describing: convo.displayName))",
                 "<\(convo.remoteIdentifier?.uuidString ?? "n/a")>"
             ].joined(separator: "\n")
             let textToCopy = convo.remoteIdentifier?.uuidString
-            alert(message, textToCopy: textToCopy)
+            alert(message, textToCopy: textToCopy, copyActionTitle: unreadStrings.actionCopy)
         } else {
-            alert("No unread conversation")
+            alert(unreadStrings.notFound)
         }
     }
 
@@ -80,18 +82,19 @@ enum DebugActions {
         guard let userSession = ZMUserSession.shared() else { return }
         let predicate = ZMConversation.predicateForConversationConsideredUnreadExcludingSilenced()
 
+        let unreadStrings = L10n.Localizable.Settings.DebuggingTools.UnreadConversations.self
         if let convo = ConversationList.conversations(inUserSession: userSession).items
             .first(where: predicate.evaluate) {
             let message = [
-                "Found an unread conversation:",
+                unreadStrings.found,
                 "\(String(describing: convo.displayName))",
                 "<\(convo.remoteIdentifier?.uuidString ?? "n/a")>"
             ].joined(separator: "\n")
             let textToCopy = convo.remoteIdentifier?.uuidString
-            alert(message, textToCopy: textToCopy)
+            alert(message, textToCopy: textToCopy, copyActionTitle: unreadStrings.actionCopy)
 
         } else {
-            alert("No unread conversation")
+            alert(unreadStrings.notFound)
         }
     }
 
@@ -234,9 +237,10 @@ enum DebugActions {
 
     /// Accepts a debug command
     static func enterDebugCommand(_ type: any SettingsCellDescriptorType) {
-        askString(title: "Debug command") { string in
+        let debugCommandStrings = L10n.Localizable.Settings.DebuggingTools.DebugCommand.self
+        askString(title: debugCommandStrings.title) { string in
             guard let command = DebugCommand(string: string) else {
-                alert("Command not recognized")
+                alert(debugCommandStrings.commandNotRecognized)
                 return
             }
 
@@ -278,13 +282,9 @@ enum DebugActions {
     }
 
     static func repairFaultyMLSRemovalKeys() {
-        guard let userSession = ZMUserSession.shared() else {
-            alert("Error: No user session available")
-            return
-        }
-
-        guard let useCase = userSession.clientSessionComponent?.repairFaultyRemovalKeysUsecase else {
-            alert("Error: Repair use case not available")
+        let strings = L10n.Localizable.Settings.DebuggingTools.RepairMlsRemovalKeys.self
+        guard let useCase = ZMUserSession.shared().clientSessionComponent?.repairFaultyRemovalKeysUsecase else {
+            alert(strings.useCaseUnavailable)
             return
         }
 
@@ -292,15 +292,12 @@ enum DebugActions {
             do {
                 let result = try await useCase.invoke()
                 await MainActor.run {
-                    let message = """
-                    Found: \(result.faultyConversationsFound) faulty conversation(s)
-                    Repaired: \(result.conversationsRepaired) conversation(s)
-                    """
-                    alert(message, title: "Faulty MLS Removal Keys Repair")
+                    let message = strings.successMessage(result.faultyConversationsFound, result.conversationsRepaired)
+                    alert(message, title: strings.successTitle)
                 }
             } catch {
                 await MainActor.run {
-                    alert("Error: \(error.localizedDescription)", title: "Repair Failed")
+                    alert(strings.failureMessage(error.localizedDescription), title: strings.failureTitle)
                 }
             }
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
@@ -18,8 +18,8 @@
 
 import GenericMessageProtocol
 import UIKit
-import WireSyncEngine
 import WireCommonComponents
+import WireSyncEngine
 
 enum DebugActions {
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
@@ -284,7 +284,7 @@ enum DebugActions {
 
     static func repairFaultyMLSRemovalKeys() {
         let strings = L10n.Localizable.Settings.DebuggingTools.RepairMlsRemovalKeys.self
-        guard let useCase = ZMUserSession.shared().clientSessionComponent?.repairFaultyRemovalKeysUsecase else {
+        guard let useCase = ZMUserSession.shared()?.clientSessionComponent?.repairFaultyRemovalKeysUsecase else {
             alert(strings.useCaseUnavailable)
             return
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
@@ -19,6 +19,7 @@
 import GenericMessageProtocol
 import UIKit
 import WireSyncEngine
+import WireCommonComponents
 
 enum DebugActions {
 
@@ -31,7 +32,7 @@ enum DebugActions {
     ) {
         guard let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) else { return }
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        if let textToCopy {
+        if let textToCopy, SecurityFlags.clipboard.isEnabled {
             alert.addAction(UIAlertAction(title: copyActionTitle, style: .default) { _ in
                 UIPasteboard.general.string = textToCopy
             })


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24866" title="WPB-24866" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24866</a>  [iOS] [Troubleshooting] Missing German translation is displayed when opening troubleshooting tools by user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR ports fixes from develop + German translations:
- see https://github.com/wireapp/wire-ios/pull/4701

It also respect the SecurityFlags CLIPBOARD_ENABLED and removes copy option in alert

### Testing

1. run device in german and use debug actions

<img width="1080" height="2340" alt="Simulator Screenshot - iPhone 13 mini - 2026-05-28 at 14 36 31" src="https://github.com/user-attachments/assets/725cb55a-0094-4d79-a633-0ffef4e33c92" />

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
