### PR TITLE
fix: increase runtime timeout minutes for manual and nightly - WPB-26444

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -31,6 +31,10 @@ on:
         type: string
         required: true
         default: 'failure' # values: always | failure | never
+      timeout_minutes:
+        type: number
+        required: false
+        default: 90
 
     secrets:
       ZENKINS_USERNAME:
@@ -53,7 +57,7 @@ jobs:
   run-tests:
     name: Run tests
     runs-on: ghcr.io/cirruslabs/macos-runner:tahoe
-    timeout-minutes: 90
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/critical_flows.yaml
+++ b/.github/workflows/critical_flows.yaml
@@ -28,4 +28,5 @@ jobs:
       run_critical_flows: true
       testiny_run_name: ${{ inputs.testiny_run_name }}
       notify: always
+      timeout_minutes: ${{ github.event_name == 'workflow_dispatch' && 120 || 90 }}
     secrets: inherit

--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -23,4 +23,5 @@ jobs:
       notify_secret: WIRE_IOS_NIGHTLY_WEBHOOK
       run_critical_flows: true
       notify: always
+      timeout_minutes: 120
     secrets: inherit


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26444" title="WPB-26444" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26444</a>  [iOS] fix: increase runtime for uitests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently the job gets cancelled after 90 mins and fail to run all tests and update testiny run execution.
So for manual run or nightly changing it to 120 mins.

**Note**: We may look for better option to avoid this in future and need to revert this.
 
### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
