### PR TITLE
revert: prevent main app from blocking notification extension (take 3) - WPB-25914

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Components/NSEClientScope.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Components/NSEClientScope.swift
@@ -259,7 +259,8 @@ final class NSEClientScope: Component<NSEClientScopeDependency> {
                 syncContext: coreDataStack.syncContext,
                 coreCryptoKeyMigrationManager: coreCryptoMigrationManager,
                 allowCreation: false,
-                localDomain: localDomain
+                localDomain: localDomain,
+                backgroundTaskManager: nil
             )
         }
     }

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
@@ -62,7 +62,10 @@ final class IncrementalSyncV2Tests: XCTestCase {
         coreCrypto = MockCoreCryptoProtocol()
         coreCrypto.mockTransaction(context: coreCryptoContext)
         coreCryptoProvider = MockCoreCryptoProviderProtocol()
-        coreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: coreCrypto)
+        coreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: coreCrypto
+        )
         journal = Journal(
             userID: UUID(),
             storage: UserDefaults.temporary()

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncV2Tests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncV2Tests.swift
@@ -67,7 +67,10 @@ class PullPendingUpdateEventsSyncV2Tests: XCTestCase {
         )
 
         // Setup mocks
-        coreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: coreCrypto)
+        coreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: coreCrypto
+        )
         decryptor.decryptEventsInContext_MockMethod = { envelope, _ in
             EventDecryptorResult(events: envelope.events, brokenMLSGroupIDs: [Scaffolding.mlsGroupID])
         }

--- a/wire-ios-data-model/Source/Core Crypto/CoreCryptoProvider.swift
+++ b/wire-ios-data-model/Source/Core Crypto/CoreCryptoProvider.swift
@@ -75,6 +75,8 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
     private var epochObserver: WireCoreCryptoUniffi.EpochObserver?
     private let localDomain: String?
 
