### PR TITLE
fix: audio message effect preview playback - WPB-24864

### DIFF
--- a/wire-ios/Wire-iOS Tests/AudioEffectsPickerViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/AudioEffectsPickerViewControllerTests.swift
@@ -90,4 +90,90 @@ final class AudioEffectsPickerViewControllerTests: XCTestCase {
         sut.selectedAudioEffect = AVSAudioEffectType.chorusMax
         snapshotHelper.verify(matching: preparedView)
     }
+
+    // MARK: - Effect apply completion (WPB-24864)
+
+    func testThatItNotifiesTheDelegateWhenTheEffectApplyCompletes() {
+        // GIVEN
+        let delegate = MockAudioEffectsPickerDelegate()
+        sut.delegate = delegate
+        var capturedCompletion: (() -> Void)?
+        sut.applyEffect = { _, _, _, completion in capturedCompletion = completion }
+
+        // WHEN
+        sut.selectedAudioEffect = .reverbMax
+
+        // THEN the delegate is not notified until the (asynchronous) apply completes
+        XCTAssertTrue(delegate.pickedEffects.isEmpty)
+
+        // WHEN the apply completes
+        capturedCompletion?()
+
+        // THEN the delegate is notified once, for the selected effect
+        XCTAssertEqual(delegate.pickedEffects.count, 1)
+        XCTAssertEqual(delegate.pickedEffects.first?.effect, .reverbMax)
+    }
+
+    func testThatItIgnoresAnEffectApplyCompletionSupersededByANewerEffect() throws {
+        // GIVEN
+        let delegate = MockAudioEffectsPickerDelegate()
+        sut.delegate = delegate
+        var pending: [(effect: AVSAudioEffectType, completion: () -> Void)] = []
+        sut.applyEffect = { effect, _, _, completion in pending.append((effect, completion)) }
+
+        // WHEN selecting two effects in a row (the second supersedes the first)
+        sut.selectedAudioEffect = .pitchupInsane
+        sut.selectedAudioEffect = .chorusMax
+        XCTAssertEqual(pending.count, 2)
+
+        let superseded = try XCTUnwrap(pending.first)
+        let latest = try XCTUnwrap(pending.last)
+
+        // WHEN the superseded (first) apply completes
+        superseded.completion()
+
+        // THEN the delegate is not notified for it
+        XCTAssertTrue(delegate.pickedEffects.isEmpty)
+
+        // WHEN the latest apply completes
+        latest.completion()
+
+        // THEN the delegate is notified once, for the latest effect only
+        XCTAssertEqual(delegate.pickedEffects.map(\.effect), [.chorusMax])
+    }
+
+    func testThatItIgnoresAStaleEffectApplyCompletionArrivingAfterTheLatestOne() throws {
+        // GIVEN
+        let delegate = MockAudioEffectsPickerDelegate()
+        sut.delegate = delegate
+        var pending: [(effect: AVSAudioEffectType, completion: () -> Void)] = []
+        sut.applyEffect = { effect, _, _, completion in pending.append((effect, completion)) }
+
+        sut.selectedAudioEffect = .pitchupInsane
+        sut.selectedAudioEffect = .paceupMed
+        XCTAssertEqual(pending.count, 2)
+
+        let stale = try XCTUnwrap(pending.first)
+        let latest = try XCTUnwrap(pending.last)
+
+        // WHEN the latest completion runs first, then the stale one arrives late
+        latest.completion()
+        stale.completion()
+
+        // THEN only the latest effect is reported to the delegate
+        XCTAssertEqual(delegate.pickedEffects.map(\.effect), [.paceupMed])
+    }
+}
+
+private final class MockAudioEffectsPickerDelegate: AudioEffectsPickerDelegate {
+
+    private(set) var pickedEffects: [(effect: AVSAudioEffectType, resultFilePath: String)] = []
+
+    func audioEffectsPickerDidPickEffect(
+        _ picker: AudioEffectsPickerViewController,
+        effect: AVSAudioEffectType,
+        resultFilePath: String
+    ) {
+        pickedEffects.append((effect, resultFilePath))
+    }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import AVFoundation
 import avs
 import UIKit
 import WireCommonComponents
@@ -59,6 +60,11 @@ final class AudioEffectsPickerViewController: UIViewController {
     var normalizedLoudness: [Float] = []
     private var lastLayoutSize = CGSize.zero
 
+    /// Identifies the most recent effect-apply request. All applied effects are written to the same
+    /// `effect.wav` file on a background queue, so a completion that is no longer the latest must not
+    /// play or hand its (about-to-be-overwritten) file to the delegate.
+    private var effectApplyGeneration = 0
+
     var selectedAudioEffect: AVSAudioEffectType = .none {
         didSet {
             if selectedAudioEffect == .reverse {
@@ -80,12 +86,20 @@ final class AudioEffectsPickerViewController: UIViewController {
                 return
             }
 
+            effectApplyGeneration += 1
+            let generation = effectApplyGeneration
+
             if selectedAudioEffect != .none {
                 audioPlayerController?.stop()
 
                 let effectPath = (NSTemporaryDirectory() as NSString).appendingPathComponent("effect.wav")
                 effectPath.deleteFileAtPath()
                 selectedAudioEffect.apply(recordingPath, outPath: effectPath) {
+                    // Ignore completions superseded by a newer effect change: the shared `effect.wav`
+                    // they reference is being deleted/overwritten by the latest apply, so playing it
+                    // would build an `AVAudioPlayer` from a corrupt file and silently stop playback.
+                    guard self.effectApplyGeneration == generation else { return }
+
                     self.delegate?.audioEffectsPickerDidPickEffect(
                         self,
                         effect: self.selectedAudioEffect,
@@ -123,6 +137,9 @@ final class AudioEffectsPickerViewController: UIViewController {
         audioPlayerController?.stop()
         audioPlayerController?.tearDown()
         audioPlayerController = .none
+        // The preview manages the shared audio session itself (see `AudioPlayerController`), so release
+        // it when leaving the picker. The player is already stopped above, so there is no running I/O.
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
     private let collectionViewLayout: UICollectionViewFlowLayout = .init()
@@ -377,8 +394,8 @@ private protocol AudioPlayerControllerDelegate: AnyObject {
 private final class AudioPlayerController: NSObject, MediaPlayer, AVAudioPlayerDelegate {
 
     let player: AVAudioPlayer
+
     weak var delegate: AudioPlayerControllerDelegate?
-    weak var mediaManager: MediaPlayerDelegate? = (UIApplication.shared.delegate as? AppDelegate)?.mediaPlaybackManager
 
     init(contentOf URL: URL) throws {
         self.player = try AVAudioPlayer(contentsOf: URL)
@@ -393,7 +410,7 @@ private final class AudioPlayerController: NSObject, MediaPlayer, AVAudioPlayerD
     }
 
     func tearDown() {
-        mediaManager?.mediaPlayer(self, didChangeTo: .completed)
+        player.stop()
         player.delegate = nil
     }
 
@@ -410,7 +427,15 @@ private final class AudioPlayerController: NSObject, MediaPlayer, AVAudioPlayerD
     }
 
     func play() {
-        mediaManager?.mediaPlayer(self, didChangeTo: .playing)
+        // The effect preview deliberately does NOT route through `MediaPlaybackManager`/AVS: doing so
+        // made AVS deactivate and reactivate the shared audio session on every effect change, which
+        // blocks the main thread and intermittently fails with "Session deactivation failed"
+        // (error 560030580), wedging the session so later previews are silent. Instead we activate the
+        // session once here and keep it active across effect changes; the picker releases it on teardown.
+        let session = AVAudioSession.sharedInstance()
+        try? session.setCategory(.playback, mode: .default)
+        try? session.setActive(true)
+
         player.currentTime = 0
         player.delegate = self
         player.play()
@@ -421,7 +446,7 @@ private final class AudioPlayerController: NSObject, MediaPlayer, AVAudioPlayerD
     }
 
     func stop() {
-        player.pause()
+        player.stop()
     }
 
     func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -73,9 +73,7 @@ final class AudioEffectsPickerViewController: UIViewController {
     ) -> Void
 
     /// Applies an audio effect, writing the result to `outputPath` and calling `completion` on the main
-    /// thread once done. Injectable so tests can drive the completion deterministically: the real
-    /// `AVSAudioEffectType.apply` runs on a background queue and no-ops under tests, so the completion
-    /// (and the stale-completion guard around it) can't otherwise be exercised.
+    /// thread once done.
     var applyEffect: EffectApplier = { effect, inputPath, outputPath, completion in
         effect.apply(inputPath, outPath: outputPath, completion: completion)
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -65,6 +65,21 @@ final class AudioEffectsPickerViewController: UIViewController {
     /// play or hand its (about-to-be-overwritten) file to the delegate.
     private var effectApplyGeneration = 0
 
+    typealias EffectApplier = (
+        _ effect: AVSAudioEffectType,
+        _ inputPath: String,
+        _ outputPath: String,
+        _ completion: @escaping () -> Void
+    ) -> Void
+
+    /// Applies an audio effect, writing the result to `outputPath` and calling `completion` on the main
+    /// thread once done. Injectable so tests can drive the completion deterministically: the real
+    /// `AVSAudioEffectType.apply` runs on a background queue and no-ops under tests, so the completion
+    /// (and the stale-completion guard around it) can't otherwise be exercised.
+    var applyEffect: EffectApplier = { effect, inputPath, outputPath, completion in
+        effect.apply(inputPath, outPath: outputPath, completion: completion)
+    }
+
     var selectedAudioEffect: AVSAudioEffectType = .none {
         didSet {
             if selectedAudioEffect == .reverse {
@@ -94,7 +109,7 @@ final class AudioEffectsPickerViewController: UIViewController {
 
                 let effectPath = (NSTemporaryDirectory() as NSString).appendingPathComponent("effect.wav")
                 effectPath.deleteFileAtPath()
-                selectedAudioEffect.apply(recordingPath, outPath: effectPath) {
+                applyEffect(selectedAudioEffect, recordingPath, effectPath) {
                     // Ignore completions superseded by a newer effect change: the shared `effect.wav`
                     // they reference is being deleted/overwritten by the latest apply, so playing it
                     // would build an `AVAudioPlayer` from a corrupt file and silently stop playback.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24864" title="WPB-24864" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24864</a>  [iOS] [Audio Messaging] Audio message cannot be played anymore when changing the effect during playback by user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When recording an audio message and previewing it with effects, playback would break: after the first effect, subsequent effects were cut off or didn't play at all, often accompanied by ~0.6s UI hangs on each tap, until no effect could be played.

Root causes in `AudioEffectsPickerViewController`:

1. **Shared audio session churn (main bug).** The effect-preview player routed through the global `MediaPlaybackManager`/AVS. AVS reacts to every `.playing`/`.completed` by synchronously deactivating and reactivating the shared `AVAudioSession` on the main thread. Cycling effects hammered this deactivate→reactivate path, which blocked the main thread (the hangs) and intermittently failed with `AVAudioSession` error `560030580` ("Deactivating an audio session that has running I/O"), leaving the session wedged so later previews were silent.

2. **Stale apply completions.** Every effect is written to a single shared `effect.wav` and applied asynchronously on a background queue. Completions were applied unconditionally, so a completion superseded by a newer effect change could build an `AVAudioPlayer` from an already-overwritten file and notify the delegate with the wrong result.

Fix:

- The preview player no longer talks to `MediaPlaybackManager`/AVS. It manages a plain `AVAudioSession` itself: activates `.playback` once on play (idempotent across effect changes, no per-effect deactivation), and the picker releases the session on teardown after stopping the player.
- Added an `effectApplyGeneration` token so only the latest effect-apply completion plays and notifies the delegate; superseded completions are ignored.

### Testing

1. Open a conversation and record an audio message.
2. Tap an effect to preview it — it plays.
3. Change the effect repeatedly (including rapidly).

Expected: every effect preview plays in full, there are no per-tap hangs, and playback never wedges. Confirmed against the prior device logs where each switch produced `set_active=0 → could not set active: NO err=560030580 Session deactivation failed` plus a hang — those entries are gone.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
