### PR TITLE
fix: deadlock related to CoreCrypto operations - WPB-23784 🍒

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
@@ -101,8 +101,9 @@ public struct PullPendingUpdateEventsSync: PullPendingUpdateEventsSyncProtocol {
                 )
 
                 var decryptedEnvelopes: [UpdateEventEnvelope] = []
-
+                var brokenMLSGroupIDs = Set<String>()
                 for envelope in envelopes {
+                    try Task.checkCancellation()
                     count += 1
 
                     WireLogger.sync.debug(
@@ -117,12 +118,15 @@ public struct PullPendingUpdateEventsSync: PullPendingUpdateEventsSyncProtocol {
 
                     events.append(contentsOf: decryptedEvents)
                     decryptedEnvelopes.append(decryptedEnvelope)
-                    journal.addValues(decryptionEventsResult.brokenMLSGroupIDs, for: .brokenMLSGroupIDs)
+
+                    brokenMLSGroupIDs = brokenMLSGroupIDs.union(decryptionEventsResult.brokenMLSGroupIDs)
 
                     if !envelope.isTransient {
                         lastEnvelopeID = envelope.id
                     }
                 }
+
+                journal.addValues(brokenMLSGroupIDs, for: .brokenMLSGroupIDs)
 
                 WireLogger.sync.debug("persisting \(decryptedEnvelopes.count) decrypted event(s)")
 

--- a/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
@@ -18,7 +18,7 @@
 
 /// Describes the current syncing state of the app.
 
-public enum SyncState: Equatable {
+public enum SyncState: Equatable, Sendable {
 
     /// The app is not syncing.
 
@@ -40,7 +40,7 @@ public enum SyncState: Equatable {
 
     case suspended
 
-    public enum InitialSyncState: Equatable {
+    public enum InitialSyncState: Equatable, Sendable {
 
         case pullLastEventID
         case pullResources
@@ -49,7 +49,7 @@ public enum SyncState: Equatable {
 
     }
 
-    public enum IncrementalSyncState: Equatable {
+    public enum IncrementalSyncState: Equatable, Sendable {
 
         case createPushChannel
         case openPushChannel
@@ -61,7 +61,7 @@ public enum SyncState: Equatable {
 
     }
 
-    public enum LiveSyncState: Equatable {
+    public enum LiveSyncState: Equatable, Sendable {
         case ongoing
         case finished
     }

--- a/WireDomain/Tests/WireDomainTests/Synchronization/GeneratorsDirectoryTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/GeneratorsDirectoryTests.swift
@@ -25,16 +25,6 @@ import WireDomainSupport
 @Suite("GeneratorsDirectory")
 struct GeneratorsDirectoryTests {
 
-    // MARK: - Helpers
-
-    /// Awaits the first time `block` is executed (used to reliably observe async `.start()` calls triggered from a
-    /// `Task { }`).
-    private func waitForCall(_ installHandler: (@escaping () -> Void) -> Void) async {
-        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-            installHandler { c.resume() }
-        }
-    }
-
     let subject = PassthroughSubject<SyncState, Never>()
     let base = MockGeneratorProtocol()
     let live = MockLiveGeneratorProtocol()
@@ -48,8 +38,6 @@ struct GeneratorsDirectoryTests {
         incremental.start_MockMethod = {}
         incremental.stop_MockMethod = {}
     }
-
-    // MARK: - Tests
 
     @Test("idle / initialSyncing stops all generators", arguments: [
         SyncState.idle, .initialSyncing(.pullLastEventID),
@@ -65,13 +53,21 @@ struct GeneratorsDirectoryTests {
         )
         sut.observeSyncState()
 
-        async let incrementalStoped: Void = waitForCall { resume in
-            incremental.stop_MockMethod = { resume() }
-        }
+        let (baseStream, baseCont) = AsyncStream<Void>.makeStream()
+        let (liveStream, liveCont) = AsyncStream<Void>.makeStream()
+        let (incrementalStream, incrementalCont) = AsyncStream<Void>.makeStream()
+        base.stop_MockMethod = { baseCont.yield() }
+        live.stop_MockMethod = { liveCont.yield() }
+        incremental.stop_MockMethod = { incrementalCont.yield() }
 
         // WHEN
         subject.send(state)
-        _ = await incrementalStoped
+        async let baseStopped = baseStream.waitForCall()
+        async let liveStopped = liveStream.waitForCall()
+        async let incrementalStopped = incrementalStream.waitForCall()
+        #expect(await baseStopped)
+        #expect(await liveStopped)
+        #expect(await incrementalStopped)
 
         // THEN
         #expect(base.stop_Invocations.count == 1)
@@ -86,21 +82,17 @@ struct GeneratorsDirectoryTests {
             generators: [live, incremental],
             syncStatePublisher: subject.eraseToAnyPublisher()
         )
-
         sut.observeSyncState()
 
-        async let incrementalStarted: Void = waitForCall { resume in
-            incremental.start_MockMethod = { resume() }
-        }
-
-        // Ensure live does NOT start on this state
+        let (incrementalStream, incrementalCont) = AsyncStream<Void>.makeStream()
+        incremental.start_MockMethod = { incrementalCont.yield() }
         live.start_MockMethod = {
             Issue.record("Live generator should not start during incrementalSyncing(.createPushChannel)")
         }
 
         // WHEN
         subject.send(.incrementalSyncing(.createPushChannel))
-        _ = await incrementalStarted
+        #expect(await incrementalStream.waitForCall())
 
         // THEN
         #expect(incremental.start_Invocations.count == 1)
@@ -116,17 +108,15 @@ struct GeneratorsDirectoryTests {
         )
         sut.observeSyncState()
 
-        async let liveStarted: Void = waitForCall { resume in
-            live.start_MockMethod = { resume() }
-        }
-
+        let (liveStream, liveCont) = AsyncStream<Void>.makeStream()
+        live.start_MockMethod = { liveCont.yield() }
         incremental.start_MockMethod = {
             Issue.record("Incremental generator should not start during liveSyncing(.ongoing)")
         }
 
         // WHEN
         subject.send(.liveSyncing(.ongoing))
-        _ = await liveStarted
+        #expect(await liveStream.waitForCall())
 
         // THEN
         #expect(live.start_Invocations.count == 1)
@@ -145,21 +135,43 @@ struct GeneratorsDirectoryTests {
         )
         sut.observeSyncState()
 
-        async let baseStopped: Void = waitForCall { resume in
-            base.stop_MockMethod = { resume() }
-        }
-
-        async let liveStopped: Void = waitForCall { resume in
-            live.stop_MockMethod = { resume() }
-        }
+        let (baseStream, baseCont) = AsyncStream<Void>.makeStream()
+        let (liveStream, liveCont) = AsyncStream<Void>.makeStream()
+        base.stop_MockMethod = { baseCont.yield() }
+        live.stop_MockMethod = { liveCont.yield() }
 
         // WHEN
         subject.send(state)
-        _ = await baseStopped
-        _ = await liveStopped
+        async let baseStopped = baseStream.waitForCall()
+        async let liveStopped = liveStream.waitForCall()
+        #expect(await baseStopped)
+        #expect(await liveStopped)
 
         // THEN
         #expect(base.stop_Invocations.count == 1)
         #expect(live.stop_Invocations.count == 1)
+    }
+}
+
+// MARK: - Helpers
+
+private extension AsyncStream where Element == Void {
+
+    /// Waits for the stream to yield its first element within `timeout`.
+    /// Returns `false` if the timeout elapses first, so callers can use `#expect`
+    /// to get a failure attributed to the right source location.
+    func waitForCall(timeout: Duration = .seconds(2)) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                var iteration = self.makeAsyncIterator()
+                return await iteration.next() != nil
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return false
+            }
+            defer { group.cancelAll() }
+            return await group.next() ?? false
+        }
     }
 }

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncTests.swift
@@ -118,6 +118,67 @@ final class PullPendingUpdateEventsSyncTests: XCTestCase {
         XCTAssertEqual(journal[.brokenMLSGroupIDs].first, Scaffolding.mlsGroupID)
     }
 
+    func testPull_cancelledDuringDecryption_throwsCancellationError() async throws {
+        // Mock
+        store.lastEventID_MockValue = Scaffolding.lastEventID
+        store.indexOfLastEventEnvelope_MockValue = Scaffolding.indexOfLastEventEnvelope
+
+        // page2 contains 2 envelopes, so cancellation mid-loop can be observed
+        api.getUpdateEventsSelfClientIDSinceEventID_MockValue = PayloadPager(start: "page2") { start in
+            switch start {
+            case "page2":
+                return Scaffolding.page2 // 2 events
+            default:
+                throw "unknown page: \(start ?? "nil")"
+            }
+        }
+
+        let box = ContinuationBox()
+
+        decryptor.decryptEventsInContext_MockMethod = { [box] envelope, _ in
+            // Suspend so the outer task can be cancelled before the next iteration
+            await withCheckedContinuation { continuation in
+                box.continuation = continuation
+            }
+            return EventDecryptorResult(events: envelope.events, brokenMLSGroupIDs: [])
+        }
+
+        store.persistEventEnvelopesIndexPublicKeys_MockMethod = { _, _, _ in }
+        store.storeLastEventIDId_MockMethod = { _ in }
+        store.storeServerTimeDelta_MockMethod = { _ in }
+
+        // When: start pull in a task
+        let pullingEventsTask = Task { [sut] in
+            try await sut.pull(publicKeys: nil)
+        }
+
+        // Wait until the first decryption suspends
+        while box.continuation == nil {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        // Cancel the task, then let the first decryption finish —
+        // the second iteration will hit Task.checkCancellation() and throw.
+        pullingEventsTask.cancel()
+        box.continuation?.resume()
+
+        // Then: pull throws CancellationError
+        let result = await pullingEventsTask.result
+        switch result {
+        case let .failure(error):
+            XCTAssertTrue(error is CancellationError, "Expected CancellationError, got: \(error)")
+        case .success:
+            XCTFail("Expected the task to be cancelled")
+        }
+
+        // Then: only the first envelope was decrypted (loop was interrupted)
+        XCTAssertEqual(decryptor.decryptEventsInContext_Invocations.count, 1)
+
+        // Then: no events were persisted and no last event ID was stored
+        XCTAssertTrue(store.persistEventEnvelopesIndexPublicKeys_Invocations.isEmpty)
+        XCTAssertTrue(store.storeLastEventIDId_Invocations.isEmpty)
+    }
+
     func testLastEventIDIsNotPersisted_untilTransactionIsCompleted() async throws {
         // Mock
         store.lastEventID_MockValue = Scaffolding.lastEventID
@@ -166,6 +227,10 @@ final class PullPendingUpdateEventsSyncTests: XCTestCase {
         XCTAssertEqual(storeLastEventIDInvocations[0], Scaffolding.envelope4.id)
     }
 
+}
+
+private final class ContinuationBox: @unchecked Sendable {
+    var continuation: CheckedContinuation<Void, Never>?
 }
 
 private enum Scaffolding {

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -19,6 +19,7 @@
 import WireCoreCrypto
 import WireDataModel
 import WireLogging
+import WireUtilitiesPackage
 
 public enum MessageSendError: Error {
     case missingMessageProtocol
@@ -85,53 +86,57 @@ public final class MessageSender: MessageSenderInterface {
     private let apiVersion: WireTransport.APIVersion?
 
     public func broadcastMessage(message: any ProteusMessage) async throws {
-        let logAttributes = await logAttributesBuilder.logAttributes(message)
-        WireLogger.messaging.debug("broadcast message", attributes: logAttributes)
-
-        await incrementalSyncObserver.waitUntilCanSendMessage()
-
-        do {
-            guard let apiVersion else { throw MessageSendError.unresolvedApiVersion }
-            try await attemptToBroadcastWithProteus(message: message, apiVersion: apiVersion)
-        } catch {
+        try await withExpiringActivity(reason: "broadcast Message") { [self] in
             let logAttributes = await logAttributesBuilder.logAttributes(message)
-            WireLogger.messaging.warn("broadcast message failed: \(error)", attributes: logAttributes)
-            throw error
+            WireLogger.messaging.debug("broadcast message", attributes: logAttributes)
+
+            await incrementalSyncObserver.waitUntilCanSendMessage()
+
+            do {
+                guard let apiVersion else { throw MessageSendError.unresolvedApiVersion }
+                try await attemptToBroadcastWithProteus(message: message, apiVersion: apiVersion)
+            } catch {
+                let logAttributes = await logAttributesBuilder.logAttributes(message)
+                WireLogger.messaging.warn("broadcast message failed: \(error)", attributes: logAttributes)
+                throw error
+            }
         }
     }
 
     public func sendMessage(message: any SendableMessage) async throws {
-        let logAttributes = await logAttributesBuilder.logAttributes(message)
-        WireLogger.messaging.debug("send message - start wait for quick sync to finish", attributes: logAttributes)
-
-        await incrementalSyncObserver.waitUntilCanSendMessage()
-
-        WireLogger.messaging.debug("send message - sync finished", attributes: logAttributes)
-
-        do {
-            try await messageDependencyResolver.waitForDependenciesToResolve(for: message)
-            WireLogger.messaging.debug(
-                "send message - resolve dependencies finished",
-                attributes: logAttributes
-            )
-            let timePoint = TimePoint(interval: 30, label: "attempt to send message")
-
-            try await attemptToSend(message: message)
-
-            WireLogger.messaging.debug(
-                "send message - attemptToSend duration: \(timePoint.elapsedTime)",
-                attributes: logAttributes
-            )
-
-        } catch {
+        try await withExpiringActivity(reason: "send Message") { [self] in
             let logAttributes = await logAttributesBuilder.logAttributes(message)
-            WireLogger.messaging.warn("send message - failed: \(error)", attributes: logAttributes)
-            throw error
-        }
+            WireLogger.messaging.debug("send message - start wait for quick sync to finish", attributes: logAttributes)
 
-        // Triggering request polling to re-evalute dependencies, other messages
-        // might have been waiting for this message to be sent.
-        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+            await incrementalSyncObserver.waitUntilCanSendMessage()
+
+            WireLogger.messaging.debug("send message - sync finished", attributes: logAttributes)
+
+            do {
+                try await messageDependencyResolver.waitForDependenciesToResolve(for: message)
+                WireLogger.messaging.debug(
+                    "send message - resolve dependencies finished",
+                    attributes: logAttributes
+                )
+                let timePoint = TimePoint(interval: 30, label: "attempt to send message")
+
+                try await attemptToSend(message: message)
+
+                WireLogger.messaging.debug(
+                    "send message - attemptToSend duration: \(timePoint.elapsedTime)",
+                    attributes: logAttributes
+                )
+
+            } catch {
+                let logAttributes = await logAttributesBuilder.logAttributes(message)
+                WireLogger.messaging.warn("send message - failed: \(error)", attributes: logAttributes)
+                throw error
+            }
+
+            // Triggering request polling to re-evalute dependencies, other messages
+            // might have been waiting for this message to be sent.
+            RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+        }
     }
 
     private func attemptToSend(message: any SendableMessage) async throws {

--- a/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0106AC952C9CA4F30022E2CF /* ProteusMessagePayloadBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0106AC942C9CA4F30022E2CF /* ProteusMessagePayloadBuilderTests.swift */; };
 		0106AC982C9CBCE40022E2CF /* MessageInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0106AC962C9CB7F90022E2CF /* MessageInfo.swift */; };
 		014F51D32EF347C70037A181 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		016951A42F9001D300D806D1 /* WireUtilitiesPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 016951A32F9001D300D806D1 /* WireUtilitiesPackage */; };
 		01DF752A2EF220F50071F336 /* EventPayloadDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DF75282EF220F50071F336 /* EventPayloadDecoder.swift */; };
 		01F5AED02CAD892000B01069 /* ProteusMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F5AECF2CAD892000B01069 /* ProteusMessageTests.swift */; };
 		06025666248E616C00E060E1 /* ZMSimpleListRequestPaginator.m in Sources */ = {isa = PBXBuildFile; fileRef = 06025665248E616C00E060E1 /* ZMSimpleListRequestPaginator.m */; };
@@ -910,6 +911,7 @@
 				598D04332C89C6CF00B64D71 /* WireFoundation in Frameworks */,
 				59537D852CFF9D1600920B59 /* WireLogging in Frameworks */,
 				591B6E3B2C8B09AA009F8A7B /* WireDataModel.framework in Frameworks */,
+				016951A42F9001D300D806D1 /* WireUtilitiesPackage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2066,6 +2068,7 @@
 			packageProductDependencies = (
 				598D04322C89C6CF00B64D71 /* WireFoundation */,
 				59537D842CFF9D1600920B59 /* WireLogging */,
+				016951A32F9001D300D806D1 /* WireUtilitiesPackage */,
 			);
 			productName = WireRequestStrategy;
 			productReference = 1669016A1D707509000FE4AF /* WireRequestStrategy.framework */;
@@ -3038,6 +3041,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		016951A32F9001D300D806D1 /* WireUtilitiesPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WireUtilitiesPackage;
+		};
 		59537D842CFF9D1600920B59 /* WireLogging */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = WireLogging;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23784" title="WPB-23784" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23784</a>  [iOS] crash on fetchResultSetAllocateInitialize
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


### Issue

Backport of #4540 to the release branch; 

It fixes the test hang in GeneratorsDirectoryTests (racy withCheckedContinuation wait-for-mock replaced with an AsyncStream + 2s timeout) plus the underlying CoreCrypto deadlock fix in MessageSender/SyncState/PullPendingUpdateEventsSync.

### Testing

Should fix the tests on CI

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
