### PR TITLE
chore: pin GitHub actions to specific hashes - WPB-24577

### DIFF
--- a/.github/actions/allure-reporting/action.yaml
+++ b/.github/actions/allure-reporting/action.yaml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Setup Node.js
       if: always()
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 20
 
@@ -24,7 +24,7 @@ runs:
         
     - name: Upload Allure Report Artifact
       if: ${{ env.ALLURE_REPORT_AVAILABLE == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.allure_artifact_name }}
         path: allure-reports/

--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -130,25 +130,25 @@ jobs:
         run: |
             echo "::add-mask::${{ secrets.CLIENT_NAME_C1_C2_C3 }}"
             echo "::add-mask::${{ secrets.CLIENT_ID_C1_C2_C3 }}"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           lfs: 'false'
           token: ${{ secrets.SUBMODULE_PAT }}
           submodules: recursive
       - name: Download changelog     
         id: download_changelog
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ needs.changelog.outputs.changelog-name }}    
       - name: Retrieve Xcode version
         run: |
           echo "XCODE_VERSION=$(cat .xcode-version)" >> $GITHUB_OUTPUT
         id: xcode-version
-      - uses: maxim-lobanov/setup-xcode@v1.6.0
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: ${{ steps.xcode-version.outputs.XCODE_VERSION }}
       - name: Restore Carthage Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: cache-carthage
         with:
           path: Carthage
