### PR TITLE
fix: not failing when missing snapshots - WPB-26403

### DIFF
--- a/WireAnalytics/Tests/TestPlans/AllTests.xctestplan
+++ b/WireAnalytics/Tests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/WireCalling/Tests/WireCallingTests/Resources/ReferenceImages/MeetingsViewSnapshotTests/testEmptyStateColorSchemeVariants.light.png
+++ b/WireCalling/Tests/WireCallingTests/Resources/ReferenceImages/MeetingsViewSnapshotTests/testEmptyStateColorSchemeVariants.light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a395863be16553876464bd7d2e0d2f1b6a0b77840b17d9f6112a881a0976b157
+size 84304

--- a/WireCalling/Tests/WireCallingTests/Resources/ReferenceImages/MeetingsViewSnapshotTests/testEmptyStateColorSchemeVariants.light.png
+++ b/WireCalling/Tests/WireCallingTests/Resources/ReferenceImages/MeetingsViewSnapshotTests/testEmptyStateColorSchemeVariants.light.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a395863be16553876464bd7d2e0d2f1b6a0b77840b17d9f6112a881a0976b157
-size 84304

--- a/WireData/Tests/TestPlans/AllTests.xctestplan
+++ b/WireData/Tests/TestPlans/AllTests.xctestplan
@@ -15,10 +15,7 @@
       }
     ],
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE"

