### PR TITLE
feat: hide profile picture for incoming cloud connections - WPB-26226

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Helpers/syncengine/UserType+ProfileImage.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/syncengine/UserType+ProfileImage.swift
@@ -25,6 +25,13 @@ var defaultUserImageCache: ImageCache<UIImage> = ImageCache()
 typealias ProfileImageCompletion = (_ image: UIImage?, _ cacheHit: Bool) -> Void
 
 extension UserType {
+
+    /// Whether the user is on the public Wire cloud domain (wire.com or the staging equivalent).
+    /// Used to decide whether to hide the profile picture for incoming connection requests.
+    var isOnPublicCloudDomain: Bool {
+        domain == "wire.com" || domain == "staging.zinfra.io"
+    }
+
     func fetchProfileImage(
         session: UserSession,
         imageCache: ImageCache<UIImage>,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/UserImageView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/UserImageView.swift
@@ -33,6 +33,11 @@ class UserImageView: AvatarImageView, UserObserving {
         didSet { updateUserImage() }
     }
 
+    /// When `true`, the remote profile image is not loaded and only the user's initials are displayed.
+    var showsInitialsOnly = false {
+        didSet { updateUser() }
+    }
+
     /// Whether the badge indicator is enabled.
     var indicatorEnabled: Bool = false {
         didSet { badgeIndicator.isHidden = !indicatorEnabled }
@@ -160,6 +165,7 @@ class UserImageView: AvatarImageView, UserObserving {
 
     /// Updates the image for the user.
     fileprivate func updateUserImage() {
+        guard !showsInitialsOnly else { return }
         guard
             let user,
             let userSession

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -52,14 +52,9 @@ final class IncomingConnectionView: UIView {
     var user: UserType {
         didSet {
             setupLabelText()
-            userImageView.showsInitialsOnly = Self.shouldHideProfilePicture(for: user)
+            userImageView.showsInitialsOnly = user.isOnPublicCloudDomain
             userImageView.user = user
         }
-    }
-
-    /// Hide the profile picture only for incoming requests from users on the public "wire.com" domain.
-    private static func shouldHideProfilePicture(for user: UserType) -> Bool {
-        user.domain == "wire.com"
     }
 
     var onAccept: UserAction?
@@ -105,7 +100,7 @@ final class IncomingConnectionView: UIView {
         userImageView.accessibilityLabel = "user image"
         userImageView.shouldDesaturate = false
         userImageView.size = .big
-        userImageView.showsInitialsOnly = Self.shouldHideProfilePicture(for: user)
+        userImageView.showsInitialsOnly = user.isOnPublicCloudDomain
         userImageView.user = user
 
         updateFederatedIndicator()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -52,8 +52,14 @@ final class IncomingConnectionView: UIView {
     var user: UserType {
         didSet {
             setupLabelText()
+            userImageView.showsInitialsOnly = Self.shouldHideProfilePicture(for: user)
             userImageView.user = user
         }
+    }
+
+    /// Hide the profile picture only for incoming requests from users on the public "wire.com" domain.
+    private static func shouldHideProfilePicture(for user: UserType) -> Bool {
+        user.domain == "wire.com"
     }
 
     var onAccept: UserAction?
@@ -99,6 +105,7 @@ final class IncomingConnectionView: UIView {
         userImageView.accessibilityLabel = "user image"
         userImageView.shouldDesaturate = false
         userImageView.size = .big
+        userImageView.showsInitialsOnly = Self.shouldHideProfilePicture(for: user)
         userImageView.user = user
 
         updateFederatedIndicator()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -151,6 +151,7 @@ final class ProfileHeaderViewController: UIViewController {
         imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
 
         imageView.initialsFont = .systemFont(ofSize: 55, weight: .semibold).monospaced()
+        imageView.showsInitialsOnly = options.contains(.showInitialsOnly)
         imageView.userSession = userSession
         imageView.user = user
 
@@ -481,6 +482,9 @@ final class ProfileHeaderViewController: UIViewController {
 
         /// Whether to allow the user to change their availability.
         static let allowEditingProfilePicture = Options(rawValue: 1 << 5)
+
+        /// Whether to display only the user's initials instead of their profile picture.
+        static let showInitialsOnly = Options(rawValue: 1 << 6)
 
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
@@ -74,6 +74,12 @@ final class ProfileDetailsViewController: UIViewController {
         // the user's profile.
         profileHeaderOptions.insert(.hideAvailability)
 
+        // For an unanswered incoming connection request, hide the picture only if the requester is on the
+        // public "wire.com" domain.
+        if user.isPendingApprovalBySelfUser, user.domain == "wire.com" {
+            profileHeaderOptions.insert(.showInitialsOnly)
+        }
+
         self.user = user
         self.isAdminRole = conversation.map(user.isGroupAdmin) ?? false
         self.viewer = viewer

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
@@ -74,9 +74,9 @@ final class ProfileDetailsViewController: UIViewController {
         // the user's profile.
         profileHeaderOptions.insert(.hideAvailability)
 
-        // For an unanswered incoming connection request, hide the picture only if the requester is on the
-        // public "wire.com" domain.
-        if user.isPendingApprovalBySelfUser, user.domain == "wire.com" {
+        // For an unanswered incoming connection request,
+        // hide the picture only if the requester is on the Wire cloud
+        if user.isPendingApprovalBySelfUser, user.isOnPublicCloudDomain {
             profileHeaderOptions.insert(.showInitialsOnly)
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26226" title="WPB-26226" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26226</a>  [iOS] Hide (incoming) connection request profile picture
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue
In order to prevent spam/unsolicited pictures, we hide the profile picture from any incoming connection request that originates from the cloud.

See the Jira ticket for more details.