### PR TITLE
fix: App cannot be started by user - WPB-24848

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
@@ -251,7 +251,7 @@ final class NSEUserScope: Component<NSEUserScopeDependency> {
             api: api
         )
 
-        return await useCase.invoke()
+        return await useCase.invoke().isBuildBlacklisted
     }
 
     // TODO: [WPB-19777] deduplicate

--- a/WireDomain/Sources/WireDomain/Synchronization/CheckBlacklistWorker.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/CheckBlacklistWorker.swift
@@ -1,0 +1,134 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Combine
+import Foundation
+import Network
+import UIKit
+import WireNetwork
+
+public actor CheckBlacklistWorker {
+
+    private static let checkInterval: TimeInterval = .oneHour * 6
+
+    private let useCase: any IsBuildBlacklistedUseCase
+    private let trigger: AsyncStream<Void>
+    private let onIsBuildBlacklisted: @Sendable () -> Void
+
+    private var triggerTask: Task<Void, Never>?
+    private var isChecking = false
+    private var lastSuccess: Date?
+
+    public init(
+        isBuildBlacklistedUseCase: any IsBuildBlacklistedUseCase,
+        onIsBuildBlacklisted: @escaping @Sendable () -> Void
+    ) {
+        self.init(
+            isBuildBlacklistedUseCase: isBuildBlacklistedUseCase,
+            trigger: CheckBlacklistWorker.makeTrigger(),
+            onIsBuildBlacklisted: onIsBuildBlacklisted
+        )
+    }
+
+    deinit {
+        triggerTask?.cancel()
+    }
+
+    public nonisolated func start() {
+        Task { await self.startAndWait() }
+    }
+
+    // MARK: - Private
+
+    init(
+        isBuildBlacklistedUseCase: any IsBuildBlacklistedUseCase,
+        trigger: AsyncStream<Void> = CheckBlacklistWorker.makeTrigger(),
+        onIsBuildBlacklisted: @escaping @Sendable () -> Void
+    ) {
+        self.useCase = isBuildBlacklistedUseCase
+        self.trigger = trigger
+        self.onIsBuildBlacklisted = onIsBuildBlacklisted
+    }
+
+    func startAndWait() async {
+        guard triggerTask == nil else { return }
+
+        triggerTask = Task {
+            for await _ in trigger {
+                await self.performCheckIfNeeded()
+            }
+        }
+        await triggerTask?.value
+    }
+
+    private func isStale() -> Bool {
+        guard let lastSuccess else { return true }
+        return lastSuccess.addingTimeInterval(Self.checkInterval) < Date()
+    }
+
+    private func performCheckIfNeeded() async {
+        guard isStale(), !isChecking else { return }
+
+        isChecking = true
+        let (isBuildBlacklisted, error) = await useCase.invoke()
+        isChecking = false
+
+        if error == nil {
+            lastSuccess = Date()
+        }
+
+        if isBuildBlacklisted {
+            onIsBuildBlacklisted()
+        }
+    }
+
+    // MARK: - Trigger
+
+    static func makeTrigger() -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            continuation.yield()
+
+            let isOnlineTrigger = Task {
+                let monitor = NWPathMonitor()
+                for await path in monitor where path.status == .satisfied {
+                    continuation.yield()
+                }
+            }
+
+            let intervalTrigger = Task {
+                while true {
+                    try await Task.sleep(for: .seconds(60 * 30)) // 30 min
+                    continuation.yield()
+                }
+            }
+
+            let willEnterForegroundTrigger = Task {
+                let notificationCenter = NotificationCenter.default
+                for await _ in notificationCenter.notifications(named: UIApplication.willEnterForegroundNotification) {
+                    continuation.yield()
+                }
+            }
+
+            continuation.onTermination = { _ in
+                isOnlineTrigger.cancel()
+                intervalTrigger.cancel()
+                willEnterForegroundTrigger.cancel()
+            }
+        }
+    }
+}

