### PR TITLE
fix: Clean up analytics errors logs for calls - WPB-25996

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Analytics/CallEndedAnalyticsController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Analytics/CallEndedAnalyticsController.swift
@@ -105,7 +105,7 @@ final class CallEndedAnalyticsController<CallCenter: WireCallCenterV3> {
 
     private func handleCallEstablished(_ conversation: ZMConversation) {
         if eventInfos[conversation.remoteIdentifier] == nil {
-            logger.error("handleCallEstablished: expected eventInfo to be non-nil")
+            logger.debug("handleCallEstablished: no eventInfo to track — call joined after establishment")
             eventInfos[conversation.remoteIdentifier] = .init(callStart: currentDateProvider.now)
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25996" title="WPB-25996" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25996</a>  [iOS] Clean up analytics errors logs: handleCallEstablished: expected eventInfo to be non-nil
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The `CallEndedAnalyticsController` logs an error message `"handleCallEstablished: expected eventInfo to be non-nil"` when a user joins an ongoing call using the "Join" call button in the conversation view.

- The analytics controller creates `eventInfo` only when a call starts with **.incoming** or **.outgoing** state
- When joining an ongoing call (e.g., pressing the green "Join" button), the call transitions directly to **.established** state without going through **.incoming** or .outgoing first
- This is expected behavior - not an error condition

### Solution

- Changed log level from `error` to `debug`
- Updated message to clarify this is expected behavior: "no eventInfo to track - call joined after establishment"
- Kept the existing behavior of creating minimal eventInfo to track the call from the join point onwards (call duration, participants, screen sharing, etc.)

### Testing

Join the call vie "Join" button (notifications are off).

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
