### PR TITLE
chore: make `UITestConfig.environment` optional - WPB-26321

### DIFF
--- a/WireDomain/Sources/WireDomain/UseCases/IsBuildBlacklistedUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/IsBuildBlacklistedUseCase.swift
@@ -43,7 +43,7 @@ public struct IsBuildBlacklistedUseCaseImpl: IsBuildBlacklistedUseCase {
         api: any BlacklistAPI
     ) {
         #if DEBUG
-            let currentBuildNumber = UITestConfig.environment.isBuildBlacklisted ? "0" : currentBuildNumber
+            let currentBuildNumber = UITestConfig.environment?.isBuildBlacklisted == true ? "0" : currentBuildNumber
         #endif
 
         self.currentBuildNumber = DeveloperOverrides.buildNumber ?? currentBuildNumber

--- a/WireFoundation/Sources/WireFoundation/WirePrimitives/UITestConfig.swift
+++ b/WireFoundation/Sources/WireFoundation/WirePrimitives/UITestConfig.swift
@@ -51,14 +51,14 @@ public struct UITestConfig: Codable {
     }
 
     #if DEBUG
-        /// Returns `UITestConfig` decoded from base64 app environment or default config if none is set.
-        public static var environment: UITestConfig {
+        /// Returns `UITestConfig` decoded from base64 app environment if set.
+        public static var environment: UITestConfig? {
             guard
                 let value = ProcessInfo.processInfo.environment[environmentKey],
                 let data = Data(base64Encoded: value),
                 let config = try? JSONDecoder().decode(UITestConfig.self, from: data)
             else {
-                return UITestConfig() // Return default config is none set in the environment
+                return nil
             }
 
             return config

--- a/wire-ios/Wire-iOS/Sources/LaunchSequenceOperation.swift
+++ b/wire-ios/Wire-iOS/Sources/LaunchSequenceOperation.swift
@@ -47,7 +47,7 @@ final class DeveloperFlagOperation: LaunchSequenceOperation {
             flag.enable(isOn)
         }
         #if DEBUG
-            for (key, value) in UITestConfig.environment.developerFlags {
+            for (key, value) in UITestConfig.environment?.developerFlags ?? [:] {
                 guard let flag = DeveloperFlag(rawValue: key) else { continue }
                 flag.enable(value)
             }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -90,7 +90,7 @@ final class AudioRecordKeyboardViewController: UIViewController, AudioRecordBase
         )
 
         #if DEBUG
-            if UITestConfig.environment.useMockAudioRecorder {
+            if UITestConfig.environment?.useMockAudioRecorder == true {
                 audioRecorder = UITestAudioRecorder()
             }
         #endif


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26321" title="WPB-26321" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26321</a>  [iOS] Make `UITestConfig.environment` optional
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR makes `UITestConfig.environment` optional to prevent it from being used outside the context of UI tests.

### Testing

Run UI tests.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests