### PR TITLE
fix: show skin tone reactions in message details [WPB-26545]

### DIFF
--- a/wire-ios/Wire-iOS Tests/MessageDetails/MessageDetailsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/MessageDetails/MessageDetailsViewControllerTests.swift
@@ -328,6 +328,53 @@ final class MessageDetailsViewControllerTests: XCTestCase {
         verify(detailsViewController)
     }
 
+    func testThatItShowsReactionWithSkinToneModifier() throws {
+        // GIVEN
+        conversation = createGroupConversation()
+
+        let message = MockMessageFactory.textMessage(withText: "Message")
+        message.senderUser = SelfUser.provider?.providedSelfUser
+        message.conversationLike = conversation
+        message.deliveryState = .read
+        message.needsReadConfirmation = false
+        message.backingUsersReaction = ["🙌🏻": [otherUser]]
+
+        // WHEN
+        let dataSource = MessageDetailsDataSource(message: message, userSession: userSession)
+
+        // THEN
+        let reaction = try XCTUnwrap(dataSource.reactions.first)
+        XCTAssertEqual(dataSource.reactions.count, 1)
+        XCTAssertEqual(reaction.items.count, 1)
+        XCTAssertTrue(try XCTUnwrap(reaction.headerText).hasPrefix("🙌🏻 "))
+        XCTAssertTrue(try XCTUnwrap(reaction.headerText).hasSuffix("(1)"))
+    }
+
+    func testThatItShowsReactionWhenEmojiRepositoryDoesNotContainIt() throws {
+        // GIVEN
+        conversation = createGroupConversation()
+
+        let message = MockMessageFactory.textMessage(withText: "Message")
+        message.senderUser = SelfUser.provider?.providedSelfUser
+        message.conversationLike = conversation
+        message.deliveryState = .read
+        message.needsReadConfirmation = false
+        message.backingUsersReaction = ["🫡": [otherUser]]
+
+        // WHEN
+        let dataSource = MessageDetailsDataSource(
+            message: message,
+            userSession: userSession,
+            emojiRepository: EmptyEmojiRepository()
+        )
+
+        // THEN
+        let reaction = try XCTUnwrap(dataSource.reactions.first)
+        XCTAssertEqual(dataSource.reactions.count, 1)
+        XCTAssertEqual(reaction.headerText, "🫡 (1)")
+        XCTAssertEqual(reaction.items.count, 1)
+    }
+
     // MARK: - Non-Combined Scenarios
 
     func testThatItShowsReceiptsOnly_Ephemeral() {
@@ -488,6 +535,24 @@ final class MessageDetailsViewControllerTests: XCTestCase {
             testName: testName,
             line: line
         )
+    }
+
+}
+
+private final class EmptyEmojiRepository: EmojiRepositoryInterface {
+
+    func emojis(for category: EmojiCategory) -> [Emoji] {
+        []
+    }
+
+    func emoji(for id: String) -> Emoji? {
+        nil
+    }
+
+    func registerRecentlyUsedEmojis(_ emojis: [Emoji.ID]) {}
+
+    func fetchRecentlyUsedEmojis() -> [Emoji] {
+        []
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsDataSource.swift
@@ -173,15 +173,28 @@ final class MessageDetailsDataSource: NSObject, ZMMessageObserver, UserObserving
     private func setupReactions() {
         reactions = message.usersReaction.lazy
             .compactMap { reaction, users in
-                guard let emoji = self.emojiRepository.emoji(for: reaction) else { return nil }
-                let name = emoji.localizedName ?? emoji.name
+                let items = MessageDetailsCellDescription.makeReactionCells(users)
+                guard !items.isEmpty else { return nil }
+
                 return MessageDetailsSectionDescription(
-                    headerText: "\(emoji.value) \(name.capitalized) (\(users.count))",
-                    items: MessageDetailsCellDescription.makeReactionCells(users)
+                    headerText: self.reactionHeaderText(for: reaction, userCount: users.count),
+                    items: items
                 )
             }
-            .filter { !$0.items.isEmpty }
             .sorted { $0.items.count > $1.items.count }
+    }
+
+    private func reactionHeaderText(for reaction: String, userCount: Int) -> String {
+        guard let emoji = emoji(for: reaction) else {
+            return "\(reaction) (\(userCount))"
+        }
+
+        let name = emoji.localizedName ?? emoji.name
+        return "\(reaction) \(name.capitalized) (\(userCount))"
+    }
+
+    private func emoji(for reaction: String) -> Emoji? {
+        emojiRepository.emoji(for: reaction) ?? emojiRepository.emoji(for: reaction.removingEmojiSkinToneModifiers)
     }
 
     func setupReadReceipts() {
@@ -207,6 +220,22 @@ final class MessageDetailsDataSource: NSObject, ZMMessageObserver, UserObserving
     private func performChanges(_ block: () -> Void) {
         block()
         observer?.dataSourceDidChange(self)
+    }
+
+}
+
+private extension String {
+
+    var removingEmojiSkinToneModifiers: String {
+        String(unicodeScalars.filter { !$0.isEmojiSkinToneModifier })
+    }
+
+}
+
+private extension Unicode.Scalar {
+
+    var isEmojiSkinToneModifier: Bool {
+        (0x1F3FB ... 0x1F3FF).contains(value)
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26545" title="WPB-26545" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26545</a>  [iOS] emojis with skin color do not show in the message details screen 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->

## Summary

Fixes message details not showing reactions when the reaction emoji includes a skin tone modifier.

## Why this happened

The conversation cell renders reactions directly from the stored reaction string, so emoji such as `🙌🏻` are visible in the message bubble.

The message details screen used a different path: it tried to resolve every reaction through `EmojiRepository` before creating the reactions section. Skin tone variants are valid reaction strings, but they are not necessarily present as exact entries in the emoji repository. When lookup failed, the data source dropped the reaction entirely, so the Reactions tab showed the empty state even though the message had reactions.

## How it was fixed

The message details data source now keeps valid reaction rows even when the emoji repository cannot resolve the exact reaction string.

For skin tone emoji, it falls back to looking up the base emoji after removing Fitzpatrick skin tone modifiers, so the UI can still show a localized emoji name while preserving the original reaction emoji in the header.

For unknown or newer emoji that are not in the repository at all, the data source now displays the raw emoji with the user count instead of hiding the reaction.

## Tests

Added regression coverage for:
- a reaction with a skin tone modifier, e.g. `🙌🏻`
- a reaction missing from `EmojiRepository`, e.g. `🫡`