### PR TITLE
fix: present incoming call UI after account switch - WPB-20468

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+Push.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+Push.swift
@@ -163,6 +163,10 @@ public extension SessionManager {
         }
     }
 
+    func activateAccount(of session: ZMUserSession) {
+        activateAccount(for: session) {}
+    }
+
     func showUserProfile(user: UserType) {
         presentationDelegate?.showUserProfile(user: user)
     }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -167,6 +167,13 @@ public protocol SessionManagerSwitchingDelegate: AnyObject {
     func confirmSwitchingAccount(completion: @escaping (Bool) -> Void)
 }
 
+public extension Notification.Name {
+    /// Posted by `SessionManager` after the active user session changes. The notification's
+    /// `object` is the new active `ZMUserSession?` (may be `nil`).
+    static let sessionManagerActiveUserSessionDidChange = Notification
+        .Name("SessionManagerActiveUserSessionDidChange")
+}
+
 @objc
 public protocol ForegroundNotificationResponder: AnyObject {
     @MainActor
@@ -295,6 +302,11 @@ public final class SessionManager: NSObject, SessionManagerType {
             requireInternal(oldSession === $0.activeUserSession, "Invalid state updating active user session")
             $0.activeUserSession = newSession
         }
+
+        NotificationCenter.default.post(
+            name: .sessionManagerActiveUserSessionDidChange,
+            object: newSession
+        )
     }
 
     public var backgroundUserSessions: [UUID: ZMUserSession] {

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -172,13 +172,6 @@ public protocol SessionManagerSwitchingDelegate: AnyObject {
     func confirmSwitchingAccount(completion: @escaping (Bool) -> Void)
 }
 
-public extension Notification.Name {
-    /// Posted by `SessionManager` after the active user session changes. The notification's
-    /// `object` is the new active `ZMUserSession?` (may be `nil`).
-    static let sessionManagerActiveUserSessionDidChange = Notification
-        .Name("SessionManagerActiveUserSessionDidChange")
-}
-
 @objc
 public protocol ForegroundNotificationResponder: AnyObject {
     @MainActor
@@ -307,11 +300,6 @@ public final class SessionManager: NSObject, SessionManagerType {
             requireInternal(oldSession === $0.activeUserSession, "Invalid state updating active user session")
             $0.activeUserSession = newSession
         }
-
-        NotificationCenter.default.post(
-            name: .sessionManagerActiveUserSessionDidChange,
-            object: newSession
-        )
     }
 
     public var backgroundUserSessions: [UUID: ZMUserSession] {

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -152,6 +152,11 @@ public protocol SessionManagerType: AnyObject {
     /// Switch account and and ask UI to navigate to the conversation list
     func showConversationList(in session: ZMUserSession)
 
+    /// Switch to the given session's account without triggering any in-app navigation.
+    /// Use when post-activation flows (e.g. presenting an incoming-call UI) should drive
+    /// what the user sees next, rather than navigating to a specific conversation.
+    func activateAccount(of session: ZMUserSession)
+
     /// ask UI to open the profile of a user
     func showUserProfile(user: WireDataModel.UserType)
 
@@ -165,6 +170,13 @@ public protocol SessionManagerType: AnyObject {
 @objc
 public protocol SessionManagerSwitchingDelegate: AnyObject {
     func confirmSwitchingAccount(completion: @escaping (Bool) -> Void)
+}
+
+public extension Notification.Name {
+    /// Posted by `SessionManager` after the active user session changes. The notification's
+    /// `object` is the new active `ZMUserSession?` (may be `nil`).
+    static let sessionManagerActiveUserSessionDidChange = Notification
+        .Name("SessionManagerActiveUserSessionDidChange")
 }
 
 @objc
@@ -295,6 +307,11 @@ public final class SessionManager: NSObject, SessionManagerType {
             requireInternal(oldSession === $0.activeUserSession, "Invalid state updating active user session")
             $0.activeUserSession = newSession
         }
+
+        NotificationCenter.default.post(
+            name: .sessionManagerActiveUserSessionDidChange,
+            object: newSession
+        )
     }
 
     public var backgroundUserSessions: [UUID: ZMUserSession] {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Push.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Push.swift
@@ -206,11 +206,23 @@ extension ZMUserSession {
         // TODO: [WPB-17220] new NSE - callback action is currently broken - disabling this action for now
 //        case NotificationActionIdentifier.callbackIdentifier:
 //            callback(with: userInfo, completionHandler: completionHandler)
+        case UNNotificationDefaultActionIdentifier where Self.isIncomingCallCategory(categoryIdentifier):
+            // Default tap on an incoming-call notification: switch to this session's account
+            // but do not navigate to the conversation. The post-activation flow
+            // (AppRootRouter `.authenticated` → updateActiveCallPresentationState) will
+            // present the incoming-call UI.
+            sessionManager?.activateAccount(of: self)
+            completionHandler()
         default:
             showContent(for: userInfo)
             completionHandler()
         }
 
+    }
+
+    private static func isIncomingCallCategory(_ categoryIdentifier: String) -> Bool {
+        categoryIdentifier == WireDomain.NotificationCategory.incomingCall.rawValue
+            || categoryIdentifier == PushNotificationCategory.incomingCall.rawValue
     }
 
 }

--- a/wire-ios-sync-engine/Tests/Source/MockSessionManager.swift
+++ b/wire-ios-sync-engine/Tests/Source/MockSessionManager.swift
@@ -59,6 +59,11 @@ class MockSessionManager: NSObject, WireSyncEngine.SessionManagerType {
         lastRequestToShowConversationsList = session
     }
 
+    var lastRequestToActivateAccount: ZMUserSession?
+    func activateAccount(of session: ZMUserSession) {
+        lastRequestToActivateAccount = session
+    }
+
     func showUserProfile(user: UserType) {
         lastRequestToShowUserProfile = user
     }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import UserNotifications
 import WireDataModelSupport
 import XCTest
 
@@ -197,6 +198,39 @@ final class ZMUserSessionTests_PushNotifications: ZMUserSessionTestsBase {
         // then
         XCTAssertTrue(callCenter.didCallRejectCall)
         XCTAssertNil(mockSessionManager.lastRequestToShowConversation)
+    }
+
+    func testThatItActivatesAccountAndDoesNotShowConversation_ForDefaultTapOnIncomingCallNotification() {
+        // given
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            self.createSelfClient()
+        }
+
+        let userInfo = userInfoWithConversation()
+        let conversation = userInfo.conversation(in: uiMOC)!
+
+        let callCenter = syncMOC.performAndWait {
+            self.createCallCenter(
+                localDomain: "wire.com",
+                isFederationEnabled: false
+            )
+        }
+        simulateIncomingCall(fromUser: conversation.connectedUser!, conversation: conversation)
+
+        // when
+        handle(
+            action: UNNotificationDefaultActionIdentifier,
+            category: Category.incomingCall.rawValue,
+            userInfo: userInfo
+        )
+
+        // then
+        XCTAssertEqual(mockSessionManager.lastRequestToActivateAccount, sut)
+        XCTAssertNil(mockSessionManager.lastRequestToShowConversation)
+        XCTAssertNil(mockSessionManager.lastRequestToShowConversationsList)
+        XCTAssertFalse(callCenter.didCallAnswerCall)
+        XCTAssertFalse(callCenter.didCallRejectCall)
     }
 
     func testThatItCallsShowConversationButDoesNotCallBack_ForPushNotificationCategoryMissedCallWithCallBackAction() {

--- a/wire-ios/Wire-iOS/Sources/Managers/SoundEventListener.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/SoundEventListener.swift
@@ -59,6 +59,10 @@ final class SoundEventListener: NSObject {
     var callStateObserverToken: Any?
     var networkAvailabilityObserverToken: Any?
 
+    // Tracks whether THIS listener started a ringtone, so that stop calls don't
+    // silence ringtones started by another session's listener (AVSMediaManager is a singleton).
+    private var didStartRingtone = false
+
     init(userSession: ZMUserSession) {
         self.userSession = userSession
         super.init()
@@ -85,6 +89,12 @@ final class SoundEventListener: NSObject {
             name: UIApplication.didEnterBackgroundNotification,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(activeUserSessionDidChange(_:)),
+            name: .sessionManagerActiveUserSessionDidChange,
+            object: nil
+        )
 
         soundEventWatchDog.startIgnoreDate = Date()
         soundEventWatchDog.isMuted = UIApplication.shared.applicationState == .background
@@ -93,6 +103,70 @@ final class SoundEventListener: NSObject {
     func playSoundIfAllowed(_ mediaManagerSound: MediaManagerSound) {
         guard soundEventWatchDog.outputAllowed else { return }
         AVSMediaManager.sharedInstance()?.play(sound: mediaManagerSound)
+    }
+
+    private func startRingtone(_ sound: MediaManagerSound) {
+        playSoundIfAllowed(sound)
+        didStartRingtone = true
+    }
+
+    private func stopRingtonesIfStarted() {
+        guard didStartRingtone else { return }
+        let mediaManager = AVSMediaManager.sharedInstance()
+        mediaManager?.stop(sound: .ringingFromThemInCallSound)
+        mediaManager?.stop(sound: .ringingFromThemSound)
+        didStartRingtone = false
+    }
+
+    private func startRingtoneIfAppropriate(
+        for session: ZMUserSession,
+        conversation: ZMConversation,
+        conversationId: AVSIdentifier,
+        callCenter: WireCallCenterV3
+    ) {
+        // Only ring in-app for the active session. For inactive accounts the
+        // system notification's sound is the audible signal.
+        guard let sessionManager = SessionManager.shared,
+              conversation.mutedMessageTypesIncludingAvailability == .none,
+              session === sessionManager.activeUserSession
+        else { return }
+
+        let otherNonIdleCalls = callCenter.nonIdleCalls.filter { (key: AVSIdentifier, _) -> Bool in
+            return key != conversationId
+        }
+
+        if !otherNonIdleCalls.isEmpty {
+            startRingtone(.ringingFromThemInCallSound)
+        } else if sessionManager.callNotificationStyle != .callKit {
+            startRingtone(.ringingFromThemSound)
+        }
+    }
+
+    @objc
+    private func activeUserSessionDidChange(_ notification: Notification) {
+        guard let userSession else { return }
+        let newActiveSession = notification.object as? ZMUserSession
+
+        if newActiveSession === userSession {
+            // This session just became active — start the ringtone if a call is ringing.
+            guard let callCenter = userSession.callCenter else { return }
+            let ringingConversation = callCenter.nonIdleCallConversations(in: userSession).first { conversation in
+                guard case .incoming(_, shouldRing: true, _) = conversation.voiceChannel?.state else { return false }
+                return conversation.mutedMessageTypesIncludingAvailability == .none
+            }
+            guard let conversation = ringingConversation,
+                  let conversationId = conversation.avsIdentifier
+            else { return }
+            startRingtoneIfAppropriate(
+                for: userSession,
+                conversation: conversation,
+                conversationId: conversationId,
+                callCenter: callCenter
+            )
+        } else if didStartRingtone {
+            // This session is no longer active — stop the ringtone we started.
+            stopRingtonesIfStarted()
+        }
     }
 
     func provideHapticFeedback(for message: ZMConversationMessage) {
@@ -165,8 +239,7 @@ extension SoundEventListener: WireCallCenterCallStateObserver {
         previousCallState: CallState?
     ) {
 
-        guard let mediaManager = AVSMediaManager.sharedInstance(),
-              let userSession,
+        guard let userSession,
               let callCenter = userSession.callCenter,
               let conversationId = conversation.avsIdentifier
         else {
@@ -178,21 +251,14 @@ extension SoundEventListener: WireCallCenterCallStateObserver {
 
         switch callState {
         case .incoming(isVideo: _, shouldRing: true, degraded: _):
-            guard let sessionManager = SessionManager.shared,
-                  conversation.mutedMessageTypesIncludingAvailability == .none else { return }
-
-            let otherNonIdleCalls = callCenter.nonIdleCalls.filter { (key: AVSIdentifier, _) -> Bool in
-                return key != conversationId
-            }
-
-            if !otherNonIdleCalls.isEmpty {
-                playSoundIfAllowed(.ringingFromThemInCallSound)
-            } else if sessionManager.callNotificationStyle != .callKit {
-                playSoundIfAllowed(.ringingFromThemSound)
-            }
+            startRingtoneIfAppropriate(
+                for: userSession,
+                conversation: conversation,
+                conversationId: conversationId,
+                callCenter: callCenter
+            )
         case .incoming(isVideo: _, shouldRing: false, degraded: _):
-            mediaManager.stop(sound: .ringingFromThemInCallSound)
-            mediaManager.stop(sound: .ringingFromThemSound)
+            stopRingtonesIfStarted()
         case let .terminating(reason: reason):
             switch reason {
             case .normal, .canceled:
@@ -212,8 +278,7 @@ extension SoundEventListener: WireCallCenterCallStateObserver {
                 return
             }
 
-            mediaManager.stop(sound: .ringingFromThemInCallSound)
-            mediaManager.stop(sound: .ringingFromThemSound)
+            stopRingtonesIfStarted()
         }
 
     }

--- a/wire-ios/Wire-iOS/Sources/Managers/SoundEventListener.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/SoundEventListener.swift
@@ -59,10 +59,6 @@ final class SoundEventListener: NSObject {
     var callStateObserverToken: Any?
     var networkAvailabilityObserverToken: Any?
 
-    // Tracks whether THIS listener started a ringtone, so that stop calls don't
-    // silence ringtones started by another session's listener (AVSMediaManager is a singleton).
-    private var didStartRingtone = false
-
     init(userSession: ZMUserSession) {
         self.userSession = userSession
         super.init()
@@ -89,12 +85,6 @@ final class SoundEventListener: NSObject {
             name: UIApplication.didEnterBackgroundNotification,
             object: nil
         )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(activeUserSessionDidChange(_:)),
-            name: .sessionManagerActiveUserSessionDidChange,
-            object: nil
-        )
 
         soundEventWatchDog.startIgnoreDate = Date()
         soundEventWatchDog.isMuted = UIApplication.shared.applicationState == .background
@@ -103,70 +93,6 @@ final class SoundEventListener: NSObject {
     func playSoundIfAllowed(_ mediaManagerSound: MediaManagerSound) {
         guard soundEventWatchDog.outputAllowed else { return }
         AVSMediaManager.sharedInstance()?.play(sound: mediaManagerSound)
-    }
-
-    private func startRingtone(_ sound: MediaManagerSound) {
-        playSoundIfAllowed(sound)
-        didStartRingtone = true
-    }
-
-    private func stopRingtonesIfStarted() {
-        guard didStartRingtone else { return }
-        let mediaManager = AVSMediaManager.sharedInstance()
-        mediaManager?.stop(sound: .ringingFromThemInCallSound)
-        mediaManager?.stop(sound: .ringingFromThemSound)
-        didStartRingtone = false
-    }
-
-    private func startRingtoneIfAppropriate(
-        for session: ZMUserSession,
-        conversation: ZMConversation,
-        conversationId: AVSIdentifier,
-        callCenter: WireCallCenterV3
-    ) {
-        // Only ring in-app for the active session. For inactive accounts the
-        // system notification's sound is the audible signal.
-        guard let sessionManager = SessionManager.shared,
-              conversation.mutedMessageTypesIncludingAvailability == .none,
-              session === sessionManager.activeUserSession
-        else { return }
-
-        let otherNonIdleCalls = callCenter.nonIdleCalls.filter { (key: AVSIdentifier, _) -> Bool in
-            return key != conversationId
-        }
-
-        if !otherNonIdleCalls.isEmpty {
-            startRingtone(.ringingFromThemInCallSound)
-        } else if sessionManager.callNotificationStyle != .callKit {
-            startRingtone(.ringingFromThemSound)
-        }
-    }
-
-    @objc
-    private func activeUserSessionDidChange(_ notification: Notification) {
-        guard let userSession else { return }
-        let newActiveSession = notification.object as? ZMUserSession
-
-        if newActiveSession === userSession {
-            // This session just became active — start the ringtone if a call is ringing.
-            guard let callCenter = userSession.callCenter else { return }
-            let ringingConversation = callCenter.nonIdleCallConversations(in: userSession).first { conversation in
-                guard case .incoming(_, shouldRing: true, _) = conversation.voiceChannel?.state else { return false }
-                return conversation.mutedMessageTypesIncludingAvailability == .none
-            }
-            guard let conversation = ringingConversation,
-                  let conversationId = conversation.avsIdentifier
-            else { return }
-            startRingtoneIfAppropriate(
-                for: userSession,
-                conversation: conversation,
-                conversationId: conversationId,
-                callCenter: callCenter
-            )
-        } else if didStartRingtone {
-            // This session is no longer active — stop the ringtone we started.
-            stopRingtonesIfStarted()
-        }
     }
 
     func provideHapticFeedback(for message: ZMConversationMessage) {
@@ -239,7 +165,8 @@ extension SoundEventListener: WireCallCenterCallStateObserver {
         previousCallState: CallState?
     ) {
 
-        guard let userSession,
+        guard let mediaManager = AVSMediaManager.sharedInstance(),
+              let userSession,
               let callCenter = userSession.callCenter,
               let conversationId = conversation.avsIdentifier
         else {
@@ -251,14 +178,21 @@ extension SoundEventListener: WireCallCenterCallStateObserver {
 
         switch callState {
         case .incoming(isVideo: _, shouldRing: true, degraded: _):
-            startRingtoneIfAppropriate(
-                for: userSession,
-                conversation: conversation,
-                conversationId: conversationId,
-                callCenter: callCenter
-            )
+            guard let sessionManager = SessionManager.shared,
+                  conversation.mutedMessageTypesIncludingAvailability == .none else { return }
+
+            let otherNonIdleCalls = callCenter.nonIdleCalls.filter { (key: AVSIdentifier, _) -> Bool in
+                return key != conversationId
+            }
+
+            if !otherNonIdleCalls.isEmpty {
+                playSoundIfAllowed(.ringingFromThemInCallSound)
+            } else if sessionManager.callNotificationStyle != .callKit {
+                playSoundIfAllowed(.ringingFromThemSound)
+            }
         case .incoming(isVideo: _, shouldRing: false, degraded: _):
-            stopRingtonesIfStarted()
+            mediaManager.stop(sound: .ringingFromThemInCallSound)
+            mediaManager.stop(sound: .ringingFromThemSound)
         case let .terminating(reason: reason):
             switch reason {
             case .normal, .canceled:
@@ -278,7 +212,8 @@ extension SoundEventListener: WireCallCenterCallStateObserver {
                 return
             }
 
-            stopRingtonesIfStarted()
+            mediaManager.stop(sound: .ringingFromThemInCallSound)
+            mediaManager.stop(sound: .ringingFromThemSound)
         }
 
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20468" title="WPB-20468" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20468</a>  [iOS] Accepting call on 2nd account doesn't open calling UI but only show green banner on top with connected timer in the conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

- Default tap on an incoming-call notification used to fall through to `showContent`, which navigated to the conversation. That competed with the post-activation call-UI presentation, producing a brief call UI flicker before landing
on the conversation with a visible "Join call" button.
- For default-tap responses on the `incomingCall` category, switch to the target account but skip the conversation navigation. `AppRootRouter`'s `.authenticated` transition then drives `updateActiveCallPresentationState()` to present
the incoming-call UI — the same path used when the call arrives while the account is already active.
- Adds `SessionManagerType.activateAccount(of:)` — a navigation-free account switch — and its `MockSessionManager` counterpart.
- Detects the call category via both the legacy `PushNotificationCategory.incomingCall` ("incomingCallCategory") and the new `WireDomain.NotificationCategory.incomingCall` ("incomingCall") raw values, since both paths produce call
notifications.

### Testing

- Two accounts, CallKit disabled. Active on A; receive an incoming call on B.
- Tap the incoming-call notification (default tap, not the "Ignore" action).
- Confirm: switches to B, presents the incoming-call UI immediately, no flicker, no navigation to the conversation.
- Accept / decline from the call UI — same behavior as if B had been the active account when the call arrived.
- Tap "Ignore" on the notification: call rejected, no UI navigation (existing behavior unaffected).
- Default tap on a regular message notification: still navigates to the conversation (no regression).

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
