### PR TITLE
fix: test sending audio recording issue - WPB-26055

### DIFF
--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -343,7 +343,16 @@ class ActiveConversationPage: PageModel {
             "Audio recording not started"
         )
 
-        try? await Task.sleep(for: .seconds(1))
+        let predicate = NSPredicate(format: "value != %@", "0:00")
+        let expectation = XCTNSPredicateExpectation(
+            predicate: predicate,
+            object: recordingTimeLabel
+        )
+        let result = await XCTWaiter().fulfillment(of: [expectation], timeout: 5)
+        XCTAssertEqual(
+            result, .completed,
+            "Audio did not recorded — timer still on 0:00"
+        )
 
         if stopRecording.waitForExistence(timeout: 2), stopRecording.isHittable {
             stopRecording.tap()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26055" title="WPB-26055" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26055</a>  [iOS] fix audio recording issue 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently audio recording is stuck as 0:00 and try to send where it fails to recognise if audio sent or not due to 0:00 
Same function being used in multiple tests

### Testing

ran locally via terminal and it worked fine.

https://github.com/user-attachments/assets/9adcdb09-d609-4bdc-a0d4-228c586083c8


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