+    private let backgroundTaskManager: (any BackgroundTaskManager)?
+
     public init(
         selfUserID: UUID,
         sharedContainerURL: URL,
@@ -83,7 +85,8 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
         syncContext: NSManagedObjectContext,
         coreCryptoKeyMigrationManager: CoreCryptoKeyMigrationManagerProtocol,
         allowCreation: Bool = true,
-        localDomain: String?
+        localDomain: String?,
+        backgroundTaskManager: (any BackgroundTaskManager)?
     ) {
         self.selfUserID = selfUserID
         self.sharedContainerURL = sharedContainerURL
@@ -94,12 +97,16 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
         self.coreCryptoKeyMigrationManager = coreCryptoKeyMigrationManager
         self.featureRespository = LegacyFeatureRepository(context: syncContext)
         self.localDomain = localDomain
+        self.backgroundTaskManager = backgroundTaskManager
     }
 
     public func coreCrypto() async throws -> SafeCoreCrypto {
         let coreCrypto = try await getCoreCrypto()
         try await registerMlsTransportIfNecessary(with: coreCrypto)
-        return SafeCoreCrypto(coreCrypto: coreCrypto)
+        return SafeCoreCrypto(
+            backgroundTaskManager: backgroundTaskManager,
+            coreCrypto: coreCrypto
+        )
     }
 
     public func initialiseMLSWithBasicCredentials(mlsClientID: MLSClientID) async throws {

--- a/wire-ios-data-model/Source/Core Crypto/SafeCoreCrypto.swift
+++ b/wire-ios-data-model/Source/Core Crypto/SafeCoreCrypto.swift
@@ -23,9 +23,14 @@ import WireLogging
 /// within a background task (if a task manager is provided).
 public final class SafeCoreCrypto {
 
+    private let backgroundTaskManager: (any BackgroundTaskManager)?
     let coreCrypto: any CoreCryptoProtocol
 
-    public init(coreCrypto: any CoreCryptoProtocol) {
+    public init(
+        backgroundTaskManager: (any BackgroundTaskManager)?,
+        coreCrypto: any CoreCryptoProtocol
+    ) {
+        self.backgroundTaskManager = backgroundTaskManager
         self.coreCrypto = coreCrypto
     }
 
@@ -33,9 +38,22 @@ public final class SafeCoreCrypto {
         try await coreCrypto.registerEpochObserver(epochObserver)
     }
 
-    /// Perform a transaction within an expiring activity to ensure the
-    /// transaction has additional time to complete while the app transitions
-    /// to a suspended state.
+    public func transaction<Result>(
+        block: @escaping (any CoreCryptoContextProtocol) async throws -> Result
+    ) async throws -> Result {
+        if let backgroundTaskManager {
+            try await transaction(
+                backgroundTaskManager: backgroundTaskManager,
+                block: block
+            )
+        } else {
+            try await coreCrypto.transaction(block)
+        }
+    }
+
+    /// Perform a transaction within the context of a background task to
+    /// ensure the transaction has additional time to complete while the
+    /// app transitions to a suspended state.
     ///
     /// This is particularly important when running in the main app because
     /// if the app is suspended during a transaction, then core crypto will
@@ -44,13 +62,30 @@ public final class SafeCoreCrypto {
     /// own transactions. This can lead to the Notification Service Extension
     /// being blocked and not process any notifications until the main app
     /// is resumed and the transaction is completed and the file lock released.
-    ///
-    public func transaction<Result>(
-        block: @escaping @Sendable (any CoreCryptoContextProtocol) async throws -> Result
+    private func transaction<Result>(
+        backgroundTaskManager: any BackgroundTaskManager,
+        block: @escaping (any CoreCryptoContextProtocol) async throws -> Result
     ) async throws -> Result {
-        try await withExpiringActivity(reason: "core crypto transaction") { [coreCrypto] in
+        let transactionTask = Task {
             try await coreCrypto.transaction(block)
         }
+
+        let taskID = backgroundTaskManager.beginBackgroundTask(
+            withName: "core crypto transaction",
+            expirationHandler: {
+                WireLogger.coreCrypto.warn(
+                    "Background task expiring, cancelling core crypto transaction",
+                    attributes: .safePublic
+                )
+                transactionTask.cancel()
+            }
+        )
+
+        defer {
+            backgroundTaskManager.endBackgroundTask(taskID)
+        }
+
+        return try await transactionTask.value
     }
 
 }

--- a/wire-ios-data-model/Source/Utilis/BackgroundTaskManager.swift
+++ b/wire-ios-data-model/Source/Utilis/BackgroundTaskManager.swift
@@ -1,0 +1,51 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+public import UIKit
+
+/// A abstraction around UIApplication's background tasks
+/// methods.
+///
+/// This is intented to be used only within the main app target
+/// (via UIApplication) and not the app extensions.
+public protocol BackgroundTaskManager {
+
+    func beginBackgroundTask(
+        withName: String?,
+        expirationHandler: (@MainActor @Sendable () -> Void)?
+    ) -> UIBackgroundTaskIdentifier
+
+    func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier)
+
+}
+
+public extension BackgroundTaskManager {
+
+    func beginBackgroundTask(
+        withName: String?
+    ) -> UIBackgroundTaskIdentifier {
+        beginBackgroundTask(
+            withName: withName,
+            expirationHandler: nil
+        )
+    }
+
+}
+
+extension UIApplication: BackgroundTaskManager {}

--- a/wire-ios-data-model/Support/Sources/CoreCryptoMocksEnvelope.swift
+++ b/wire-ios-data-model/Support/Sources/CoreCryptoMocksEnvelope.swift
@@ -37,7 +37,10 @@ public class CoreCryptoMocksEnvelope {
         self.coreCrypto = MockCoreCryptoProtocol()
         self.coreCryptoProvider = MockCoreCryptoProviderProtocol()
 
-        coreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: coreCrypto)
+        coreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: coreCrypto
+        )
         coreCrypto.mockTransaction(context: coreCryptoContext)
     }
 

--- a/wire-ios-data-model/Tests/E2EIdentity/E2EIServiceTests.swift
+++ b/wire-ios-data-model/Tests/E2EIdentity/E2EIServiceTests.swift
@@ -38,7 +38,10 @@ final class E2EIServiceTests: ZMConversationTestsBase {
         mockCoreCrypto = MockCoreCryptoProtocol()
         mockCoreCrypto.mockTransaction(context: mockCoreCryptoContext)
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
-        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: mockCoreCrypto
+        )
         sut = E2EIService(
             e2eIdentity: mockE2eIdentity,
             coreCryptoProvider: mockCoreCryptoProvider,

--- a/wire-ios-data-model/Tests/E2EIdentity/E2EIVerificationStatusServiceTests.swift
+++ b/wire-ios-data-model/Tests/E2EIdentity/E2EIVerificationStatusServiceTests.swift
@@ -35,7 +35,10 @@ final class E2EIVerificationStatusServiceTests: XCTestCase {
         mockCoreCrypto = MockCoreCryptoProtocol()
         mockCoreCrypto.mockTransaction(context: mockCoreCryptoContext)
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
-        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: mockCoreCrypto
+        )
         sut = E2EIVerificationStatusService(coreCryptoProvider: mockCoreCryptoProvider)
     }
 

--- a/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
@@ -41,7 +41,10 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         mockCoreCrypto = MockCoreCryptoProtocol()
         mockCoreCrypto.mockTransaction(context: mockCoreCryptoContext)
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
-        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: mockCoreCrypto
+        )
         mockLegacyFeatureRepository = MockLegacyFeatureRepositoryInterface()
 
         sut = MLSActionExecutor(

--- a/wire-ios-data-model/Tests/MLS/MLSEncryptionServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSEncryptionServiceTests.swift
@@ -37,7 +37,10 @@ final class MLSEncryptionServiceTests: XCTestCase {
         mockCoreCrypto = MockCoreCryptoProtocol()
         mockCoreCrypto.mockTransaction(context: mockCoreCryptoContext)
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
-        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: mockCoreCrypto
+        )
         sut = MLSEncryptionService(coreCryptoProvider: mockCoreCryptoProvider)
     }
 

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -57,7 +57,10 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         mockCoreCrypto = MockCoreCryptoProtocol()
         mockCoreCrypto.mockTransaction(context: mockCoreCryptoContext)
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
-        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: mockCoreCrypto
+        )
         mockEncryptionService = MockMLSEncryptionServiceInterface()
         mockDecryptionService = MockMLSDecryptionServiceInterface()
         mockMLSActionExecutor = MockMLSActionExecutor()