--- a/WireDomain/Sources/WireDomain/Synchronization/CheckBlacklistWorker.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/CheckBlacklistWorker.swift
@@ -103,9 +103,17 @@ public actor CheckBlacklistWorker {
         AsyncStream { continuation in
             continuation.yield()
 
+            // Differs from the cherry-picked commit: this branch targets iOS 16.4,
+            // where NWPathMonitor's AsyncSequence conformance is unavailable (iOS 17+),
+            // so we bridge pathUpdateHandler into an AsyncStream instead.
             let isOnlineTrigger = Task {
                 let monitor = NWPathMonitor()
-                for await path in monitor where path.status == .satisfied {
+                let pathStream = AsyncStream<NWPath> { pathContinuation in
+                    monitor.pathUpdateHandler = { pathContinuation.yield($0) }
+                    pathContinuation.onTermination = { _ in monitor.cancel() }
+                    monitor.start(queue: DispatchQueue(label: "CheckBlacklistWorker.NWPathMonitor"))
+                }
+                for await path in pathStream where path.status == .satisfied {
                     continuation.yield()
                 }
             }

--- a/WireDomain/Sources/WireDomain/UseCases/IsBuildBlacklistedUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/IsBuildBlacklistedUseCase.swift
@@ -18,11 +18,12 @@
 
 import Foundation
 import WireFoundation
-import WireNetwork
+@preconcurrency import WireNetwork
 
-public protocol IsBuildBlacklistedUseCase {
+// sourcery: AutoMockable
+public protocol IsBuildBlacklistedUseCase: Sendable {
 
-    func invoke() async -> Bool
+    func invoke() async -> (isBuildBlacklisted: Bool, error: Error?)
 
 }
 
@@ -41,11 +42,15 @@ public struct IsBuildBlacklistedUseCaseImpl: IsBuildBlacklistedUseCase {
         currentBuildNumber: String,
         api: any BlacklistAPI
     ) {
+        #if DEBUG
+            let currentBuildNumber = UITestConfig.environment.isBuildBlacklisted ? "0" : currentBuildNumber
+        #endif
+
         self.currentBuildNumber = DeveloperOverrides.buildNumber ?? currentBuildNumber
         self.api = api
     }
 
-    public func invoke() async -> Bool {
+    public func invoke() async -> (isBuildBlacklisted: Bool, error: Error?) {
         do {
             let blacklist = try await api.getBlacklist()
 
@@ -53,15 +58,17 @@ public struct IsBuildBlacklistedUseCaseImpl: IsBuildBlacklistedUseCase {
                 let currentVersion = Int(currentBuildNumber),
                 let minLegalVersion = Int(blacklist.minimumLegalBuildNumber)
             else {
-                return false
+                return (false, nil)
             }
 
-            return currentVersion < minLegalVersion || blacklist.illegalBuildNumbers.contains(String(currentVersion))
+            let isBlacklisted = currentVersion < minLegalVersion
+                || blacklist.illegalBuildNumbers.contains(String(currentVersion))
+            return (isBlacklisted, nil)
         } catch {
             // As per specs, if there is any failure obtaining the blacklist,
             // whether it is missing, can't be decoded, or otherwise, then
             // consider it empty (i.e all clients valid).
-            return false
+            return (false, error)
         }
     }
 

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -2625,6 +2625,33 @@ public class MockInitiateResetMLSConversationUseCaseProtocol: InitiateResetMLSCo
 
 }
 
+public class MockIsBuildBlacklistedUseCase: IsBuildBlacklistedUseCase, @unchecked Sendable {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+
+    // MARK: - invoke
+
+    public var invoke_Invocations: [Void] = []
+    public var invoke_MockMethod: (() async -> (isBuildBlacklisted: Bool, error: Error?))?
+    public var invoke_MockValue: (isBuildBlacklisted: Bool, error: Error?)?
+
+    public func invoke() async -> (isBuildBlacklisted: Bool, error: Error?) {
+        invoke_Invocations.append(())
+
+        if let mock = invoke_MockMethod {
+            return await mock()
+        } else if let mock = invoke_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `invoke`")
+        }
+    }
+
+}
+
 public class MockLiveGeneratorProtocol: LiveGeneratorProtocol {
 
     // MARK: - Life cycle

--- a/WireDomain/Tests/WireDomainTests/Synchronization/CheckBlacklistWorkerTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/CheckBlacklistWorkerTests.swift
@@ -1,0 +1,138 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+import WireDomainSupport
+@testable import WireDomain
+
+struct CheckBlacklistWorkerTests {
+
+    private final class CallbackCounter: Sendable {
+        nonisolated(unsafe) var count = 0
+    }
+
+    private let mockUseCase: MockIsBuildBlacklistedUseCase
+    private let continuation: AsyncStream<Void>.Continuation
+    private let sut: CheckBlacklistWorker
+    private let callbackCounter: CallbackCounter
+
+    init() {
+        let mockUseCase = MockIsBuildBlacklistedUseCase()
+        mockUseCase.invoke_MockValue = (false, nil)
+        let (trigger, continuation) = AsyncStream.makeStream(of: Void.self)
+        let callbackCounter = CallbackCounter()
+
+        self.mockUseCase = mockUseCase
+        self.continuation = continuation
+        self.callbackCounter = callbackCounter
+        self.sut = CheckBlacklistWorker(
+            isBuildBlacklistedUseCase: mockUseCase,
+            trigger: trigger,
+            onIsBuildBlacklisted: { callbackCounter.count += 1 }
+        )
+    }
+
+    // MARK: - Tests
+
+    @Test
+    func `calls use case on trigger`() async {
+        // Given
+        continuation.yield()
+        continuation.finish()
+
+        // When
+        await sut.startAndWait()
+
+        // Then
+        #expect(mockUseCase.invoke_Invocations.count == 1)
+    }
+
+    @Test
+    func `calls blacklisted callback when build is blacklisted`() async {
+        // Given
+        mockUseCase.invoke_MockValue = (true, nil)
+        continuation.yield()
+        continuation.finish()
+
+        // When
+        await sut.startAndWait()
+
+        // Then
+        #expect(callbackCounter.count == 1)
+    }
+
+    @Test
+    func `does not call blacklisted callback when build is not blacklisted`() async {
+        // Given
+        mockUseCase.invoke_MockValue = (false, nil)
+        continuation.yield()
+        continuation.finish()
+
+        // When
+        await sut.startAndWait()
+
+        // Then
+        // swiftformat:disable:next isEmpty
+        #expect(callbackCounter.count == 0)
+    }
+
+    @Test
+    func `calls blacklisted callback when build is blacklisted even if error`() async {
+        // Given
+        mockUseCase.invoke_MockValue = (true, URLError(.notConnectedToInternet))
+        continuation.yield()
+        continuation.finish()
+
+        // When
+        await sut.startAndWait()
+
+        // Then
+        #expect(callbackCounter.count == 1)
+    }
+
+    @Test
+    func `skips check when not stale`() async {
+        // Given
+        mockUseCase.invoke_MockValue = (false, nil)
+        continuation.yield()
+        continuation.yield()
+        continuation.finish()
+
+        // When
+        await sut.startAndWait()
+
+        // Then
+        #expect(mockUseCase.invoke_Invocations.count == 1)
+    }
+
+    @Test
+    func `rechecks after error because result remains stale`() async {
+        // Given
+        mockUseCase.invoke_MockValue = (false, URLError(.notConnectedToInternet))
+        continuation.yield()
+        continuation.yield()
+        continuation.finish()
+
+        // When
+        await sut.startAndWait()
+
+        // Then
+        #expect(mockUseCase.invoke_Invocations.count == 2)
+    }
+}

--- a/WireDomain/Tests/WireDomainTests/UseCases/IsBuildBlacklistedUseCaseTest.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/IsBuildBlacklistedUseCaseTest.swift
@@ -46,10 +46,11 @@ struct IsBuildBlacklistedUseCaseTest {
         )
 
         // When
-        let isBlacklisted = await sut.invoke()
+        let (isBlacklisted, error) = await sut.invoke()
 
         // Then
         #expect(isBlacklisted == true)
+        #expect(error == nil)
     }
 
     @Test(
@@ -64,27 +65,31 @@ struct IsBuildBlacklistedUseCaseTest {
         )
 
         // When
-        let isBlacklisted = await sut.invoke()
+        let (isBlacklisted, error) = await sut.invoke()
 
         // Then
         #expect(isBlacklisted == false)
+        #expect(error == nil)
     }
 
     @Test("Failures are equivalent to empty blacklist")
     func failuresAreEquivalentToEmptyBlacklist() async throws {
+        struct SomeError: Error {}
+
         // Given
         let sut = IsBuildBlacklistedUseCaseImpl(
             currentBuildNumber: "1",
             api: api
         )
 
-        api.getBlacklist_MockError = "some error"
+        api.getBlacklist_MockError = SomeError()
 
         // When
-        let isBlacklisted = await sut.invoke()
+        let (isBlacklisted, error) = await sut.invoke()
 
         // Then
         #expect(isBlacklisted == false)
+        #expect(error is SomeError)
     }
 
 }

--- a/WireFoundation/Sources/WireFoundation/WirePrimitives/UITestConfig.swift
+++ b/WireFoundation/Sources/WireFoundation/WirePrimitives/UITestConfig.swift
@@ -1,0 +1,56 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Configuration values for UITests.
+public struct UITestConfig: Codable {
+
+    /// The key used to store the config in the environment variables when running UITests.
+    public static let environmentKey = "UITEST_CONFIG"
+
+    // MARK: - Configuration data
+
+    public var isBuildBlacklisted = false
+
+    // MARK: - Init
+
+    public init() {}
+
+    // MARK: - Encoding/Decoding
+
+    /// The string representation of the config as a base64 encoded JSON string.
+    public func encode() -> String {
+        try! JSONEncoder().encode(self).base64EncodedString()
+    }
+
+    #if DEBUG
+        /// Returns `UITestConfig` decoded from base64 app environment or default config if none is set.
+        public static var environment: UITestConfig {
+            guard
+                let value = ProcessInfo.processInfo.environment[environmentKey],
+                let data = Data(base64Encoded: value),
+                let config = try? JSONDecoder().decode(UITestConfig.self, from: data)
+            else {
+                return UITestConfig() // Return default config is none set in the environment
+            }
+
+            return config
+        }
+    #endif
+}

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -323,4 +323,11 @@ public enum Locators {
         case classificationBanner = "ClassificationBanner"
 
     }
+    
+    public enum BlockerPage: String {
+
+        case mainContent
+        case clientObsoleteAlertTitle = "Update required"
+
+    }
 }

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -323,7 +323,7 @@ public enum Locators {
         case classificationBanner = "ClassificationBanner"
 
     }
-    
+
     public enum BlockerPage: String {
 
         case mainContent

--- a/wire-ios-share-engine/Sources/SharingSessionLoader.swift
+++ b/wire-ios-share-engine/Sources/SharingSessionLoader.swift
@@ -246,7 +246,7 @@ public struct SharingSessionLoader {
             api: api
         )
 
-        return await useCase.invoke()
+        return await useCase.invoke().isBuildBlacklisted
     }
 
     private func makeSharingSession(

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -218,12 +218,6 @@ final class UserSessionLoader {
             contextStorage: contextStorage
         )
 
-        // Check if this build is blacklisted.
-        if await isBuildBlacklisted(userSession: userSession) {
-            await userSession.close(deleteCookie: false)
-            throw Failure.buildIsBlacklisted
-        }
-
         // Perform pending migrations.
         do {
             try await performPendingMigrations(
@@ -617,11 +611,6 @@ final class UserSessionLoader {
             // Don't block session loading, we'll try again later.
             return nil
         }
-    }
-
-    private func isBuildBlacklisted(userSession: ZMUserSession) async -> Bool {
-        let useCase = userSession.userSessionComponent.makeIsBuildBlacklistedUseCase()
-        return await useCase.invoke()
     }
 
     private func performPendingMigrations(

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
@@ -113,16 +113,4 @@ extension ZMUserSession {
         }
     }
 
-    var checkBuildBlacklistAction: RecurringAction {
-        .init(id: #function, interval: .oneHour * 6) { [weak self] in
-            guard let self else { return }
-            let useCase = userSessionComponent.makeIsBuildBlacklistedUseCase()
-            let isBuildBlacklisted = (try? await useCase.invoke()) ?? false
-            if isBuildBlacklisted {
-                self.isBuildBlacklisted = true
-                delegate?.userSessionDidDiscoverBuildIsBlacklisted()
-            }
-        }
-    }
-
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -46,7 +46,7 @@ public final class ZMUserSession: NSObject {
 
     private let currentAppVersion: String
     private let currentBuildNumber: String
-    public internal(set) var isBuildBlacklisted = false
+    public private(set) var isBuildBlacklisted = false
     private var tokens: [Any] = []
     public private(set) var isTornDown = false
 
@@ -402,6 +402,16 @@ public final class ZMUserSession: NSObject {
         mlsService: mlsService
     )
 
+    private lazy var checkBlacklistWorker: CheckBlacklistWorker? = .init(
+        isBuildBlacklistedUseCase: userSessionComponent.makeIsBuildBlacklistedUseCase(),
+        onIsBuildBlacklisted: { [weak self] in
+            guard let self else { return }
+
+            isBuildBlacklisted = true
+            delegate?.userSessionDidDiscoverBuildIsBlacklisted()
+        }
+    )
+
     let logFilesProvider: LogFilesProviding
 
     // MARK: Dependency Injection
@@ -682,6 +692,7 @@ public final class ZMUserSession: NSObject {
         }
 
         await startWorkAgentAndGenerators()
+        checkBlacklistWorker?.start()
     }
 
     private func startWorkAgentAndGenerators() async {
@@ -770,6 +781,7 @@ public final class ZMUserSession: NSObject {
         callCenter?.tearDown()
         coreDataStack.close()
         contextStorage.clear()
+        checkBlacklistWorker = nil
 
         // Note: strategyDirectory, legacyUpdateEventProcessor, and urlActionProcessors
         // are left to be cleaned up when ZMUserSession is deallocated to avoid
@@ -870,7 +882,6 @@ public final class ZMUserSession: NSObject {
         recurringActionService.registerAction(updateProteusToMLSMigrationStatusAction)
         recurringActionService.registerAction(refreshTeamMetadataAction)
         recurringActionService.registerAction(refreshFederationCertificatesAction)
-        recurringActionService.registerAction(checkBuildBlacklistAction)
     }
 
     func startRequestLoopTracker() {

--- a/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
@@ -179,6 +179,8 @@ final class AppStateCalculator {
         to appState: AppState,
         completion: (() -> Void)? = nil
     ) {
+        let appState = validAppState(from: appState)
+
         guard hasEnteredForeground  else {
             pendingAppState = appState
             completion?()
@@ -199,6 +201,15 @@ final class AppStateCalculator {
         )
         delegate?.appStateCalculator(self, didCalculate: appState) {
             completion?()
+        }
+    }
+
+    private func validAppState(from appState: AppState) -> AppState {
+        switch appState {
+        case let .authenticated(session) where session.isBuildBlacklisted:
+            .blacklisted(reason: .appVersionBlacklisted)
+        default:
+            appState
         }
     }
 }
@@ -323,9 +334,7 @@ extension AppStateCalculator: SessionManagerDelegate {
     }
 
     func sessionManagerDidReportLockChange(forSession session: UserSession) {
-        if session.isBuildBlacklisted {
-            transition(to: .blacklisted(reason: .appVersionBlacklisted))
-        } else if session.isLocked {
+        if session.isLocked {
             transition(to: .locked(session))
         } else {
             transition(to: .authenticated(session))

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugOverrides/DeveloperOverridesForm.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugOverrides/DeveloperOverridesForm.swift
@@ -33,7 +33,7 @@ struct DeveloperOverridesForm: View {
         Form {
             Section("build number") {
                 TextField("e.g. 12345", text: $buildNumber)
-                Text("Use can set this to a blacklisted build number to simulate account blocking.")
+                Text("You can set this to a blacklisted build number to simulate account blocking.")
                     .foregroundStyle(.secondary)
             }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlockerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlockerViewController.swift
@@ -18,6 +18,7 @@
 
 import MessageUI
 import UIKit
+import WireLocators
 import WireLogging
 import WireMultiBackendUI
 import WireSyncEngine
@@ -54,6 +55,7 @@ final class BlockerViewController: LaunchImageViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.accessibilityIdentifier = Locators.BlockerPage.mainContent.rawValue
         setupApplicationNotifications()
     }
 

--- a/wire-ios/WireUITests/BlacklistTests.swift
+++ b/wire-ios/WireUITests/BlacklistTests.swift
@@ -1,0 +1,41 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+final class BlacklistTests: WireUITestCase {
+
+    override func setUpWithError() throws {
+        uiTestConfig.isBuildBlacklisted = true
+
+        try super.setUpWithError()
+    }
+
+    @MainActor
+    func testBlacklistAfterLogin__TC_9483() async throws {
+        let user = try await userHelper.createPersonalUser()
+        _ = try app.loginUser(email: user.email, password: user.password)
+
+        let blockerPage = try BlockerPage()
+
+        XCTAssertTrue(
+            blockerPage.clientObsoleteAlert.waitForExistence(timeout: 10),
+            "Client obsolete alert did not appear"
+        )
+    }
+}

--- a/wire-ios/WireUITests/Helper/WireUITestCase.swift
+++ b/wire-ios/WireUITests/Helper/WireUITestCase.swift
@@ -19,6 +19,7 @@
 // Methods to reset app or simulator caused issues, so instead
 // of using a script in the scheme, we delete the app using springboard
 
+import WireFoundation
 import XCTest
 
 class WireUITestCase: XCTestCase {
@@ -27,6 +28,8 @@ class WireUITestCase: XCTestCase {
     let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
     var userHelper: UserHelper!
     var callingServiceClient: CallingServiceClient!
+    var uiTestConfig = UITestConfig()
+    private var notificationPermissionMonitor: NSObjectProtocol?
 
     override func setUpWithError() throws {
         // Tap "Allow" on permission alert from a previous failed test, so next test is not blocked
@@ -43,6 +46,7 @@ class WireUITestCase: XCTestCase {
 
         app = XCUIApplication()
         app.launchEnvironment["UITEST_APPLOCK_TIMEOUT"] = "2"
+        app.launchEnvironment[UITestConfig.environmentKey] = uiTestConfig.encode()
         app.launchArguments = launchArguments
         app.setDeveloperFlags([
             .useWireAuthentication: true

--- a/wire-ios/WireUITests/Pages/BlockerPage.swift
+++ b/wire-ios/WireUITests/Pages/BlockerPage.swift
@@ -1,0 +1,35 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireLocators
+import XCTest
+
+class BlockerPage: PageModel {
+
+    override var pageMainElement: XCUIElement {
+        mainContent
+    }
+
+    var mainContent: XCUIElement {
+        app.otherElements[Locators.BlockerPage.mainContent.rawValue]
+    }
+
+    var clientObsoleteAlert: XCUIElement {
+        app.alerts[Locators.BlockerPage.clientObsoleteAlertTitle.rawValue]
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24848" title="WPB-24848" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24848</a>  [iOS] [App Launch] App cannot be started by user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

On C build, on special environment, the biometric prompt for EAR seemed not to happen especially on cold start. After more testing, it did happen but after 60 seconds after the blacklist check is done.

For some reason, the resolving of the url (which points to a 404, blacklist disabled on this environment) times out.

Solution:

Port fix of 4.18 to differ checking the blacklist from the userSession loading. See #4485 

### Testing

Run app on the special environment

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
