### PR TITLE
fix: force unwrap of optional on conversation link preview article - WPB-24477 🍒

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
@@ -112,7 +112,9 @@ final class ConversationLinkPreviewArticleCellDescription: ConversationMessageCe
         didSet {
             if let message {
                 configuration.message = message
-                configuration.textMessageData = message.textMessageData!
+                if let data = message.textMessageData {
+                    configuration.textMessageData = data
+                }
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24477" title="WPB-24477" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24477</a>  [iOS] crash on conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry-pick of #4514 (originally #4511) onto the 4.16 release branch.

## Summary

- Fix crash caused by force unwrap of optional on conversation link preview article (WPB-24477)

## Issue

Crashes on forced unwrap in conversation link preview. The fix safely unwraps the optional.

## Testing

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)