### PR TITLE
fix: screen curtain when keyboard is displayed - WPB-26034

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/ScreenCurtain/ScreenCurtainView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ScreenCurtain/ScreenCurtainView.swift
@@ -31,7 +31,13 @@ struct ScreenCurtainView: View {
             }
             Spacer()
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.black)
+        // Ignore all safe areas (incl. the keyboard) so the curtain fully covers the screen.
+        // Otherwise, when the keyboard is visible (e.g. on the AppLock passcode screen),
+        // SwiftUI's keyboard avoidance shrinks the black background to the keyboard top,
+        // leaving an uncovered gray bar when the app resigns active.
+        .ignoresSafeArea()
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26034" title="WPB-26034" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26034</a>  [iOS] If the keyboard is open and one pulls the Info Center downward, an unattractive gray bar appears
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When pulling the control or notification center, while the app is on a conversation with the keyboard opened (EAR enabled), the screen curtain is displayed.

It does not extend fully. This PR fixes it.

### Testing

1. EAR enabled
2. open conversation
3. type message
4. pull notification center

See screenshot in ticket.
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
