### PR TITLE
fix: do not leave subconversation for 1:1 calls - WPB-25738

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -863,11 +863,28 @@ public extension WireCallCenterV3 {
             snapshot?.mlsConferenceStaleParticipantsRemover?.stopSubscribing()
             snapshot?.mlsConferenceStaleParticipantsRemover = nil
 
+            guard isGroupConversation(conversationId: conversationId) else { return }
+
             leaveSubconversation(
                 parentQualifiedID: mlsParentIDs.0,
                 parentGroupID: mlsParentIDs.1
             )
         }
+    }
+
+    private func isGroupConversation(conversationId: AVSIdentifier) -> Bool {
+        guard
+            let context = uiMOC,
+            let domain = conversationId.domain ?? localDomain,
+            let conversation = ZMConversation.fetch(
+                with: conversationId.identifier,
+                domain: domain,
+                in: context
+            )
+        else {
+            return false
+        }
+        return conversation.conversationType == .group
     }
 
     /// Rejects an incoming call in the conversation.

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -679,6 +679,34 @@ final class WireCallCenterV3Tests: MessagingTest {
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
     }
 
+    func testThatClosingAnMLSOneOnOneCallDoesNotLeaveTheSubconversation() throws {
+        // Given
+        let conversationID = try XCTUnwrap(oneOnOneConversationID)
+        oneOnOneConversation.messageProtocol = .mls
+        oneOnOneConversation.mlsGroupID = .random()
+
+        let mlsService = MockMLSServiceInterface()
+        syncMOC.performAndWait {
+            syncMOC.mlsService = mlsService
+        }
+
+        var didLeaveSubconversation = false
+        mlsService
+            .leaveSubconversationParentQualifiedIDParentGroupIDSubconversationType_MockMethod = { _, _, _ in
+                didLeaveSubconversation = true
+            }
+
+        // When
+        sut.closeCall(conversationId: conversationID)
+
+        // Then
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        XCTAssertFalse(
+            didLeaveSubconversation,
+            "leaveSubconversation should not be called for 1-1 MLS calls"
+        )
+    }
+
     func testThatItLeavesSubconversationIfNeededOnIncoming() throws {
         // Given
         groupConversation.messageProtocol = .mls


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25738" title="WPB-25738" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25738</a>  [iOS] Clean up calling error logs: "failed to leave subconversation"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Cherry-pick of #4719 targeting `release/cycle-4.16`.

- Do not call `leaveSubconversation` when closing a 1:1 call, since subconversations are not used in 1:1 calls
- Fixes ~35 `failed to leave subconversation: WireDataModel.MLSService.SubgroupFailure.missingSubgroupID` error logs per 2 days in DD

## Test plan

- [ ] Join / close 1:1 call — no subconversation error logs
- [ ] Join / close group call — still works as expected

## Original PR

https://github.com/wireapp/wire-ios/pull/4719

🤖 Generated with [Claude Code](https://claude.com/claude-code)