### PR TITLE
fix: zoom transition crash on message action dismiss - WPB-26341

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
@@ -68,9 +68,19 @@ extension ConversationContentViewController: ConversationMessageCellDelegate {
 
         let actionView = view.targetView(for: message, dataSource: dataSource)
         let shouldDismissModal = action != .delete && action != .copy
-        if messagePresenter.modalTargetController?.presentedViewController != nil,
+        if let modalTargetController = messagePresenter.modalTargetController,
+           let presented = modalTargetController.presentedViewController,
            shouldDismissModal {
-            messagePresenter.modalTargetController?.dismiss(animated: true) {
+            // Only animate the dismissal when no transition is already in flight.
+            // A presented controller that is still being presented/dismissed (e.g. the
+            // system context-menu zoom morph on iOS 18+) collides with an animated
+            // dismiss and aborts inside _UIZoomTransitionController via
+            // -[UIView _morphPreviewFromCurrentState:...]. A non-animated dismiss
+            // bypasses the zoom transition controller entirely.
+            let isTransitioning = presented.isBeingPresented
+                || presented.isBeingDismissed
+                || modalTargetController.transitionCoordinator != nil
+            modalTargetController.dismiss(animated: !isTransitioning) {
                 self.messageAction(
                     actionId: action,
                     for: message,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26341" title="WPB-26341" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26341</a>  [iOS] Crash during zoom
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

TestFlight crash (4.21.0, iOS 26.6 beta): `EXC_CRASH (SIGABRT)` from an `NSAssertion` inside UIKit's zoom transition — `-[UIView(UIMorphableInternal) _morphPreviewFromCurrentState:...]` (`_UIMorphable.m:33`), reached via `_UIZoomTransitionController` during an animated modal dismiss.

The crash originates at `ConversationContentViewController.perform(action:for:view:)`, which calls `modalTargetController?.dismiss(animated: true)`. The app never requests a `.zoom` transition itself — the zoom morph is driven by the system context-menu preview (`UIContextMenuConfiguration` + `previewProvider`). When a single-tap action fires `dismiss(animated:)` while that preview's present/dismiss morph is still in flight, the two zoom transitions collide on the same controller and UIKit aborts in the morph snapshot path. The collision is aggravated on the iOS 26.x beta.

Fix: only animate the dismissal when no transition is already in flight (`isBeingPresented` / `isBeingDismissed` / live `transitionCoordinator`). A non-animated dismiss in that case bypasses `_UIZoomTransitionController` entirely, removing the crash site. The common path keeps the normal animation.

### Testing

1. Long-press an image/link message to open the context-menu preview.
2. While the preview morph is animating, tap the message cell to trigger a single-tap action.
3. Repeat on iOS 18+/26; the app should no longer crash and the modal should dismiss cleanly.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
