### PR TITLE
chore: update dorny/paths-filter to v4.0.1 - WPB-26340

### DIFF
--- a/.github/workflows/swiftformat.yml
+++ b/.github/workflows/swiftformat.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
 
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
 
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |

--- a/.github/workflows/test_pr_changes.yml
+++ b/.github/workflows/test_pr_changes.yml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ github.event_name == 'merge_group' }} # on PR, paths-filter can access list of changed files from event payload
         with:
           lfs: 'false' # as long as we use lfs only for snapshotTesting it should not be useful here
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26340" title="WPB-26340" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26340</a>  [iOS] Update dorny/paths-filter GitHub Action
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Update dorny/paths-filter GitHub action to v4.0.1 which includes support for Node V24 solving the following issue:

<img width="490" height="349" alt="Wire 2026-06-11 at 9_50 AM" src="https://github.com/user-attachments/assets/be5168c6-3cc2-478a-80ec-b8cafd4b11ca" />

It was run here without any deprecation warning: https://github.com/wireapp/wire-ios/actions/runs/27357869165

### Testing

Run GitHub actions

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

