### PR TITLE
fix: restore legacy backup error - WPB-24854

### DIFF
--- a/WireUI/Sources/WireSettingsUI/Account/BackupImportExport/Import/ImportBackupViewModel.swift
+++ b/WireUI/Sources/WireSettingsUI/Account/BackupImportExport/Import/ImportBackupViewModel.swift
@@ -89,6 +89,20 @@ final class ImportBackupViewModel: ObservableObject {
 
     func pickedBackupFile(result: Result<URL, any Error>) {
         func onFailure(_ error: any Error) {
+            switch error {
+            case ImportBackupError.invalidFileExtension:
+                alertContent = .init(
+                    title: Strings.Alert.InvalidFileError.title,
+                    message: Strings.Alert.InvalidFileError.message,
+                    action: Strings.Alert.ok
+                )
+            default:
+                alertContent = .init(
+                    title: Strings.Alert.GenericError.title,
+                    message: Strings.Alert.GenericError.message,
+                    action: Strings.Alert.ok
+                )
+            }
             logger.error("failed to pick backup file to restore: \(String(reflecting: error))")
             state = .restoreFailed
         }
@@ -128,6 +142,11 @@ final class ImportBackupViewModel: ObservableObject {
                 try await startImport(from: url, password: "")
             } catch {
                 logger.error("Failed to start import: \(error)")
+                alertContent = .init(
+                    title: Strings.Alert.GenericError.title,
+                    message: Strings.Alert.GenericError.message,
+                    action: Strings.Alert.ok
+                )
                 state = .restoreFailed
             }
         }
@@ -144,6 +163,11 @@ final class ImportBackupViewModel: ObservableObject {
                 try await startImport(from: url, password: password)
             } catch {
                 logger.error("Failed to start import: \(error)")
+                alertContent = .init(
+                    title: Strings.Alert.GenericError.title,
+                    message: Strings.Alert.GenericError.message,
+                    action: Strings.Alert.ok
+                )
                 state = .restoreFailed
             }
         }

--- a/WireUI/Tests/WireSettingsUITests/Account/BackupImportExport/Import/ImportBackupViewModelTests.swift
+++ b/WireUI/Tests/WireSettingsUITests/Account/BackupImportExport/Import/ImportBackupViewModelTests.swift
@@ -40,6 +40,8 @@ final class ImportBackupViewModelTests: XCTestCase {
 
     private var fileManager: FileManager { .default }
 
+    private typealias GenericErrorStrings = L10n.Localizable.ImportBackup.Alert.GenericError
+
     override func setUp() async throws {
 
         temporaryDirectory = try fileManager.url(
@@ -420,6 +422,63 @@ final class ImportBackupViewModelTests: XCTestCase {
         // Then
         wait(forConditionToBeTrue: sut.isAlertPresented, timeout: 3)
         XCTAssertFalse(sut.alertContent.title.isEmpty)
+    }
+
+    func testConfirmOverwrite_whenUseCaseCreationFails_showsGenericAlert() {
+        // Given - destructive import requires confirmation first
+        let sut = sut as ImportBackupViewModel
+        mockImportBackupUseCase.isImportDestructive = true
+
+        sut.pickedBackupFile(result: .success(temporaryFile))
+        wait(forConditionToBeTrue: sut.isImportConfirmationPresented, timeout: 3)
+
+        // When - creating the use case throws on confirmation (error escapes `startImport`)
+        mockFactory.errorToThrow = NSError(domain: "test", code: 999)
+        sut.confirmOverwrite()
+
+        // Then - a populated generic alert is shown rather than a stale/blank one
+        wait(forConditionToBeTrue: sut.isAlertPresented, timeout: 3)
+        XCTAssertEqual(sut.alertContent.title, GenericErrorStrings.title)
+        XCTAssertEqual(sut.alertContent.message, GenericErrorStrings.message)
+        XCTAssertFalse(sut.alertContent.action.isEmpty)
+    }
+
+    func testEnterPassword_whenUseCaseCreationFails_showsGenericAlert() {
+        // Given - reach the password prompt
+        let sut = sut as ImportBackupViewModel
+        mockImportBackupUseCase.isImportDestructive = false
+        mockCoordinator.startImportForPassword_MockMethod = { _, _ in
+            let (stream, continuation) = AsyncThrowingStream<ImportBackupProgress, any Error>.makeStream()
+            continuation.finish(throwing: ImportBackupError.passwordRequired)
+            return stream
+        }
+
+        sut.pickedBackupFile(result: .success(temporaryFile))
+        wait(forConditionToBeTrue: sut.isEnterBackupPasswordPresented, timeout: 3)
+
+        // When - creating the use case throws on retry (error escapes `startImport`)
+        mockFactory.errorToThrow = NSError(domain: "test", code: 999)
+        sut.enterPassword("pw")
+
+        // Then - a populated generic alert is shown rather than a blank one
+        wait(forConditionToBeTrue: sut.isAlertPresented, timeout: 3)
+        XCTAssertEqual(sut.alertContent.title, GenericErrorStrings.title)
+        XCTAssertEqual(sut.alertContent.message, GenericErrorStrings.message)
+        XCTAssertFalse(sut.alertContent.action.isEmpty)
+    }
+
+    func testPickBackupFileWithGenericFailure_showsGenericAlert() {
+        // Given
+        let sut = sut as ImportBackupViewModel
+
+        // When - a non-`invalidFileExtension` error is reported
+        sut.pickedBackupFile(result: .failure(NSError(domain: "test", code: 123)))
+
+        // Then - the default branch now shows a populated generic alert rather than a blank one
+        wait(forConditionToBeTrue: sut.isAlertPresented, timeout: 3)
+        XCTAssertEqual(sut.alertContent.title, GenericErrorStrings.title)
+        XCTAssertEqual(sut.alertContent.message, GenericErrorStrings.message)
+        XCTAssertFalse(sut.alertContent.action.isEmpty)
     }
 
     // MARK: - State Transition Tests


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24854" title="WPB-24854" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24854</a>  [iOS] [Backup] Empty error message appears when importing backup by user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

If you try to restore a legacy backup (i.e web) on iOS, you will get an error. Currently an empty alert is shown, this PR fixes it.

Also add generic error alerts that were not covered to avoid empty alert to be shown.

### Testing

See ticket's user credentials, and restore backup

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