--- a/wire-ios-data-model/Tests/Proteus/ProteusServiceTests.swift
+++ b/wire-ios-data-model/Tests/Proteus/ProteusServiceTests.swift
@@ -41,7 +41,10 @@ class ProteusServiceTests: XCTestCase {
         mockCoreCrypto = MockCoreCryptoProtocol()
         mockCoreCrypto.mockTransaction(context: mockCoreCryptoContext)
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
-        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: mockCoreCrypto
+        )
         sut = ProteusService(coreCryptoProvider: mockCoreCryptoProvider)
     }
 

--- a/wire-ios-data-model/Tests/UseCases/IsUserE2EICertifiedUseCaseTests.swift
+++ b/wire-ios-data-model/Tests/UseCases/IsUserE2EICertifiedUseCaseTests.swift
@@ -50,7 +50,10 @@ final class IsUserE2EICertifiedUseCaseTests: ZMBaseManagedObjectTest {
         mockCoreCrypto = MockCoreCryptoProtocol()
         mockCoreCrypto.mockTransaction(context: mockCoreCryptoContext)
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
-        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: mockCoreCrypto
+        )
         mockLegacyFeatureRepository = .init()
         mockLegacyFeatureRepository.fetchE2EI_MockValue = .init(status: .enabled, config: .init())
         sut = .init(

--- a/wire-ios-request-strategy/Sources/E2EIdentity/E2EIKeyPackageRotatorTests.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/E2EIKeyPackageRotatorTests.swift
@@ -36,7 +36,10 @@ class E2EIKeyPackageRotatorTests: MessagingTestBase {
 
         mockCoreCrypto = MockCoreCryptoProtocol()
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
-        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: mockCoreCrypto
+        )
         mockLegacyFeatureRepository = .init()
 
         sut = E2EIKeyPackageRotator(

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
@@ -569,7 +569,8 @@ extension MessagingTestBase {
             syncContext: syncMOC,
             coreCryptoKeyMigrationManager: mockKeyMigrationManager,
             allowCreation: true,
-            localDomain: owningDomain
+            localDomain: owningDomain,
+            backgroundTaskManager: nil
         )
 
         // Initialize CoreCrypto (this calls proteusInit internally)

--- a/wire-ios-request-strategy/Tests/Helpers/ProteusClientSimulator.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/ProteusClientSimulator.swift
@@ -83,7 +83,8 @@ final class ProteusClientSimulator {
             syncContext: syncMOC,
             coreCryptoKeyMigrationManager: mockKeyMigrationManager,
             allowCreation: true,
-            localDomain: owningDomain
+            localDomain: owningDomain,
+            backgroundTaskManager: nil
         )
 
         // Initialize CoreCrypto

--- a/wire-ios-share-engine/Sources/SharingSession.swift
+++ b/wire-ios-share-engine/Sources/SharingSession.swift
@@ -236,7 +236,8 @@ public final class SharingSession {
             syncContext: coreDataStack.syncContext,
             coreCryptoKeyMigrationManager: CoreCryptoKeyMigrationManager(journal: journal),
             allowCreation: false,
-            localDomain: localDomain
+            localDomain: localDomain,
+            backgroundTaskManager: nil
         )
         let featureRepository = LegacyFeatureRepository(context: coreDataStack.syncContext)
         let mlsActionExecutor = MLSActionExecutor(

--- a/wire-ios-share-engine/Sources/SharingSessionLoader.swift
+++ b/wire-ios-share-engine/Sources/SharingSessionLoader.swift
@@ -335,7 +335,8 @@ public struct SharingSessionLoader {
             syncContext: coreDataStack.syncContext,
             coreCryptoKeyMigrationManager: CoreCryptoKeyMigrationManager(journal: journal),
             allowCreation: false,
-            localDomain: backendMetadata.domain
+            localDomain: backendMetadata.domain,
+            backgroundTaskManager: nil
         )
         let featureRepository = LegacyFeatureRepository(context: coreDataStack.syncContext)
         let mlsActionExecutor = MLSActionExecutor(

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -437,7 +437,8 @@ final class UserSessionLoader {
             sharedUserDefaults: sharedUserDefaults,
             syncContext: coreDataStack.syncContext,
             coreCryptoKeyMigrationManager: coreCryptoKeyMigrationManager,
-            localDomain: backendMetadata.domain
+            localDomain: backendMetadata.domain,
+            backgroundTaskManager: UIApplication.shared
         )
 
         let lastEventIDRepository = LastEventIDRepository(

--- a/wire-ios-sync-engine/Tests/Source/E2EI/CertificateRevocationListsCheckerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/E2EI/CertificateRevocationListsCheckerTests.swift
@@ -43,7 +43,10 @@ final class CertificateRevocationListsCheckerTests: XCTestCase {
         let coreCrypto = MockCoreCryptoProtocol()
         coreCrypto.mockTransaction(context: mockCoreCryptoContext)
         let provider = MockCoreCryptoProviderProtocol()
-        provider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: coreCrypto)
+        provider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: coreCrypto
+        )
 
         coreDataHelper = CoreDataStackHelper()
         mockCoreDataStack = try await coreDataHelper.createStack()

--- a/wire-ios-sync-engine/Tests/Source/Use cases/CheckOneOnOneConversationIsReadyUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/CheckOneOnOneConversationIsReadyUseCaseTests.swift
@@ -44,7 +44,10 @@ class CheckOneOnOneConversationIsReadyUseCaseTests: XCTestCase {
         mockCoreCrypto = MockCoreCryptoProtocol()
         mockCoreCrypto.mockTransaction(context: mockCoreCryptoContext)
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
-        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: mockCoreCrypto
+        )
 
         sut = CheckOneOnOneConversationIsReadyUseCase(
             context: syncMOC,

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
@@ -156,7 +156,10 @@ class ZMUserSessionTestsBase: MessagingTest {
         let mockCoreCrypto = MockCoreCryptoProtocol()
         mockCoreCrypto.registerEpochObserver_MockMethod = { _ in }
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
-        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        mockCoreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: mockCoreCrypto
+        )
 
         let mockContextStorable = MockLAContextStorable()
         mockContextStorable.clear_MockMethod = {}

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests_NetworkState.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests_NetworkState.swift
@@ -42,7 +42,10 @@ final class ZMUserSessionTests_NetworkState: ZMUserSessionTestsBase {
         let mockCoreCrypto = MockCoreCryptoProtocol()
         mockCoreCrypto.registerEpochObserver_MockMethod = { _ in }
         let coreCryptoProvider = MockCoreCryptoProviderProtocol()
-        coreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        coreCryptoProvider.coreCrypto_MockValue = SafeCoreCrypto(
+            backgroundTaskManager: nil,
+            coreCrypto: mockCoreCrypto
+        )
         coreCryptoProvider.registerMlsTransport_MockMethod = { _ in }
         coreCryptoProvider.registerEpochObserver_MockMethod = { _ in }
         let coreDataStack = try await createCoreDataStack()

--- a/wire-ios-system/Source/ExpiringActivity.swift
+++ b/wire-ios-system/Source/ExpiringActivity.swift
@@ -41,25 +41,22 @@ public struct ExpiringActivityNotAllowedToRun: Error {}
 ///   - reason: Description of what the activity does, helpful for debugging purposes.
 ///   - block: async operation which supports cancellation.
 
-public func withExpiringActivity<Result: Sendable>(
-    reason: String,
-    block: @escaping @Sendable () async throws -> Result
-) async throws -> Result {
-    let manager = ExpiringActivityManager<Result>()
-    return try await manager.withExpiringActivity(reason: reason, block: block)
+public func withExpiringActivity(reason: String, block: @escaping () async throws -> Void) async throws {
+    let manager = ExpiringActivityManager()
+    try await manager.withExpiringActivity(reason: reason, block: block)
 }
 
 /// Single-use: one instance per activity. The only entry point is the
 /// `withExpiringActivity(reason:block:)` free function above, which creates a
 /// fresh manager every call. Members below are `private` to enforce this — the
 /// actor's idempotency tracking (`didStartWork`) is not designed to reset.
-actor ExpiringActivityManager<Result: Sendable> {
+actor ExpiringActivityManager {
 
     let api: any ExpiringActivityInterface
-    private var task: Task<Result, any Error>?
+    private var task: Task<Void, any Error>?
     // Stored as actor state so resumeOnce() is serialised through the actor
     // executor — no lock required, no threads blocked.
-    private var continuation: CheckedContinuation<Result, any Error>?
+    private var continuation: CheckedContinuation<Void, any Error>?
     // Distinguishes "work was never started" from "work started then stopped".
     // Without this, a second stopWork() (e.g. outer-task cancel followed by
     // OS expiry) misreports the latter as ExpiringActivityNotAllowedToRun.
@@ -73,52 +70,30 @@ actor ExpiringActivityManager<Result: Sendable> {
         self.api = api
     }
 
-    func withExpiringActivity(
-        reason: String,
-        block: @escaping @Sendable () async throws -> Result
-    ) async throws -> Result {
+    func withExpiringActivity(reason: String, block: @escaping () async throws -> Void) async throws {
         try await withTaskCancellationHandler {
             // withCheckedThrowingContinuation forwards the caller's actor
             // isolation to its body closure, so the body runs on this actor's
             // executor and may access isolated state directly.
             try await withCheckedThrowingContinuation { continuation in
                 self.continuation = continuation
-
                 api.performExpiringActivity(withReason: reason) { expiring in
                     if !expiring {
                         let semaphore = DispatchSemaphore(value: 0)
                         Task {
                             do {
-                                WireLogger.backgroundActivity.debug(
-                                    "Start of activity: \(reason)"
-                                )
-
-                                let result = try await self.startWork(
-                                    block: block,
-                                    semaphore: semaphore
-                                ).value
-
-                                WireLogger.backgroundActivity.debug(
-                                    "Expiring activity completed: \(reason)"
-                                )
-
-                                await self.resumeOnce(returning: result)
-
+                                WireLogger.backgroundActivity.debug("Start of activity: \(reason)")
+                                try await self.startWork(block: block, semaphore: semaphore).value
+                                WireLogger.backgroundActivity.debug("Expiring activity completed: \(reason)")
+                                await self.resumeOnce()
                             } catch {
-                                WireLogger.backgroundActivity.warn(
-                                    "Expiring activity ended with an error: \(error)"
-                                )
-
+                                WireLogger.backgroundActivity.warn("Expiring activity ended with an error: \(error)")
                                 await self.resumeOnce(throwing: error)
                             }
                         }
                         semaphore.wait()
-
                     } else {
-                        WireLogger.backgroundActivity.warn(
-                            "Background activity is expiring: \(reason)"
-                        )
-
+                        WireLogger.backgroundActivity.warn("Background activity is expiring: \(reason)")
                         Task {
                             do {
                                 try await self.stopWork()
@@ -134,8 +109,8 @@ actor ExpiringActivityManager<Result: Sendable> {
         }
     }
 
-    private func resumeOnce(returning result: Result) {
-        continuation?.resume(returning: result)
+    private func resumeOnce() {
+        continuation?.resume()
         continuation = nil
     }
 
@@ -145,16 +120,16 @@ actor ExpiringActivityManager<Result: Sendable> {
     }
 
     private func startWork(
-        block: @escaping @Sendable () async throws -> Result,
+        block: @escaping () async throws -> Void,
         semaphore: DispatchSemaphore
-    ) -> Task<Result, any Error> {
+    ) -> Task<Void, any Error> {
         didStartWork = true
         let task = Task {
             defer {
                 WireLogger.backgroundActivity.debug("Releasing semaphore")
                 semaphore.signal()
             }
-            return try await block()
+            try await block()
         }
         self.task = task
         return task

--- a/wire-ios-system/Tests/ExpiringActivityTests.swift
+++ b/wire-ios-system/Tests/ExpiringActivityTests.swift
@@ -28,7 +28,7 @@ class ExpiringActivityTests: XCTestCase {
 
         // given
         let api = MockExpiringActivityAPI()
-        let sut = ExpiringActivityManager<Void>(api: api)
+        let sut = ExpiringActivityManager(api: api)
 
         api.method = { _, block in
             self.concurrentQueue.async {
@@ -55,7 +55,7 @@ class ExpiringActivityTests: XCTestCase {
 
         // given
         let api = MockExpiringActivityAPI()
-        let sut = ExpiringActivityManager<Void>(api: api)
+        let sut = ExpiringActivityManager(api: api)
 
         api.method = { _, block in
             self.concurrentQueue.async {
@@ -79,7 +79,7 @@ class ExpiringActivityTests: XCTestCase {
 
         // given
         let api = MockExpiringActivityAPI()
-        let sut = ExpiringActivityManager<Void>(api: api)
+        let sut = ExpiringActivityManager(api: api)
 
         api.method = { _, block in
             self.concurrentQueue.async {
@@ -118,7 +118,7 @@ class ExpiringActivityTests: XCTestCase {
     /// continuation must not be resumed twice.
     func testCancellationErrorIsThrown_WhenExpiryFiresAfterOuterTaskCancellation() async throws {
         let api = MockExpiringActivityAPI()
-        let sut = ExpiringActivityManager<Void>(api: api)
+        let sut = ExpiringActivityManager(api: api)
 
         let workStarted = expectation(description: "work started")
         let expiryFired = expectation(description: "expiry fired")
@@ -163,7 +163,7 @@ class ExpiringActivityTests: XCTestCase {
     /// mode being guarded against here is a crash.
     func testNoCrash_WhenExpiryCallbackFiresBeforeWorkStarts() async throws {
         let api = MockExpiringActivityAPI()
-        let sut = ExpiringActivityManager<Void>(api: api)
+        let sut = ExpiringActivityManager(api: api)
 
         api.method = { _, block in
             // Deliver expiry before start to maximise the chance of the race.
@@ -180,7 +180,7 @@ class ExpiringActivityTests: XCTestCase {
 
         // given
         let api = MockExpiringActivityAPI()
-        let sut = ExpiringActivityManager<Void>(api: api)
+        let sut = ExpiringActivityManager(api: api)
 
         api.method = { _, block in
             self.concurrentQueue.async {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25914" title="WPB-25914" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25914</a>  [iOS] Manage release iOS 4.20.0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR reverts the PR #4738 that is suspected of causing a crash on multi-user relogin flow.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
