### PR TITLE
fix: invalid cookie data in NSE - WPB-24202

### DIFF
--- a/wire-ios-utilities/Source/NSUserDefaults+SharedUserDefaults.m
+++ b/wire-ios-utilities/Source/NSUserDefaults+SharedUserDefaults.m
@@ -22,6 +22,8 @@
 #import <CommonCrypto/CommonCrypto.h>
 
 
+NSString * const ZMCookieKeyKey = @"ZMCookieKey";
+
 @implementation NSUserDefaults (SharedUserDefaults)
 
 + (NSString *)groupName
@@ -43,18 +45,17 @@
 
 + (NSData *)cookiesKey
 {
-    static NSString * const CookieKeyKey = @"ZMCookieKey";
     NSUserDefaults *sharedDefaults = [NSUserDefaults sharedUserDefaults];
-    NSData *key = [sharedDefaults dataForKey:CookieKeyKey];
+    NSData *key = [sharedDefaults dataForKey:ZMCookieKeyKey];
     if (key == nil) {
         
 #if TARGET_OS_IPHONE
         //On older versions we stored key in standard user defaults.
         //We need to check for key there first and save it to shared defaults.
         //This way extension can use it to decrypt cookies stored in keychain
-        key = [[NSUserDefaults standardUserDefaults] dataForKey:CookieKeyKey];
+        key = [[NSUserDefaults standardUserDefaults] dataForKey:ZMCookieKeyKey];
         if (key != nil) {
-            [[NSUserDefaults standardUserDefaults] removeObjectForKey:CookieKeyKey];
+            [[NSUserDefaults standardUserDefaults] removeObjectForKey:ZMCookieKeyKey];
         }
         else {
 #endif
@@ -68,7 +69,7 @@
         }
 #endif
         
-        [sharedDefaults setObject:key forKey:CookieKeyKey];
+        [sharedDefaults setObject:key forKey:ZMCookieKeyKey];
     }
     return key;
 }

--- a/wire-ios-utilities/Source/UserDefaults+Shared.swift
+++ b/wire-ios-utilities/Source/UserDefaults+Shared.swift
@@ -16,14 +16,16 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import <Foundation/Foundation.h>
+import Foundation
 
-extern NSString * const ZMCookieKeyKey;
+public extension UserDefaults {
 
-@interface NSUserDefaults (SharedUserDefaults)
+    /// Returns the `UserDefaults.cookiesKey()` if created and accessible. Unlike `UserDefaults.cookiesKey()`, this
+    /// property will not attempt to create the key.
+    static var existingCookiesKey: Data? {
+        guard let defaults = UserDefaults.shared() else { return nil }
 
-+ (NSString *)groupName;
-+ (instancetype)sharedUserDefaults;
-+ (NSData *)cookiesKey;
+        return defaults.data(forKey: ZMCookieKeyKey)
+    }
 
-@end
+}

--- a/wire-ios-utilities/Tests/Source/NSUserDefaults+SharedUserDefaultsTests.m
+++ b/wire-ios-utilities/Tests/Source/NSUserDefaults+SharedUserDefaultsTests.m
@@ -27,10 +27,8 @@
 
 @implementation NSUserDefaults_SharedUserDefaultsTests
 
-static NSString *const cookiesKey = @"ZMCookieKey";
-
 - (void)tearDown {
-    [[NSUserDefaults sharedUserDefaults] removeObjectForKey:cookiesKey];
+    [[NSUserDefaults sharedUserDefaults] removeObjectForKey:ZMCookieKeyKey];
     [super tearDown];
 }
 
