### PR TITLE
fix: reduce memory pressure

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Helpers/ImageCache.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/ImageCache.swift
@@ -24,6 +24,28 @@ final class ImageCache<T: AnyObject> {
     var cache: NSCache<NSString, T> = NSCache()
     var processingQueue = DispatchQueue(label: "ImageCacheQueue", qos: .background, attributes: [.concurrent])
     var dispatchGroup: DispatchGroup = .init()
+
+    private var backgroundObserver: (any NSObjectProtocol)?
+
+    init() {
+        // Drop decoded images when the app is backgrounded. NSCache only evicts reliably
+        // while in the foreground, so without this the cached images stay resident and inflate
+        // the suspended app's memory footprint, making it a prime target for jetsam
+        // ("System Pressure" background terminations).
+        backgroundObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.cache.removeAllObjects()
+        }
+    }
+
+    deinit {
+        if let backgroundObserver {
+            NotificationCenter.default.removeObserver(backgroundObserver)
+        }
+    }
 }
 
 extension UIImage {


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Xcode Organizer shows our Background Terminations rising ~3× from 4.7.0 (~1.7/day) to 4.12.2 (~6.5/day), then plateauing. The category breakdown is 98% "System Pressure" (memory-pressure jetsam of the suspended app) — 0% File Lock, 0% Task Timeout. So this is not a CoreCrypto file-lock issue (0xDEAD10CC) and not an ExpiringActivity/watchdog issue; it's the backgrounded app's memory footprint making it a prime jetsam target.

Root cause: the in-memory image caches (UIImage.defaultUserImageCache, MediaAssetCache.defaultImageCache, and the global defaultUserImageCache) are unbounded NSCaches that are never released when the app backgrounds. NSCache only evicts reliably in the foreground, so decoded images accumulated during use stay resident while suspended. The rise tracks new image surfaces added over those releases (e.g. WPB-16312 cells image previews).

Change

Register for UIApplication.didEnterBackgroundNotification inside ImageCache.init and removeAllObjects() on background. Placing it in the type means all instances get the behavior with no call-site changes; observer is torn down in deinit.

- wire-ios/Wire-iOS/Sources/Helpers/ImageCache.swift

Impact

Smaller resident footprint while suspended → fewer "System Pressure" background terminations. Foreground behavior is unchanged (caches refill on demand).

Validation

Measure backgrounded memory footprint before/after, and watch the System Pressure background-termination rate in Organizer post-release (the only category this should move).
### Testing

TBD

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
