### PR TITLE
fix: silence in-app ringtone on inactive accounts - WPB-20468

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -167,6 +167,13 @@ public protocol SessionManagerSwitchingDelegate: AnyObject {
     func confirmSwitchingAccount(completion: @escaping (Bool) -> Void)
 }
 
+public extension Notification.Name {
+    /// Posted by `SessionManager` after the active user session changes. The notification's
+    /// `object` is the new active `ZMUserSession?` (may be `nil`).
+    static let sessionManagerActiveUserSessionDidChange = Notification
+        .Name("SessionManagerActiveUserSessionDidChange")
+}
+
 @objc
 public protocol ForegroundNotificationResponder: AnyObject {
     @MainActor
@@ -295,6 +302,11 @@ public final class SessionManager: NSObject, SessionManagerType {
             requireInternal(oldSession === $0.activeUserSession, "Invalid state updating active user session")
             $0.activeUserSession = newSession
         }
+
+        NotificationCenter.default.post(
+            name: .sessionManagerActiveUserSessionDidChange,
+            object: newSession
+        )
     }
 
     public var backgroundUserSessions: [UUID: ZMUserSession] {

--- a/wire-ios/Wire-iOS/Sources/Managers/SoundEventListener.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/SoundEventListener.swift
@@ -59,6 +59,10 @@ final class SoundEventListener: NSObject {
     var callStateObserverToken: Any?
     var networkAvailabilityObserverToken: Any?
 
+    // Tracks whether THIS listener started a ringtone, so that stop calls don't
+    // silence ringtones started by another session's listener (AVSMediaManager is a singleton).
+    private var didStartRingtone = false
+
     init(userSession: ZMUserSession) {
         self.userSession = userSession
         super.init()
@@ -85,6 +89,12 @@ final class SoundEventListener: NSObject {
             name: UIApplication.didEnterBackgroundNotification,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(activeUserSessionDidChange(_:)),
+            name: .sessionManagerActiveUserSessionDidChange,
+            object: nil
+        )
 
         soundEventWatchDog.startIgnoreDate = Date()
         soundEventWatchDog.isMuted = UIApplication.shared.applicationState == .background
@@ -93,6 +103,70 @@ final class SoundEventListener: NSObject {
     func playSoundIfAllowed(_ mediaManagerSound: MediaManagerSound) {
         guard soundEventWatchDog.outputAllowed else { return }
         AVSMediaManager.sharedInstance()?.play(sound: mediaManagerSound)
+    }
+
+    private func startRingtone(_ sound: MediaManagerSound) {
+        playSoundIfAllowed(sound)
+        didStartRingtone = true
+    }
+
+    private func stopRingtonesIfStarted() {
+        guard didStartRingtone else { return }
+        let mediaManager = AVSMediaManager.sharedInstance()
+        mediaManager?.stop(sound: .ringingFromThemInCallSound)
+        mediaManager?.stop(sound: .ringingFromThemSound)
+        didStartRingtone = false
+    }
+
+    private func startRingtoneIfAppropriate(
+        for session: ZMUserSession,
+        conversation: ZMConversation,
+        conversationId: AVSIdentifier,
+        callCenter: WireCallCenterV3
+    ) {
+        // Only ring in-app for the active session. For inactive accounts the
+        // system notification's sound is the audible signal.
+        guard let sessionManager = SessionManager.shared,
+              conversation.mutedMessageTypesIncludingAvailability == .none,
+              session === sessionManager.activeUserSession
+        else { return }
+
+        let otherNonIdleCalls = callCenter.nonIdleCalls.filter { (key: AVSIdentifier, _) -> Bool in
+            return key != conversationId
+        }
+
+        if !otherNonIdleCalls.isEmpty {
+            startRingtone(.ringingFromThemInCallSound)
+        } else if sessionManager.callNotificationStyle != .callKit {
+            startRingtone(.ringingFromThemSound)
+        }
+    }
+
+    @objc
+    private func activeUserSessionDidChange(_ notification: Notification) {
+        guard let userSession else { return }
+        let newActiveSession = notification.object as? ZMUserSession
+
+        if newActiveSession === userSession {
+            // This session just became active — start the ringtone if a call is ringing.
+            guard let callCenter = userSession.callCenter else { return }
+            let ringingConversation = callCenter.nonIdleCallConversations(in: userSession).first { conversation in
+                guard case .incoming(_, shouldRing: true, _) = conversation.voiceChannel?.state else { return false }
+                return conversation.mutedMessageTypesIncludingAvailability == .none
+            }
+            guard let conversation = ringingConversation,
+                  let conversationId = conversation.avsIdentifier
+            else { return }
+            startRingtoneIfAppropriate(
+                for: userSession,
+                conversation: conversation,
+                conversationId: conversationId,
+                callCenter: callCenter
+            )
+        } else if didStartRingtone {
+            // This session is no longer active — stop the ringtone we started.
+            stopRingtonesIfStarted()
+        }
     }
 
     func provideHapticFeedback(for message: ZMConversationMessage) {
@@ -165,8 +239,7 @@ extension SoundEventListener: WireCallCenterCallStateObserver {
         previousCallState: CallState?
     ) {
 
-        guard let mediaManager = AVSMediaManager.sharedInstance(),
-              let userSession,
+        guard let userSession,
               let callCenter = userSession.callCenter,
               let conversationId = conversation.avsIdentifier
         else {
@@ -178,21 +251,14 @@ extension SoundEventListener: WireCallCenterCallStateObserver {
 
         switch callState {
         case .incoming(isVideo: _, shouldRing: true, degraded: _):
-            guard let sessionManager = SessionManager.shared,
-                  conversation.mutedMessageTypesIncludingAvailability == .none else { return }
-
-            let otherNonIdleCalls = callCenter.nonIdleCalls.filter { (key: AVSIdentifier, _) -> Bool in
-                return key != conversationId
-            }
-
-            if !otherNonIdleCalls.isEmpty {
-                playSoundIfAllowed(.ringingFromThemInCallSound)
-            } else if sessionManager.callNotificationStyle != .callKit {
-                playSoundIfAllowed(.ringingFromThemSound)
-            }
+            startRingtoneIfAppropriate(
+                for: userSession,
+                conversation: conversation,
+                conversationId: conversationId,
+                callCenter: callCenter
+            )
         case .incoming(isVideo: _, shouldRing: false, degraded: _):
-            mediaManager.stop(sound: .ringingFromThemInCallSound)
-            mediaManager.stop(sound: .ringingFromThemSound)
+            stopRingtonesIfStarted()
         case let .terminating(reason: reason):
             switch reason {
             case .normal, .canceled:
@@ -212,8 +278,7 @@ extension SoundEventListener: WireCallCenterCallStateObserver {
                 return
             }
 
-            mediaManager.stop(sound: .ringingFromThemInCallSound)
-            mediaManager.stop(sound: .ringingFromThemSound)
+            stopRingtonesIfStarted()
         }
 
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20468" title="WPB-20468" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20468</a>  [iOS] Accepting call on 2nd account doesn't open calling UI but only show green banner on top with connected timer in the conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

- Gate `SoundEventListener` ringtone playback on the active session. Inactive accounts no longer play the in-app ringtone for incoming calls — the system notification's sound is the audible signal for them.
- When this session becomes the active one (e.g. after the user switches accounts), re-evaluate call state and start the ringtone if a call is still ringing. When the session loses active status while ringing, stop the ringtone.
- Track `didStartRingtone` per listener so that one session's call-end doesn't silence another session's active ringtone (`AVSMediaManager` is a singleton).
- Adds `Notification.Name.sessionManagerActiveUserSessionDidChange`, posted from `SessionManager.setActiveUserSession`, consumed by `SoundEventListener`.

### Testing

- Two accounts, CallKit disabled. Active on A. Trigger an incoming call to B. Confirm: system notification sound plays once, no in-app ringtone overlap, no persistent in-app ringtone while still on A.
- Tap the notification (default tap). Switch to B. Confirm: in-app ringtone starts on B as the call UI appears.
- Accept/decline from the call UI. Confirm: ringtone stops.
- Active on A, call ringing on A (in-app ringtone playing). Switch to B (no call on B). Confirm: A's ringtone stops on switch.
- Active on A with a call established, second incoming call on B. Confirm: A's call audio is unaffected by B's call lifecycle.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