@@ -105,7 +103,7 @@ static NSString *const cookiesKey = @"ZMCookieKey";
 {
     //given
     NSData *key1 = [NSUserDefaults cookiesKey];
-    [[NSUserDefaults sharedUserDefaults] removeObjectForKey:cookiesKey];
+    [[NSUserDefaults sharedUserDefaults] removeObjectForKey:ZMCookieKeyKey];
     
     //when
     NSData *key2 = [NSUserDefaults cookiesKey];
@@ -121,8 +119,8 @@ static NSString *const cookiesKey = @"ZMCookieKey";
     //given
     NSData *key1 = [NSUserDefaults cookiesKey];
     
-    [[NSUserDefaults standardUserDefaults] setObject:key1 forKey:cookiesKey];
-    [[NSUserDefaults sharedUserDefaults] removeObjectForKey:cookiesKey];
+    [[NSUserDefaults standardUserDefaults] setObject:key1 forKey:ZMCookieKeyKey];
+    [[NSUserDefaults sharedUserDefaults] removeObjectForKey:ZMCookieKeyKey];
     
     //when
     NSData *key2 = [NSUserDefaults cookiesKey];
@@ -131,10 +129,10 @@ static NSString *const cookiesKey = @"ZMCookieKey";
     //then
     
     //key should be removed from standard user defaults
-    XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:cookiesKey]);
+    XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:ZMCookieKeyKey]);
     
     //key should be stored in shared user defaults
-    XCTAssertEqualObjects([[NSUserDefaults sharedUserDefaults] objectForKey:cookiesKey], key1);
+    XCTAssertEqualObjects([[NSUserDefaults sharedUserDefaults] objectForKey:ZMCookieKeyKey], key1);
 }
 #endif
 

--- a/wire-ios-utilities/Tests/Source/UserDefaults+Shared.swift
+++ b/wire-ios-utilities/Tests/Source/UserDefaults+Shared.swift
@@ -16,14 +16,30 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import <Foundation/Foundation.h>
+import Testing
 
-extern NSString * const ZMCookieKeyKey;
+@testable import WireUtilities
 
-@interface NSUserDefaults (SharedUserDefaults)
+@Suite(.serialized)
+final class UserDefaults_SharedTests {
 
-+ (NSString *)groupName;
-+ (instancetype)sharedUserDefaults;
-+ (NSData *)cookiesKey;
+    deinit {
+        UserDefaults.shared().removeObject(forKey: ZMCookieKeyKey)
+    }
 
-@end
+    @Test()
+    func `existingCookiesKey defaults to nil`() {
+        // Given, When, Then
+        #expect(UserDefaults.existingCookiesKey == nil)
+    }
+
+    @Test()
+    func `existingCookiesKey returns cookiesKey if set`() throws {
+        // Given
+        let key = try #require(UserDefaults.cookiesKey()) // This call creates the key in UserDefaults
+
+        // When, Then
+        #expect(UserDefaults.existingCookiesKey == key)
+    }
+
+}

--- a/wire-ios/Wire Notification Service Extension/NotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/NotificationService.swift
@@ -103,6 +103,14 @@ final class NotificationService: UNNotificationServiceExtension {
             return nil
         }
 
+        guard let cookiesKey = UserDefaults.existingCookiesKey else {
+            WireLogger.notifications.warn(
+                "no cookie encryption key, not loading service",
+                attributes: .safePublic
+            )
+            return nil
+        }
+
         WireLogger.notifications.info(
             "loading new notification service",
             attributes: .safePublic
@@ -112,7 +120,7 @@ final class NotificationService: UNNotificationServiceExtension {
             currentBuildNumber: currentBuildNumber,
             appContainerURL: appContainerURL,
             sharedUserDefaults: sharedUserDefaults,
-            cookieEncryptionKey: UserDefaults.cookiesKey(),
+            cookieEncryptionKey: cookiesKey,
             minTLSVersion: SecurityFlags.minTLSVersion.stringValue,
             preferredAPIVersion: BackendInfo.preferredAPIVersion.map {
                 UInt($0.rawValue)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24202" title="WPB-24202" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24202</a>  [iOS] Push Issue - Message only appears when opening the app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This is a manual cherry pick of https://github.com/wireapp/wire-ios/pull/4734 to our 4.16 release cycle branch. There were no merge conflicts.

### Testing

See https://github.com/wireapp/wire-ios/pull/4734

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.