@@ -160,7 +160,7 @@ jobs:
          # Restore Swift Package Dependencies Cache
       - name: Restore Swift Package Dependencies Cache
         id: cache-swift-packages
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ env.PACKAGES_DIR }}
           key: ${{ runner.os }}-swiftpm-project-${{ hashFiles('**/*.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ env.ENABLE_COUNTLY }}-${{ env.ENABLE_DATADOG }}
@@ -171,19 +171,19 @@ jobs:
           ( cd $REPO_ROOT && xcodebuild -resolvePackageDependencies -disableAutomaticPackageResolution -clonedSourcePackagesDirPath "$PACKAGES_DIR" )
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           bundler-cache: true
           
       - name: Install ImageMagick
-        uses: gerlero/brew-install@v1
+        uses: gerlero/brew-install@5e2f576b2a0ede9d50a5b08c0099c70fdda0b0b9 # v1.1.2
         with:
           packages: imagemagick ghostscript freetype
           
       - name: Run setup
         run: sh ./setup.sh
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -197,7 +197,7 @@ jobs:
         continue-on-error: true
         run: ./scripts/check_duplicate_classes.sh .
       - name: Archiving Logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: build-logs (${{ github.run_id }} - ${{ github.run_attempt}})
@@ -208,24 +208,24 @@ jobs:
 
       - name: Archiving env variables
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: post-build-env-${{ inputs.fastlane_action }} (${{ github.run_id }} - ${{ github.run_attempt}})
           path: |
             **/.post_build/*.env
       - name: Load .env file
         if: always()
-        uses: xom9ikk/dotenv@v2.3.0
+        uses: xom9ikk/dotenv@ac290ca23a42155a0cba1031d23afa46240116a9 # v2.3.0
         with:
           path: fastlane/.post_build
-      - uses: akiojin/decode-base64-github-action@v1.0.2
+      - uses: akiojin/decode-base64-github-action@82bef0d9c88d987dc48c45218029b8b8426b3e33 # v1.0.2
         id: base64-decoded-S3_PATHS
         with:
           base64: ${{ env.S3_PATHS }}
       - name: Notify on Wire if succeeded
         if: success()
         continue-on-error: true
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
         with:
           status: ${{ job.status }}
           text: |
@@ -242,7 +242,7 @@ jobs:
       - name: Notify on Wire if failed
         if: failure()
         continue-on-error: true
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
         with:
           status: ${{ job.status }}
           text: "🆘 Build **${{ env.APP_NAME }}** (version: ${{ env.BUILD_VERSION }} build: ${{ env.BUILD_NUMBER }}) failed 🆘\n**Triggered by:** ${{ github.triggering_actor }}\n**Build log:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n"

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -62,7 +62,7 @@ jobs:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch }}
           lfs: 'true'
@@ -84,17 +84,17 @@ jobs:
           echo "XCODE_VERSION=$(cat .xcode-version)" >> $GITHUB_OUTPUT
         id: xcode-version
 
-      - uses: maxim-lobanov/setup-xcode@v1.6.0
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: ${{ steps.xcode-version.outputs.XCODE_VERSION }}
 
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@d0a56edc74279820eabbe34477511327e710d0de # v2.4.0
         with:
           path: fastlane/
 
       - name: Restore Carthage Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         id: cache-carthage
         with:
           path: Carthage
@@ -107,7 +107,7 @@ jobs:
         # Restore Swift Package Dependencies Cache
       - name: Restore Swift Package Dependencies Cache
         id: cache-swift-packages
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ env.PACKAGES_DIR }}
           key: ${{ runner.os }}-swiftpm-project-${{ hashFiles('**/*.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-false
@@ -118,12 +118,12 @@ jobs:
           ( cd $REPO_ROOT && xcodebuild -resolvePackageDependencies -disableAutomaticPackageResolution -clonedSourcePackagesDirPath "$PACKAGES_DIR" )
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           bundler-cache: true
 
       - name: Install ImageMagick
-        uses: gerlero/brew-install@v1
+        uses: gerlero/brew-install@5e2f576b2a0ede9d50a5b08c0099c70fdda0b0b9 # v1.1.2
         with:
           packages: imagemagick ghostscript freetype
 
@@ -142,7 +142,7 @@ jobs:
 
       - name: Install 1Password
         if: ${{ inputs.run_critical_flows }}
-        uses: 1password/install-cli-action@v1
+        uses: 1password/install-cli-action@143a85f84a90555d121cde2ff5872e393a47ab9f # v1.0.0
 
       - name: Generate env file
         if: ${{ inputs.run_critical_flows }}
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload .xcresult files as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: XCResults for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
           path: artifacts/**/*.xcresult
@@ -196,7 +196,7 @@ jobs:
           xcrun swift test --package-path ./scripts
 
       - name: Upload Failed snapshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: Failed Snapshots and log for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
@@ -205,7 +205,7 @@ jobs:
             xcodebuild*.log
 
       - name: Upload Test Reports as Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: Test reports for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
@@ -217,7 +217,7 @@ jobs:
 
       - name: Publish Test Results Summary
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/macos@v2
+        uses: EnricoMi/publish-unit-test-result-action/macos@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           files: |
             build/reports/*.junit
@@ -262,7 +262,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Archiving DerivedData Logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: Derived Data Xcode for ${{env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
@@ -278,7 +278,7 @@ jobs:
             echo "commit_message=$(git log -1 --pretty=format:"%s")" >> $GITHUB_ENV
 
       - name: Always Notify on Wire
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
         continue-on-error: true
         if:  ${{ inputs.notify == 'always'  && always() }}
         with:
@@ -292,7 +292,7 @@ jobs:
             **Build log:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       
       - name: Only Notify on Wire failures
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
         continue-on-error: true
         if: ${{ inputs.notify == 'failure' && failure() }}
         with:
@@ -328,7 +328,7 @@ jobs:
           echo "SANITIZED_BRANCH=$SANITIZED_BRANCH" >> $GITHUB_ENV
 
       - name: Download .xcresult files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: XCResults for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
           path: ./artifacts
@@ -362,7 +362,7 @@ jobs:
           echo "SANITIZED_BRANCH=$SANITIZED_BRANCH" >> $GITHUB_ENV
 
       - name: Download tests results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         continue-on-error: true
         with:
           name: Test reports for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -337,7 +337,7 @@ jobs:
         run: ls -R
       
       - name: Analyze .xcresult file
-        uses: wireapp/analyze-xcoderesults-action@v1
+        uses: wireapp/analyze-xcoderesults-action@6d612319f44cb3d1e3d3a9beaf9495670e7c4077 # v1.0.0
         with:
           results: ${{ matrix.xcresult_file }}
           warningAnnotations: true
@@ -366,7 +366,7 @@ jobs:
         continue-on-error: true
         with:
           name: Test reports for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
       - name: Install datadog-ci

--- a/.github/workflows/auto_approve_cherry_pick.yml
+++ b/.github/workflows/auto_approve_cherry_pick.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Approve PR as bot user
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           # PAT from zenkins user
           github-token: ${{ secrets.SUBMODULE_PAT }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,7 +25,7 @@ jobs:
       changelog-name: ${{ steps.expose-url.outputs.changelog-name }}
     steps:
       - name: 'Checkout Git repository with history for all branches and tags'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           lfs: 'false'
           fetch-depth: 0
@@ -75,7 +75,7 @@ jobs:
 
       - name: 'Upload changelog'
         id: upload-file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: CHANGELOG-${{ github.run_number }}-${{ steps.date.outputs.date }}.md
           path: ./CHANGELOG.md

--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           lfs: 'true'
           token: ${{ secrets.SUBMODULE_PAT }}
@@ -52,7 +52,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
 
@@ -64,7 +64,7 @@ jobs:
           scripts/determine-cherry-pick-target.py "${{ github.event.pull_request.base.ref }}"
 
       - name: Cherry pick to target branch
-        uses: wireapp/action-auto-cherry-pick@v1.0.2
+        uses: wireapp/action-auto-cherry-pick@a4a732fe8b79e3fae70362e6271b8982be5b1bc1 # v1.0.2
         with:
           target-branch: ${{ steps.target-branch.outputs.target }}
           pr-labels: 'cherry-pick'

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -19,10 +19,10 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.SUBMODULE_PAT }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Crowdin action
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2.16.2
         with:
           # For more info: https://github.com/crowdin/github-action/blob/master/action.yml
           project_id: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/jira_lint_and_link.yml
+++ b/.github/workflows/jira_lint_and_link.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.action == 'opened' || github.event.changes.title != null
     steps:
-      - uses: cakeinpanic/jira-description-action@v0.8.0
+      - uses: cakeinpanic/jira-description-action@c414eafc7ea6960b2a7a00442a9653543e35e5bc # v0.8.0
         name: jira-description-action
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-author-assigner.yml
+++ b/.github/workflows/pr-author-assigner.yml
@@ -7,6 +7,6 @@ jobs:
     assign-author:
         runs-on: ubuntu-24.04
         steps:
-            -   uses: samspills/assign-pr-to-author@v1.0.2
+            -   uses: samspills/assign-pr-to-author@b313feb250ff414d3aff26525b986f080ee7bd7a # v1.0.2
                 with:
                     repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/semantic_commit_lint.yml
+++ b/.github/workflows/semantic_commit_lint.yml
@@ -21,7 +21,7 @@ jobs:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
       - name: Run Semantic Commint Linter
-        uses: amannn/action-semantic-pull-request@v5.5.3
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         with:
           # Configure which types are allowed.
           # Default: https://github.com/commitizen/conventional-commit-types
@@ -63,7 +63,7 @@ jobs:
 
       - name: Checkout
         if: always()
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           sparse-checkout: .github
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     stale:
         runs-on: ubuntu-24.04
         steps:
-            -   uses: actions/stale@v9
+            -   uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
                 with:
                     days-before-stale: 30
                     days-before-close: 7

--- a/.github/workflows/swiftformat.yml
+++ b/.github/workflows/swiftformat.yml
@@ -18,14 +18,14 @@ jobs:
 
     steps:
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes
         with:
           filters: |
             swift:
               - '**/*.swift'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         if: ${{ steps.changes.outputs.swift == 'true' }}
 
       - name: Install SwiftFormat 0.58.3

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -20,14 +20,14 @@ jobs:
 
     steps:
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes
         with:
           filters: |
             swift:
               - '**/*.swift'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         if: ${{ steps.changes.outputs.swift == 'true' }}
 
       - name: GitHub Action for SwiftLint

--- a/.github/workflows/test_pr_changes.yml
+++ b/.github/workflows/test_pr_changes.yml
@@ -23,11 +23,11 @@ jobs:
       folders: ${{ steps.filter.outputs.changes }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         if: ${{ github.event_name == 'merge_group' }} # on PR, paths-filter can access list of changed files from event payload
         with:
           lfs: 'false' # as long as we use lfs only for snapshotTesting it should not be useful here
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: |


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24577" title="WPB-24577" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24577</a>  [iOS] set specific hash for github actions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR pins GitHub actions to specific hashes based on the existing version. If a version was something like v4 then I have looked for the latest action starting v4 - (eg. v4.3.2) and pinned it to that hash as was done in https://github.com/wireapp/wire-ios/pull/4821 but to the 4.16 branch

### Testing

Run GitHub actions

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.