### PR TITLE
fix: proteus reset session has no effect - WPB-26033

### DIFF
--- a/WireDomain/Sources/WireDomain/UseCases/ResetProteusSessionUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/ResetProteusSessionUseCase.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import os
 import WireDataModel
 import WireLogging
 
@@ -110,7 +111,7 @@ public struct ResetProteusSessionUseCase: ResetProteusSessionUseCaseProtocol {
 /// user's clients have been notified about the session reset (i.e. `sessionHasBeenReset`).
 private final class SessionResetObserver: NSObject, UserClientObserver {
 
-    private let lock = NSLock()
+    private let lock = OSAllocatedUnfairLock()
     private var continuation: CheckedContinuation<Void, Never>?
     private var didReset = false
     private var token: NSObjectProtocol?
@@ -121,26 +122,25 @@ private final class SessionResetObserver: NSObject, UserClientObserver {
 
     func waitUntilReset() async {
         await withCheckedContinuation { continuation in
-            lock.lock()
-            if didReset {
-                lock.unlock()
-                continuation.resume()
-            } else {
+            let alreadyReset = lock.withLock {
+                if didReset { return true }
                 self.continuation = continuation
-                lock.unlock()
+                return false
             }
+            if alreadyReset { continuation.resume() }
         }
     }
 
     func userClientDidChange(_ changeInfo: UserClientChangeInfo) {
         guard changeInfo.sessionHasBeenReset else { return }
 
-        lock.lock()
-        let continuation = continuation
-        self.continuation = nil
-        didReset = true
-        token = nil
-        lock.unlock()
+        let continuation = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+            let continuation = self.continuation
+            self.continuation = nil
+            didReset = true
+            token = nil
+            return continuation
+        }
 
         continuation?.resume()
     }

--- a/WireDomain/Sources/WireDomain/UseCases/ResetProteusSessionUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/ResetProteusSessionUseCase.swift
@@ -37,9 +37,14 @@ public protocol ResetProteusSessionUseCaseProtocol {
 public struct ResetProteusSessionUseCase: ResetProteusSessionUseCaseProtocol {
 
     private let syncContext: NSManagedObjectContext
+    private let proteusService: any ProteusServiceInterface
 
-    public init(syncContext: NSManagedObjectContext) {
+    public init(
+        syncContext: NSManagedObjectContext,
+        proteusService: any ProteusServiceInterface
+    ) {
         self.syncContext = syncContext
+        self.proteusService = proteusService
     }
 
     public func invoke(userClient: UserClient) async {
@@ -70,22 +75,20 @@ public struct ResetProteusSessionUseCase: ResetProteusSessionUseCaseProtocol {
     private func deleteProteusSession(objectID: NSManagedObjectID) async {
         let context = syncContext
 
-        let session: (id: ProteusSessionID, service: any ProteusServiceInterface)? = await context.perform {
+        let sessionID: ProteusSessionID? = await context.perform {
             guard
                 let client = (try? context.existingObject(with: objectID)) as? UserClient,
-                !client.isSelfClient(),
-                let sessionID = client.proteusSessionID,
-                let proteusService = context.proteusService
+                !client.isSelfClient()
             else {
                 return nil
             }
-            return (sessionID, proteusService)
+            return client.proteusSessionID
         }
 
-        guard let session else { return }
+        guard let sessionID else { return }
 
         do {
-            try await session.service.deleteSession(id: session.id)
+            try await proteusService.deleteSession(id: sessionID)
         } catch {
             WireLogger.proteus.error("Failed to delete session while resetting: \(error)")
         }

--- a/WireDomain/Sources/WireDomain/UseCases/ResetProteusSessionUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/ResetProteusSessionUseCase.swift
@@ -1,0 +1,148 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireDataModel
+import WireLogging
+
+// sourcery: AutoMockable
+public protocol ResetProteusSessionUseCaseProtocol {
+
+    /// Resets the proteus session between the self client and the given client.
+    ///
+    /// The local session is deleted and the client is marked so that the other party's
+    /// clients get notified about the reset. When such a notification is expected (i.e. there is
+    /// a one-to-one conversation), the call only returns once the other clients have been notified,
+    /// so callers can keep a loading indicator visible for the whole operation.
+    ///
+    /// Can be called several times without issues.
+    func invoke(userClient: UserClient) async
+}
+
+public struct ResetProteusSessionUseCase: ResetProteusSessionUseCaseProtocol {
+
+    private let syncContext: NSManagedObjectContext
+
+    public init(syncContext: NSManagedObjectContext) {
+        self.syncContext = syncContext
+    }
+
+    public func invoke(userClient: UserClient) async {
+        let objectID = userClient.objectID
+
+        await deleteProteusSession(objectID: objectID)
+
+        // Only wait for the "other clients notified" signal when there is a one-to-one
+        // conversation to send the reset message to. Otherwise `ResetSessionRequestStrategy`
+        // returns early and the flag is never cleared, which would block the caller forever.
+        let shouldWaitForNotification = await userClient.managedObjectContext?.perform {
+            userClient.user?.oneToOneConversation != nil
+        } ?? false
+
+        guard shouldWaitForNotification else {
+            await markNeedsToNotifyOtherClients(objectID: objectID)
+            return
+        }
+
+        let observer = SessionResetObserver()
+        observer.start(observing: userClient)
+        await markNeedsToNotifyOtherClients(objectID: objectID)
+        await observer.waitUntilReset()
+    }
+
+    // MARK: - Private
+
+    private func deleteProteusSession(objectID: NSManagedObjectID) async {
+        let context = syncContext
+
+        let session: (id: ProteusSessionID, service: any ProteusServiceInterface)? = await context.perform {
+            guard
+                let client = (try? context.existingObject(with: objectID)) as? UserClient,
+                !client.isSelfClient(),
+                let sessionID = client.proteusSessionID,
+                let proteusService = context.proteusService
+            else {
+                return nil
+            }
+            return (sessionID, proteusService)
+        }
+
+        guard let session else { return }
+
+        do {
+            try await session.service.deleteSession(id: session.id)
+        } catch {
+            WireLogger.proteus.error("Failed to delete session while resetting: \(error)")
+        }
+    }
+
+    private func markNeedsToNotifyOtherClients(objectID: NSManagedObjectID) async {
+        let context = syncContext
+
+        await context.perform {
+            guard let client = (try? context.existingObject(with: objectID)) as? UserClient else {
+                return
+            }
+            // Marking the client triggers `ResetSessionRequestStrategy` to notify the other party.
+            client.needsToNotifyOtherUserAboutSessionReset = true
+            context.saveOrRollback()
+        }
+    }
+}
+
+// MARK: - SessionResetObserver
+
+/// Bridges the `UserClientChangeInfo` observation to async/await, resuming once the other
+/// user's clients have been notified about the session reset (i.e. `sessionHasBeenReset`).
+private final class SessionResetObserver: NSObject, UserClientObserver {
+
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var didReset = false
+    private var token: NSObjectProtocol?
+
+    func start(observing client: UserClient) {
+        token = UserClientChangeInfo.add(observer: self, for: client)
+    }
+
+    func waitUntilReset() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if didReset {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                self.continuation = continuation
+                lock.unlock()
+            }
+        }
+    }
+
+    func userClientDidChange(_ changeInfo: UserClientChangeInfo) {
+        guard changeInfo.sessionHasBeenReset else { return }
+
+        lock.lock()
+        let continuation = continuation
+        self.continuation = nil
+        didReset = true
+        token = nil
+        lock.unlock()
+
+        continuation?.resume()
+    }
+}

--- a/WireDomain/Sources/WireDomain/UseCases/ResetProteusSessionUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/ResetProteusSessionUseCase.swift
@@ -26,11 +26,7 @@ public protocol ResetProteusSessionUseCaseProtocol {
     /// Resets the proteus session between the self client and the given client.
     ///
     /// The local session is deleted and the client is marked so that the other party's
-    /// clients get notified about the reset. When such a notification is expected (i.e. there is
-    /// a one-to-one conversation), the call only returns once the other clients have been notified,
-    /// so callers can keep a loading indicator visible for the whole operation.
-    ///
-    /// Can be called several times without issues.
+    /// clients get notified about the reset.
     func invoke(userClient: UserClient) async
 }
 

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -4075,6 +4075,30 @@ public class MockResetMLSConversationLockRepositoryProtocol: ResetMLSConversatio
 
 }
 
+public class MockResetProteusSessionUseCaseProtocol: ResetProteusSessionUseCaseProtocol {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+
+    // MARK: - invoke
+
+    public var invokeUserClient_Invocations: [UserClient] = []
+    public var invokeUserClient_MockMethod: ((UserClient) async -> Void)?
+
+    public func invoke(userClient: UserClient) async {
+        invokeUserClient_Invocations.append(userClient)
+
+        guard let mock = invokeUserClient_MockMethod else {
+            fatalError("no mock for `invokeUserClient`")
+        }
+
+        await mock(userClient)
+    }
+
+}
+
 public class MockSelfUserProviderProtocol: SelfUserProviderProtocol {
 
     // MARK: - Life cycle

--- a/WireDomain/Tests/TestPlans/AllTests.xctestplan
+++ b/WireDomain/Tests/TestPlans/AllTests.xctestplan
@@ -31,6 +31,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : false,
       "target" : {
         "containerPath" : "container:",
         "identifier" : "WireDomainPackageTests",
@@ -38,6 +39,7 @@
       }
     },
     {
+      "parallelizable" : false,
       "skippedTests" : [
         "PullAllConversationsSyncTests\/testPull_LegacyIdentifiers()",
         "PullMLSStatusSyncTests\/testPull_EndpointUnavailable()",

--- a/WireDomain/Tests/WireDomainTests/UseCases/ResetProteusSessionUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/ResetProteusSessionUseCaseTests.swift
@@ -1,0 +1,102 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireDataModel
+import WireDataModelSupport
+import XCTest
+@testable import WireDomain
+
+final class ResetProteusSessionUseCaseTests: XCTestCase {
+
+    private var sut: ResetProteusSessionUseCase!
+    private var proteusService: MockProteusServiceInterface!
+    private var stack: CoreDataStack!
+    private var coreDataStackHelper: CoreDataStackHelper!
+    private var modelHelper: ModelHelper!
+
+    private var context: NSManagedObjectContext {
+        stack.syncContext
+    }
+
+    override func setUp() async throws {
+        coreDataStackHelper = CoreDataStackHelper()
+        modelHelper = ModelHelper()
+        stack = try await coreDataStackHelper.createStack()
+        proteusService = MockProteusServiceInterface()
+
+        await context.perform { [self] in
+            context.proteusService = proteusService
+        }
+
+        sut = ResetProteusSessionUseCase(syncContext: context)
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        proteusService = nil
+        stack = nil
+        try coreDataStackHelper.cleanupDirectory()
+        coreDataStackHelper = nil
+        modelHelper = nil
+    }
+
+    // MARK: - Tests
+
+    func testInvoke_DeletesProteusSessionAndMarksClientForNotification() async throws {
+        // Given a client with a session and no one-to-one conversation to notify.
+        proteusService.deleteSessionId_MockMethod = { _ in }
+
+        let (userClient, sessionID) = await context.perform { [self] in
+            let user = modelHelper.createUser(in: context)
+            let client = modelHelper.createClient(for: user)
+            return (client, client.proteusSessionID)
+        }
+        let expectedSessionID = try XCTUnwrap(sessionID)
+
+        // When
+        await sut.invoke(userClient: userClient)
+
+        // Then the local session is deleted...
+        XCTAssertEqual(proteusService.deleteSessionId_Invocations, [expectedSessionID])
+
+        // ...and the client is marked so the other party gets notified.
+        let needsToNotify = await context.perform { userClient.needsToNotifyOtherUserAboutSessionReset }
+        XCTAssertTrue(needsToNotify)
+    }
+
+    func testInvoke_GivenSessionDeletionFails_StillMarksClientForNotification() async throws {
+        // Given the proteus session deletion fails.
+        proteusService.deleteSessionId_MockError = ProteusServiceError.failedToDeleteSession
+
+        let userClient = await context.perform { [self] in
+            let user = modelHelper.createUser(in: context)
+            return modelHelper.createClient(for: user)
+        }
+
+        // When
+        await sut.invoke(userClient: userClient)
+
+        // Then the client is still marked for notification despite the deletion failure.
+        let needsToNotify = await context.perform { userClient.needsToNotifyOtherUserAboutSessionReset }
+        XCTAssertTrue(needsToNotify)
+    }
+}
+
+private enum ProteusServiceError: Error {
+    case failedToDeleteSession
+}

--- a/WireDomain/Tests/WireDomainTests/UseCases/ResetProteusSessionUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/ResetProteusSessionUseCaseTests.swift
@@ -39,11 +39,10 @@ final class ResetProteusSessionUseCaseTests: XCTestCase {
         stack = try await coreDataStackHelper.createStack()
         proteusService = MockProteusServiceInterface()
 
-        await context.perform { [self] in
-            context.proteusService = proteusService
-        }
-
-        sut = ResetProteusSessionUseCase(syncContext: context)
+        sut = ResetProteusSessionUseCase(
+            syncContext: context,
+            proteusService: proteusService
+        )
     }
 
     override func tearDown() async throws {

--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -289,36 +289,6 @@ public class UserClient: ZMManagedObject, UserClientType {
         }
     }
 
-    /// Resets the session between the client and the selfClient
-    /// Can be called several times without issues
-
-    public func resetSession() {
-        guard
-            let uiMOC = managedObjectContext?.zm_userInterface,
-            let syncMOC = uiMOC.zm_sync
-        else {
-            return
-        }
-
-        WaitingGroupTask(context: syncMOC) {
-            guard let syncClient = await syncMOC.perform({
-                (try? syncMOC.existingObject(with: self.objectID)) as? UserClient
-            }) else {
-                return
-            }
-
-            // Delete session and fingerprint
-            try? await syncClient.deleteSession()
-
-            await syncMOC.perform {
-                // Mark that we need notify the other party about the session reset
-                syncClient.needsToNotifyOtherUserAboutSessionReset = true
-
-                syncMOC.saveOrRollback()
-            }
-        }
-    }
-
     public func resolveDecryptionFailedSystemMessages() {
         let request = NSBatchUpdateRequest(entityName: ZMSystemMessage.entityName())
 

--- a/wire-ios-data-model/Source/Model/UserClient/UserClientType.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClientType.swift
@@ -44,9 +44,6 @@ public protocol UserClientType: NSObjectProtocol {
 
     var e2eIdentityCertificate: E2eIdentityCertificate? { get set }
 
-    /// Delete any existing session with client and establish a new one.
-    func resetSession()
-
     /// Returns true if this is the active client of the self user
     func isSelfClient() -> Bool
 }

--- a/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -305,37 +305,6 @@ final class UserClientTests: ZMBaseManagedObjectTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
 
-    func testThatItSetsNeedsToNotifyOtherUserAboutSessionReset_WhenResettingSession() {
-        var otherClient: UserClient!
-
-        // given
-        syncMOC.performGroupedAndWait {
-            _ = self.createSelfClient(onMOC: self.syncMOC)
-
-            otherClient = UserClient.insertNewObject(in: self.syncMOC)
-            otherClient.remoteIdentifier = UUID.create().transportString()
-
-            let otherUser = ZMUser.insertNewObject(in: self.syncMOC)
-            otherUser.remoteIdentifier = UUID.create()
-            otherClient.user = otherUser
-
-            let connection = ZMConnection.insertNewSentConnection(to: otherUser)
-            connection.status = .accepted
-        }
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        // when
-        syncMOC.performGroupedAndWait {
-            otherClient.resetSession()
-        }
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        // then
-        syncMOC.performGroupedAndWait {
-            XCTAssertTrue(otherClient.needsToNotifyOtherUserAboutSessionReset)
-        }
-    }
-
     func testThatItAsksForMoreWhenRunningOutOfPrekeys() {
 
         syncMOC.performGroupedAndWait {

--- a/wire-ios-sync-engine/Source/UserSession/UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/UserSession.swift
@@ -254,6 +254,8 @@ public protocol UserSession: AnyObject {
 
     var getUserClientFingerprint: GetUserClientFingerprintUseCaseProtocol { get }
 
+    var resetProteusSession: ResetProteusSessionUseCaseProtocol { get }
+
     var isUserE2EICertifiedUseCase: IsUserE2EICertifiedUseCaseProtocol { get }
 
     var isSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProtocol { get }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -298,7 +298,10 @@ public final class ZMUserSession: NSObject {
     }
 
     public var resetProteusSession: ResetProteusSessionUseCaseProtocol {
-        ResetProteusSessionUseCase(syncContext: coreDataStack.syncContext)
+        ResetProteusSessionUseCase(
+            syncContext: coreDataStack.syncContext,
+            proteusService: proteusService
+        )
     }
 
     lazy var e2eiRepository: E2EIRepositoryInterface = {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -297,6 +297,10 @@ public final class ZMUserSession: NSObject {
         )
     }
 
+    public var resetProteusSession: ResetProteusSessionUseCaseProtocol {
+        ResetProteusSessionUseCase(syncContext: coreDataStack.syncContext)
+    }
+
     lazy var e2eiRepository: E2EIRepositoryInterface = {
         let acmeDiscoveryPath = e2eiFeature.config.acmeDiscoveryUrl ?? ""
         let acmeApi = AcmeAPI(acmeDiscoveryPath: acmeDiscoveryPath)

--- a/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.manual.swift
+++ b/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.manual.swift
@@ -547,6 +547,15 @@ public class MockUserSession: UserSession {
 
     public var underlyingGetUserClientFingerprint: GetUserClientFingerprintUseCaseProtocol!
 
+    // MARK: - resetProteusSession
+
+    public var resetProteusSession: ResetProteusSessionUseCaseProtocol {
+        get { return underlyingResetProteusSession }
+        set(value) { underlyingResetProteusSession = value }
+    }
+
+    public var underlyingResetProteusSession: ResetProteusSessionUseCaseProtocol!
+
     // MARK: - isUserE2EICertifiedUseCase
 
     public var isUserE2EICertifiedUseCase: IsUserE2EICertifiedUseCaseProtocol {

--- a/wire-ios/Tests/Mocks/MockUserClient.swift
+++ b/wire-ios/Tests/Mocks/MockUserClient.swift
@@ -48,10 +48,6 @@ final class MockUserClient: NSObject, UserClientType {
         false
     }
 
-    func resetSession() {
-        // No-op
-    }
-
     func fetchFingerprintOrPrekeys() {
         // No-op
     }

--- a/wire-ios/Tests/Mocks/UserSessionMock.swift
+++ b/wire-ios/Tests/Mocks/UserSessionMock.swift
@@ -298,6 +298,10 @@ final class UserSessionMock: UserSession {
         mockGetUserClientFingerprintUseCaseProtocol
     }
 
+    var resetProteusSession: ResetProteusSessionUseCaseProtocol {
+        MockResetProteusSessionUseCase()
+    }
+
     lazy var isUserE2EICertifiedUseCase: IsUserE2EICertifiedUseCaseProtocol = {
         let mock = MockIsUserE2EICertifiedUseCaseProtocol()
         mock.invokeConversationUser_MockValue = false
@@ -477,3 +481,7 @@ extension UserSessionMock: ContextProvider {
 }
 
 class MockNotificationContext: NSObject, NotificationContext {}
+
+private struct MockResetProteusSessionUseCase: ResetProteusSessionUseCaseProtocol {
+    func invoke(userClient: UserClient) async {}
+}

--- a/wire-ios/Tests/Mocks/UserSessionMock.swift
+++ b/wire-ios/Tests/Mocks/UserSessionMock.swift
@@ -22,6 +22,7 @@ import WireAnalytics
 import WireDataModel
 import WireDataModelSupport
 import WireDomain
+import WireDomainSupport
 import WireFoundation
 import WireRequestStrategySupport
 import WireSyncEngine
@@ -298,8 +299,13 @@ final class UserSessionMock: UserSession {
         mockGetUserClientFingerprintUseCaseProtocol
     }
 
+    lazy var mockResetProteusSession: MockResetProteusSessionUseCaseProtocol = {
+        let mock = MockResetProteusSessionUseCaseProtocol()
+        mock.invokeUserClient_MockMethod = { _ in }
+        return mock
+    }()
     var resetProteusSession: ResetProteusSessionUseCaseProtocol {
-        MockResetProteusSessionUseCase()
+        mockResetProteusSession
     }
 
     lazy var isUserE2EICertifiedUseCase: IsUserE2EICertifiedUseCaseProtocol = {
@@ -482,6 +488,3 @@ extension UserSessionMock: ContextProvider {
 
 class MockNotificationContext: NSObject, NotificationContext {}
 
-private struct MockResetProteusSessionUseCase: ResetProteusSessionUseCaseProtocol {
-    func invoke(userClient: UserClient) async {}
-}

--- a/wire-ios/Tests/Mocks/UserSessionMock.swift
+++ b/wire-ios/Tests/Mocks/UserSessionMock.swift
@@ -304,6 +304,7 @@ final class UserSessionMock: UserSession {
         mock.invokeUserClient_MockMethod = { _ in }
         return mock
     }()
+
     var resetProteusSession: ResetProteusSessionUseCaseProtocol {
         mockResetProteusSession
     }
@@ -487,4 +488,3 @@ extension UserSessionMock: ContextProvider {
 }
 
 class MockNotificationContext: NSObject, NotificationContext {}
-

--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -648,16 +648,16 @@ class MockDeviceDetailsViewActions: DeviceDetailsViewActions {
     // MARK: - resetSession
 
     var resetSession_Invocations: [Void] = []
-    var resetSession_MockMethod: (() -> Void)?
+    var resetSession_MockMethod: (() async -> Void)?
 
-    func resetSession() {
+    func resetSession() async {
         resetSession_Invocations.append(())
 
         guard let mock = resetSession_MockMethod else {
             fatalError("no mock for `resetSession`")
         }
 
-        mock()
+        await mock()
     }
 
     // MARK: - updateVerified

--- a/wire-ios/Wire-iOS Tests/DeviceManagement/DeviceDetailsViewActionsHandlerTests.swift
+++ b/wire-ios/Wire-iOS Tests/DeviceManagement/DeviceDetailsViewActionsHandlerTests.swift
@@ -83,6 +83,29 @@ final class DeviceDetailsViewActionsHandlerTests: XCTestCase, CoreDataFixtureTes
         wait(for: [expectation], timeout: 0.5)
     }
 
+    @MainActor
+    func testResetSession_InvokesUseCaseAndTogglesProcessing() async {
+        // Given
+        let deviceActionHandler = DeviceDetailsViewActionsHandler(
+            userClient: client,
+            userSession: mockSession,
+            credentials: emailCredentials,
+            saveFileManager: saveFileManager,
+            getProteusFingerprint: mockGetProteusFingerprint,
+            contextProvider: mockContextProvider,
+            e2eiCertificateEnrollment: mockEnrollE2eICertificateUseCase
+        )
+        var processingStates: [Bool] = []
+        deviceActionHandler.isProcessing = { processingStates.append($0) }
+
+        // When
+        await deviceActionHandler.resetSession()
+
+        // Then
+        XCTAssertEqual(mockSession.mockResetProteusSession.invokeUserClient_Invocations.count, 1)
+        XCTAssertEqual(processingStates, [true, false])
+    }
+
     func testThatItReturnsFingerPrint_WhenGetFingerPrintIsInvoked() async throws {
         let deviceActionHandler = DeviceDetailsViewActionsHandler(
             userClient: client,

--- a/wire-ios/Wire-iOS UnitTests/DeviceInfoViewModelTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/DeviceInfoViewModelTests.swift
@@ -152,6 +152,19 @@ final class DeviceInfoViewModelTests: XCTestCase {
         await fulfillment(of: [expectation])
     }
 
+    func testThatItCallsResetSessionMethodInDeviceActionsHandlerAndShowsSuccess_WhenResetSessionIsCalled() async {
+        let expectation = expectation(description: "resetSession should be called")
+        mockDeviceActionsHandler.resetSession_MockMethod = {
+            expectation.fulfill()
+        }
+
+        XCTAssertFalse(deviceInfoViewModel.showResetSessionSuccess)
+        await deviceInfoViewModel.resetSession()
+
+        await fulfillment(of: [expectation])
+        XCTAssertTrue(deviceInfoViewModel.showResetSessionSuccess)
+    }
+
     func testThatItCallsEnrollMethodInDeviceActionsHandler_WhenEnrolClientMethodIsCalled() async {
         let expectation = expectation(description: "enrollClient should be called")
         mockDeviceActionsHandler.enrollClient_MockMethod = {

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 /* Begin PBXBuildFile section */
 		0143895E2BC81DC200EC6920 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 0143895D2BC81DC200EC6920 /* PrivacyInfo.xcprivacy */; };
 		0145AE992B1156FC0097E3B8 /* WireSyncEngineSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0145AE982B1156FC0097E3B8 /* WireSyncEngineSupport.framework */; };
+		FADE000000000000000000A2 /* WireDomainSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FADE000000000000000000A1 /* WireDomainSupport.framework */; };
+		FADE000000000000000000A3 /* WireDomainSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FADE000000000000000000A1 /* WireDomainSupport.framework */; };
 		016DB6DE2C261A4900DEB81B /* WireDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 016DB6DD2C261A4900DEB81B /* WireDomain.framework */; };
 		016DB6DF2C261A4900DEB81B /* WireDomain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 016DB6DD2C261A4900DEB81B /* WireDomain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		01B71B952D6D2DAB002C5A38 /* RedactedScript-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 01B71AA22D6D2DAB002C5A38 /* RedactedScript-Regular.ttf */; };
@@ -253,6 +255,7 @@
 /* Begin PBXFileReference section */
 		0143895D2BC81DC200EC6920 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		0145AE982B1156FC0097E3B8 /* WireSyncEngineSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireSyncEngineSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FADE000000000000000000A1 /* WireDomainSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDomainSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		015DC1DC2D68DD85004EE8C9 /* iOS StyleKit.pcvd */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = "iOS StyleKit.pcvd"; sourceTree = "<group>"; };
 		015DC1DD2D68DD85004EE8C9 /* SECURITY.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = SECURITY.md; sourceTree = "<group>"; };
 		015DC1DE2D68DD85004EE8C9 /* swiftgen.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
@@ -1008,6 +1011,7 @@
 				598E86D12BF4D97800FC5438 /* WireUtilitiesSupport.framework in Frameworks */,
 				59C951C22E2B67E3002C0A3E /* WireLoggingSupport in Frameworks */,
 				591B6E1C2C8B0964009F8A7B /* WireDataModelSupport.framework in Frameworks */,
+				FADE000000000000000000A2 /* WireDomainSupport.framework in Frameworks */,
 				595BE7A42E32367F00ED9088 /* WireAnalyticsSupport in Frameworks */,
 				5996E8AD2C19D0DF007A52F0 /* WireTesting.framework in Frameworks */,
 			);
@@ -1028,6 +1032,7 @@
 				E6C25FC52AFFAAC300406A1C /* WireTesting.framework in Frameworks */,
 				59B768432D2D58BE007B5F1E /* WireFoundationSupport in Frameworks */,
 				591B6E242C8B0970009F8A7B /* WireDataModelSupport.framework in Frameworks */,
+				FADE000000000000000000A3 /* WireDomainSupport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1187,6 +1192,7 @@
 				EE33C48C296485FA00C058D1 /* WireShareEngine.framework */,
 				EE67F739296F0E28001D7C88 /* WireSyncEngine.framework */,
 				0145AE982B1156FC0097E3B8 /* WireSyncEngineSupport.framework */,
+				FADE000000000000000000A1 /* WireDomainSupport.framework */,
 				EEE25B4329719C950008B894 /* WireSystem.framework */,
 				598E86F62BF4DD5C00FC5438 /* WireSystemSupport.framework */,
 				E6C25FC42AFFAAC300406A1C /* WireTesting.framework */,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceDetailsViewActionsHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceDetailsViewActionsHandler.swift
@@ -90,8 +90,11 @@ final class DeviceDetailsViewActionsHandler: DeviceDetailsViewActions, Observabl
         }
     }
 
-    func resetSession() {
-        userClient.resetSession()
+    @MainActor
+    func resetSession() async {
+        isProcessing?(true)
+        await userSession.resetProteusSession.invoke(userClient: userClient)
+        isProcessing?(false)
     }
 
     @MainActor

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceInfoViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceInfoViewModel.swift
@@ -30,7 +30,7 @@ protocol DeviceDetailsViewActions {
     /// - Returns: Certificate chain of all the clients
     func enrollClient() async throws -> String
     func removeDevice() async -> Bool
-    func resetSession()
+    func resetSession() async
     func updateVerified(_ value: Bool) async -> Bool
     func copyToClipboard(_ value: String)
     func downloadE2EIdentityCertificate(certificate: E2eIdentityCertificate)
@@ -97,6 +97,7 @@ final class DeviceInfoViewModel: ObservableObject {
     @Published var isActionInProgress: Bool = false
     @Published var proteusKeyFingerprint: String = ""
     @Published var showEnrollmentCertificateError = false
+    @Published var showResetSessionSuccess = false
 
     var actionsHandler: DeviceDetailsViewActions
     var conversationClientDetailsActions: ConversationUserClientDetailsActions
@@ -154,8 +155,10 @@ final class DeviceInfoViewModel: ObservableObject {
         shouldDismiss = await actionsHandler.removeDevice()
     }
 
-    func resetSession() {
-        actionsHandler.resetSession()
+    @MainActor
+    func resetSession() async {
+        await actionsHandler.resetSession()
+        showResetSessionSuccess = true
     }
 
     @MainActor

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/Components/DeviceDetailsBottomView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/Components/DeviceDetailsBottomView.swift
@@ -34,7 +34,9 @@ struct DeviceDetailsBottomView: View {
     var resetSessionView: some View {
         HStack {
             Button {
-                viewModel.resetSession()
+                Task {
+                    await viewModel.resetSession()
+                }
             } label: {
                 Text(L10n.Localizable.Profile.Devices.Detail.ResetSession.title)
                     .padding(.all, ViewConstants.Padding.standard)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/DeviceDetailsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/DeviceDetailsView.swift
@@ -130,7 +130,7 @@ struct DeviceDetailsView: View {
             L10n.Localizable.Self.Settings.DeviceDetails.ResetSession.success,
             isPresented: $viewModel.showResetSessionSuccess
         ) {
-            Button(L10n.Localizable.General.ok) {}
+            Button(L10n.Localizable.General.ok) { /* dismisses automatically */ }
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/DeviceDetailsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/DeviceDetailsView.swift
@@ -30,6 +30,7 @@ struct DeviceDetailsView: View {
     @ObservedObject private(set) var viewModel: DeviceInfoViewModel
     @State private var isCertificateViewPresented = false
     @State private var didEnrollCertificateFail = false
+    @State private var didResetSession = false
 
     @ViewBuilder var e2eIdentityCertificateView: some View {
         VStack(alignment: .leading) {
@@ -110,6 +111,9 @@ struct DeviceDetailsView: View {
         .onReceive(viewModel.$showEnrollmentCertificateError, perform: { _ in
             didEnrollCertificateFail = viewModel.showEnrollmentCertificateError
         })
+        .onReceive(viewModel.$showResetSessionSuccess, perform: { showSuccess in
+            didResetSession = showSuccess
+        })
         .sheet(isPresented: $isCertificateViewPresented) {
             if let certificate = viewModel.e2eIdentityCertificate {
                 E2EIdentityCertificateDetailsView(
@@ -124,6 +128,14 @@ struct DeviceDetailsView: View {
         .alert(E2ei.Error.Alert.title, isPresented: $didEnrollCertificateFail) {
             Button(L10n.Localizable.General.ok) {
                 didEnrollCertificateFail = false
+            }
+        }
+        .alert(
+            L10n.Localizable.Self.Settings.DeviceDetails.ResetSession.success,
+            isPresented: $didResetSession
+        ) {
+            Button(L10n.Localizable.General.ok) {
+                viewModel.showResetSessionSuccess = false
             }
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/DeviceDetailsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/DeviceDetailsView.swift
@@ -30,7 +30,6 @@ struct DeviceDetailsView: View {
     @ObservedObject private(set) var viewModel: DeviceInfoViewModel
     @State private var isCertificateViewPresented = false
     @State private var didEnrollCertificateFail = false
-    @State private var didResetSession = false
 
     @ViewBuilder var e2eIdentityCertificateView: some View {
         VStack(alignment: .leading) {
@@ -111,9 +110,6 @@ struct DeviceDetailsView: View {
         .onReceive(viewModel.$showEnrollmentCertificateError, perform: { _ in
             didEnrollCertificateFail = viewModel.showEnrollmentCertificateError
         })
-        .onReceive(viewModel.$showResetSessionSuccess, perform: { showSuccess in
-            didResetSession = showSuccess
-        })
         .sheet(isPresented: $isCertificateViewPresented) {
             if let certificate = viewModel.e2eIdentityCertificate {
                 E2EIdentityCertificateDetailsView(
@@ -132,11 +128,9 @@ struct DeviceDetailsView: View {
         }
         .alert(
             L10n.Localizable.Self.Settings.DeviceDetails.ResetSession.success,
-            isPresented: $didResetSession
+            isPresented: $viewModel.showResetSessionSuccess
         ) {
-            Button(L10n.Localizable.General.ok) {
-                viewModel.showResetSessionSuccess = false
-            }
+            Button(L10n.Localizable.General.ok) {}
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -307,8 +307,13 @@ final class SettingsClientViewController: UIViewController,
 
         switch clientSection {
         case .resetSession:
-            userClient.resetSession()
             activityIndicator.start()
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                await userSession.resetProteusSession.invoke(userClient: userClient)
+                activityIndicator.stop()
+                presentResetSessionSuccessAlert()
+            }
 
         case .removeDevice:
             removalObserver = nil
@@ -405,24 +410,23 @@ final class SettingsClientViewController: UIViewController,
         if let tableView {
             tableView.reloadData()
         }
+    }
 
-        if changeInfo.sessionHasBeenReset {
-            activityIndicator.stop()
-            let alert = UIAlertController(
-                title: "",
-                message: L10n.Localizable.Self.Settings.DeviceDetails.ResetSession.success,
-                preferredStyle: .alert
-            )
-            let okAction = UIAlertAction(
-                title: L10n.Localizable.General.ok,
-                style: .default,
-                handler: { [unowned alert] _ in
-                    alert.dismiss(animated: true, completion: .none)
-                }
-            )
-            alert.addAction(okAction)
-            present(alert, animated: true, completion: .none)
-        }
+    private func presentResetSessionSuccessAlert() {
+        let alert = UIAlertController(
+            title: "",
+            message: L10n.Localizable.Self.Settings.DeviceDetails.ResetSession.success,
+            preferredStyle: .alert
+        )
+        let okAction = UIAlertAction(
+            title: L10n.Localizable.General.ok,
+            style: .default,
+            handler: { [unowned alert] _ in
+                alert.dismiss(animated: true, completion: .none)
+            }
+        )
+        alert.addAction(okAction)
+        present(alert, animated: true, completion: .none)
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Devices/OtherUserDeviceDetailsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Devices/OtherUserDeviceDetailsView.swift
@@ -26,6 +26,7 @@ struct OtherUserDeviceDetailsView: View {
 
     @ObservedObject var viewModel: DeviceInfoViewModel
     @State private var isCertificateViewPresented: Bool = false
+    @State private var didResetSession = false
 
     private var e2eIdentityCertificateView: some View {
         VStack(alignment: .leading) {
@@ -136,6 +137,9 @@ struct OtherUserDeviceDetailsView: View {
                 dismiss()
             }
         }
+        .onReceive(viewModel.$showResetSessionSuccess, perform: { showSuccess in
+            didResetSession = showSuccess
+        })
         .sheet(isPresented: $isCertificateViewPresented) {
             if let certificate = viewModel.e2eIdentityCertificate {
                 E2EIdentityCertificateDetailsView(
@@ -145,6 +149,14 @@ struct OtherUserDeviceDetailsView: View {
                     performDownload: viewModel.downloadE2EIdentityCertificate,
                     performCopy: viewModel.copyToClipboard
                 )
+            }
+        }
+        .alert(
+            L10n.Localizable.Self.Settings.DeviceDetails.ResetSession.success,
+            isPresented: $didResetSession
+        ) {
+            Button(L10n.Localizable.General.ok) {
+                viewModel.showResetSessionSuccess = false
             }
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Devices/OtherUserDeviceDetailsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Devices/OtherUserDeviceDetailsView.swift
@@ -26,7 +26,6 @@ struct OtherUserDeviceDetailsView: View {
 
     @ObservedObject var viewModel: DeviceInfoViewModel
     @State private var isCertificateViewPresented: Bool = false
-    @State private var didResetSession = false
 
     private var e2eIdentityCertificateView: some View {
         VStack(alignment: .leading) {
@@ -137,9 +136,6 @@ struct OtherUserDeviceDetailsView: View {
                 dismiss()
             }
         }
-        .onReceive(viewModel.$showResetSessionSuccess, perform: { showSuccess in
-            didResetSession = showSuccess
-        })
         .sheet(isPresented: $isCertificateViewPresented) {
             if let certificate = viewModel.e2eIdentityCertificate {
                 E2EIdentityCertificateDetailsView(
@@ -153,11 +149,9 @@ struct OtherUserDeviceDetailsView: View {
         }
         .alert(
             L10n.Localizable.Self.Settings.DeviceDetails.ResetSession.success,
-            isPresented: $didResetSession
+            isPresented: $viewModel.showResetSessionSuccess
         ) {
-            Button(L10n.Localizable.General.ok) {
-                viewModel.showResetSessionSuccess = false
-            }
+            Button(L10n.Localizable.General.ok) {}
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Devices/OtherUserDeviceDetailsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Devices/OtherUserDeviceDetailsView.swift
@@ -151,7 +151,7 @@ struct OtherUserDeviceDetailsView: View {
             L10n.Localizable.Self.Settings.DeviceDetails.ResetSession.success,
             isPresented: $viewModel.showResetSessionSuccess
         ) {
-            Button(L10n.Localizable.General.ok) {}
+            Button(L10n.Localizable.General.ok) { /* dismiss automatically */ }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26033" title="WPB-26033" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26033</a>  [iOS] If one tries to reset a session of the device, it can appear to the user as if the button has no function because no feedback is shown.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

* Moved logic to own usecase
* Update UIKit usage
* Added alert to notify user the action was done on SwiftUI view

### Testing

2 scenarios:
1. tap on reset session on other devices
2. tap on reset session on self other device

**Note:** the unit tests might be blocked by the fixed on https://github.com/wireapp/wire-ios/pull/4832/changes. Some tests on 4.16 branch are flaky

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