--- a/WireDomain/Tests/TestPlans/AllTests.xctestplan
+++ b/WireDomain/Tests/TestPlans/AllTests.xctestplan
@@ -15,10 +15,7 @@
       }
     ],
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/WireFoundation/Sources/WireTesting/Utilities/SnapshotHelper.swift
+++ b/WireFoundation/Sources/WireTesting/Utilities/SnapshotHelper.swift
@@ -33,10 +33,10 @@ public struct SnapshotHelper {
     private var snapshotReferenceDirectory = ""
 
     private var defaultRecordMode: SnapshotTestingConfiguration.Record? {
-        let CIEnv = ProcessInfo.processInfo.environment["CI"]
+        let ciEnv = ProcessInfo.processInfo.environment["CI"]
         let recordEnv = ProcessInfo.processInfo.environment["SNAPSHOT_TESTING_RECORD"]
 
-        if CIEnv == "true" {
+        if ciEnv == "true" {
             return .never
         } else if let recordEnv, let record = SnapshotTestingConfiguration.Record(rawValue: recordEnv) {
             return record

--- a/WireFoundation/Sources/WireTesting/Utilities/SnapshotHelper.swift
+++ b/WireFoundation/Sources/WireTesting/Utilities/SnapshotHelper.swift
@@ -36,7 +36,7 @@ public struct SnapshotHelper {
         let CIEnv = ProcessInfo.processInfo.environment["CI"]
         let recordEnv = ProcessInfo.processInfo.environment["SNAPSHOT_TESTING_RECORD"]
 
-        if CIEnv == "true" || CIEnv == "1" {
+        if CIEnv == "true" {
             return .never
         } else if let recordEnv, let record = SnapshotTestingConfiguration.Record(rawValue: recordEnv) {
             return record

--- a/WireFoundation/Sources/WireTesting/Utilities/SnapshotHelper.swift
+++ b/WireFoundation/Sources/WireTesting/Utilities/SnapshotHelper.swift
@@ -33,14 +33,15 @@ public struct SnapshotHelper {
     private var snapshotReferenceDirectory = ""
 
     private var defaultRecordMode: SnapshotTestingConfiguration.Record? {
-        let ci = ProcessInfo.processInfo.environment["CI"]
-        if let value = ProcessInfo.processInfo.environment["SNAPSHOT_TESTING_RECORD"],
-           let record = SnapshotTestingConfiguration.Record(rawValue: value) {
-            return record
-        } else if ci == nil || ci?.isEmpty == true {
-            return .missing
-        } else {
+        let CIEnv = ProcessInfo.processInfo.environment["CI"]
+        let recordEnv = ProcessInfo.processInfo.environment["SNAPSHOT_TESTING_RECORD"]
+
+        if CIEnv == "true" || CIEnv == "1" {
             return .never
+        } else if let recordEnv, let record = SnapshotTestingConfiguration.Record(rawValue: recordEnv) {
+            return record
+        } else {
+            return .missing
         }
     }
 

--- a/WireFoundation/Tests/TestPlans/AllTests.xctestplan
+++ b/WireFoundation/Tests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/WireNetwork/Tests/TestPlans/AllTests.xctestplan
+++ b/WireNetwork/Tests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/WireNetwork/Tests/WireNetworkTests/Helpers/HTTPRequestSnapshotHelper.swift
+++ b/WireNetwork/Tests/WireNetworkTests/Helpers/HTTPRequestSnapshotHelper.swift
@@ -25,8 +25,7 @@ import struct WireNetwork.HTTPRequest
 struct HTTPRequestSnapshotHelper {
 
     private var defaultRecordMode: SnapshotTestingConfiguration.Record? {
-        let ci = ProcessInfo.processInfo.environment["CI"]
-        return (ci == nil || ci?.isEmpty == true) ? .missing : .never
+        ProcessInfo.processInfo.environment["CI"] == "true" ? .never : .missing
     }
 
     /// Snapshot test a given request

--- a/WireNetwork/Tests/WireNetworkTests/Helpers/RequestSnapshotter.swift
+++ b/WireNetwork/Tests/WireNetworkTests/Helpers/RequestSnapshotter.swift
@@ -139,8 +139,7 @@ final class RequestSnapshotter {
     }
 
     private var defaultRecordMode: SnapshotTestingConfiguration.Record? {
-        let ci = ProcessInfo.processInfo.environment["CI"]
-        return (ci == nil || ci?.isEmpty == true) ? .missing : .never
+        ProcessInfo.processInfo.environment["CI"] == "true" ? .never : .missing
     }
 
 }

--- a/WireUI/Tests/TestPlans/AllTests.xctestplan
+++ b/WireUI/Tests/TestPlans/AllTests.xctestplan
@@ -16,10 +16,6 @@
     ],
     "environmentVariableEntries" : [
       {
-        "key" : "CI",
-        "value" : "${CI}"
-      },
-      {
         "enabled" : false,
         "key" : "SNAPSHOT_TESTING_RECORD",
         "value" : "failed"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -597,6 +597,8 @@ platform :ios do
             UI.user_error! "missing id for tests"
         end
 
+        ENV['TEST_RUNNER_CI'] = 'true'
+
         ci_args = is_running_on_ci ? "CI=1" : nil
 
         run_tests_options = {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -597,9 +597,7 @@ platform :ios do
             UI.user_error! "missing id for tests"
         end
 
-        ENV['TEST_RUNNER_CI'] = 'true'
-
-        ci_args = is_running_on_ci ? "CI=1" : nil
+        ENV['TEST_RUNNER_CI'] = ENV['CI']
 
         run_tests_options = {
             step_name: "🧪 Running tests for scheme: #{scheme}",
@@ -619,8 +617,7 @@ platform :ios do
             cloned_source_packages_path: ENV['PACKAGES_DIR'],
             disable_package_automatic_updates: true,
             skip_package_dependencies_resolution: true,
-            number_of_retries: build.number_of_retries,
-            xcargs: ci_args
+            number_of_retries: build.number_of_retries
         }
         run_tests_options[:only_testing] = options[:only_testing] if options[:only_testing]&.any?
 

--- a/scripts/AllTests.xctestplan
+++ b/scripts/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/wire-ios-canvas/WireCanvasTests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-canvas/WireCanvasTests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "targetForVariableExpansion" : {
       "containerPath" : "container:WireCanvas.xcodeproj",

--- a/wire-ios-data-model/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-data-model/Tests/TestPlans/AllTests.xctestplan
@@ -15,10 +15,7 @@
       }
     ],
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "targetForVariableExpansion" : {
       "containerPath" : "container:WireDataModel.xcodeproj",

--- a/wire-ios-images/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-images/Tests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/wire-ios-link-preview/WireLinkPreviewTests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-link-preview/WireLinkPreviewTests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/wire-ios-mocktransport/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-mocktransport/Tests/TestPlans/AllTests.xctestplan
@@ -15,10 +15,7 @@
       }
     ],
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/wire-ios-request-strategy/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-request-strategy/Tests/TestPlans/AllTests.xctestplan
@@ -19,10 +19,6 @@
         "enabled" : false,
         "key" : "LIBDISPATCH_COOPERATIVE_POOL_STRICT",
         "value" : "1"
-      },
-      {
-        "key" : "CI",
-        "value" : "${CI}"
       }
     ],
     "language" : "en",

--- a/wire-ios-share-engine/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-share-engine/Tests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/wire-ios-sync-engine/Tests/TestsPlans/AllTests.xctestplan
+++ b/wire-ios-sync-engine/Tests/TestsPlans/AllTests.xctestplan
@@ -33,10 +33,6 @@
         "enabled" : false,
         "key" : "ZMLOG_TAGS",
         "value" : "MockTransportRequests"
-      },
-      {
-        "key" : "CI",
-        "value" : "${CI}"
       }
     ],
     "targetForVariableExpansion" : {

--- a/wire-ios-system/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-system/Tests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/wire-ios-testing/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-testing/Tests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/wire-ios-transport/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-transport/Tests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/wire-ios-utilities/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-utilities/Tests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/wire-ios-ziphy/ZiphyTests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-ziphy/ZiphyTests/TestPlans/AllTests.xctestplan
@@ -10,10 +10,7 @@
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "CI",
-        "value" : "${CI}"
-      }
+
     ],
     "language" : "en",
     "region" : "DE",

--- a/wire-ios/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios/Tests/TestPlans/AllTests.xctestplan
@@ -29,10 +29,6 @@
         "value" : "failed"
       },
       {
-        "key" : "CI",
-        "value" : "${CI}"
-      },
-      {
         "key" : "IMAGE_DIFF_DIR",
         "value" : "$(SOURCE_ROOT)\/SnapshotResults"
       },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26403" title="WPB-26403" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26403</a>  [iOS] CI won't fail for non-existent snapshot reference images
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently missing snapshot tests don't necessarily result in a test failure when running on CI. This PR fixes the issue by:

1. Updates `SnapshotHelper.defaultRecordMode` to first check if we are running in the CI
2. Change how the CI env is propagated. Now it is set as a env variable via Fastlane - `TEST_RUNNER_CI`. This is supported by `xcodebuild` as a way of passing env variables to test runners. The `TEST_RUNNER_` prefix is stripped. This means that we no longer need to add the `${CI}` env variable to test plans which is brittle and the underlying cause for this failure that led to this bug ticket being created.
3. Test CI env for a specific value "true" which is what is set by GitHub actions. We are in control of the CI used so it makes sense that we can test for specific values.
4. Remove CI env variables from test plans as they are no longer needed.

### Testing

Tested that it works in this job were I had deleted one snapshot test: https://github.com/wireapp/wire-ios/actions/runs/28037475222/job/82994846904?pr=4892#step:5:878

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
