### PR TITLE
chore: port commit of LTS branch straight to develop - WPB-26010

### DIFF
--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -4,6 +4,8 @@
 # It is triggered whenever a pull request is merged into any `release/*` branch.
 #
 # Target branch selection:
+# - If the source branch is the LTS release branch (vars.LTS_RELEASE, e.g. release/cycle-4.16),
+#   targets `develop` directly, skipping any future release branches.
 # - Gets all release branches and sorts them
 # - Finds the position of the source branch in the sorted list
 # - Selects the next branch in the sorted list, or `develop` if no next branch exists
@@ -56,6 +58,8 @@ jobs:
 
       - name: Determine target branch
         id: target-branch
+        env:
+          LTS_RELEASE: ${{ vars.LTS_RELEASE }}
         run: |
           scripts/determine-cherry-pick-target.py "${{ github.event.pull_request.base.ref }}"
 

--- a/scripts/determine-cherry-pick-target.py
+++ b/scripts/determine-cherry-pick-target.py
@@ -3,10 +3,12 @@
 Determine the target branch for cherry-picking from a release branch.
 
 This script:
-1. Gets all release branches matching release/cycle-* pattern
-2. Sorts them by version number (major.minor)
-3. Finds the position of the input branch in the sorted list
-4. Selects the next branch in the sorted list, or 'develop' if no next branch exists
+1. If the input branch is the LTS release branch (LTS_RELEASE env var, e.g.
+   release/cycle-4.16), targets 'develop' directly, skipping future release branches
+2. Gets all release branches matching release/cycle-* pattern
+3. Sorts them by version number (major.minor)
+4. Finds the position of the input branch in the sorted list
+5. Selects the next branch in the sorted list, or 'develop' if no next branch exists
 
 Usage:
     python3 scripts/determine-cherry-pick-target.py <base_branch>
@@ -56,6 +58,13 @@ def determine_target_branch(base_branch):
     # Check if base branch matches release/cycle-* pattern
     if not base_branch.startswith("release/cycle-"):
         print(f"Base branch {base_branch} doesn't match release/cycle-* pattern, using develop")
+        return "develop"
+
+    # If the base branch is the LTS release branch, skip future release branches
+    # and cherry-pick straight to develop.
+    lts_release = os.environ.get("LTS_RELEASE", "").strip()
+    if lts_release and base_branch == lts_release:
+        print(f"Base branch {base_branch} is the LTS release branch, using develop")
         return "develop"
     
     # Get all release branches


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26010" title="WPB-26010" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26010</a>  [iOS] modify cherry-pick action to port LTS commits to develop directly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When a PR is merged to a LTS release branch, we don't necessarly want to apply it to the next release. 

In this case we apply directly to develop

### Testing

N/A
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
