### PR TITLE
chore: bump AVS 10.3.23 - WPB-25715 🍒

### DIFF
--- a/WireAVS/Package.swift
+++ b/WireAVS/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WireAVS",
-            url: "https://github.com/wireapp/wire-avs/releases/download/10.1.51/avs.xcframework.zip",
-            checksum: "9e7d7c0dd553a5b624d8bb29f2d40997fe4e8c2fae59930ad7febe3d6dee237e"
+            url: "https://github.com/wireapp/wire-avs/releases/download/10.3.23/avs.xcframework.zip",
+            checksum: "1b93474d2a7b2978674e145d41129c6eb346493b468182a43cb61298f9447f9c"
         )
     ]
 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25715" title="WPB-25715" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25715</a>  [AVS] Quality handler json code crashes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry-pick of #4728 onto the 4.16 release branch.

## Summary

- Bump AVS to 10.3.23 which contains the fix for the quality handler JSON crash (WPB-25715)

## Issue

The new AVS version contains the fix for the AVS crash: [Fix quality handler connection hierarchy](https://github.com/wireapp/wire-avs/releases/tag/10.3.23)

## Testing

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)