### PR TITLE
fix: call UI on CallKit answer for inactive account - WPB-20468

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -1730,14 +1730,17 @@ extension SessionManager: WireCallCenterCallStateObserver {
         guard let moc = conversation.managedObjectContext else { return }
 
         switch callState {
-        case .answered, .outgoing:
+        case .answered:
             let (backgroundUserSessions, activeUserSession) = state.withLockUnchecked { state in
                 (state.backgroundUserSessions, state.activeUserSession)
             }
 
             for (_, session) in backgroundUserSessions
                 where session.managedObjectContext == moc && activeUserSession != session {
-                showConversation(conversation, at: nil, in: session)
+                // Switch to the call's account without navigating to the conversation.
+                // The post-activation flow (AppRootRouter `.authenticated` →
+                // updateActiveCallPresentationState) presents the in-app call UI.
+                activateAccount(of: session)
             }
         default:
             return

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -1730,7 +1730,7 @@ extension SessionManager: WireCallCenterCallStateObserver {
         guard let moc = conversation.managedObjectContext else { return }
 
         switch callState {
-        case .answered:
+        case .answered, .outgoing:
             let (backgroundUserSessions, activeUserSession) = state.withLockUnchecked { state in
                 (state.backgroundUserSessions, state.activeUserSession)
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20468" title="WPB-20468" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20468</a>  [iOS] Accepting call on 2nd account doesn't open calling UI but only show green banner on top with connected timer in the conversation
  </td></table>

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->

### Issue

- Same root cause as the previously-merged [PR](https://github.com/wireapp/wire-ios/pull/4810) (which fixed the
no-CallKit notification-tap path), now applied to the CallKit answer path. 
- When the user taps "Answer" in the CallKit UI for a call on a non-active account, the call transitions to `.answered`.
`SessionManager.callCenterDidChange` observed this and called `showConversation(conversation, at: nil, in: session)` for
any matching background session — which switched the account but *also* navigated to the conversation, dismissing the call
UI right after it briefly appeared.
- Now: `activateAccount(of: session)` switches the account without conversation navigation. `AppRootRouter`'s
`.authenticated` flow + `updateActiveCallPresentationState()` keep the call UI presented — same code path used when the
account was already active when the call arrived.

## Test plan

- [ ] Two accounts, CallKit enabled. Active on A; receive an incoming call on B.
- [ ] Tap "Answer" in the CallKit UI.
- [ ] Confirm: app switches to B, call UI is presented and stays — no flicker, no navigation to the conversation.
- [ ] End the call normally. Confirm post-call return to the previously-visible screen.
- [ ] Tap "Decline" instead of "Answer": call rejected, no UI navigation (existing behavior unaffected).
- [ ] Regression: call arrives on the active account itself, CallKit answer → unchanged from before.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
