### PR TITLE
fix: empty space between input bar and mention list - WPB-25192 🍒

### DIFF
--- a/wire-ios/Wire-iOS Tests/ReferenceImages/UserSearchResultsViewControllerTests/testThatHighlightedItemStaysAtMiddleAfterSelectedAnUserAtTheMiddle.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/UserSearchResultsViewControllerTests/testThatHighlightedItemStaysAtMiddleAfterSelectedAnUserAtTheMiddle.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e53eff78bd12755fbb4d5138f389b3d4ab56eaac4635243d05201fd1d638fb90
-size 178002
+oid sha256:f749b2967251d2309f0a740e6d797066893f0bfd725a058eabd4edeee9da858a
+size 105617

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/UserSearchResultsViewControllerTests/testThatHighlightedTopMostItemUpdatesAfterSelectedTopMostUser.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/UserSearchResultsViewControllerTests/testThatHighlightedTopMostItemUpdatesAfterSelectedTopMostUser.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1f77f0499d840b681d50cae7dc01ed6d7e4259cacda633f38bbe46e65b43939
-size 177107
+oid sha256:193ec59014fa877e647ea21d8f46546d228489a3c4b904616602d688f8e8c423
+size 104218

--- a/wire-ios/Wire-iOS Tests/UserSearchResultsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserSearchResultsViewControllerTests.swift
@@ -137,9 +137,8 @@ final class UserSearchResultsViewControllerTests: XCTestCase {
     func testThatHighlightedTopMostItemUpdatesAfterSelectedTopMostUser() {
         createSUT()
 
-        sut.users = mockSearchResultUsers()
-
-        let numberOfUsers = MockUserType.usernames.count
+        let numberOfUsers = 5
+        sut.users = Array(mockSearchResultUsers().prefix(5))
 
         for _ in 0 ..< numberOfUsers {
             sut.selectPreviousUser()
@@ -151,17 +150,16 @@ final class UserSearchResultsViewControllerTests: XCTestCase {
     func testThatHighlightedItemStaysAtMiddleAfterSelectedAnUserAtTheMiddle() {
         createSUT()
 
-        sut.users = mockSearchResultUsers()
-
-        let numberOfUsers = MockUserType.usernames.count
+        let numberOfUsers = 5
+        sut.users = Array(mockSearchResultUsers().prefix(5))
 
         // go to top most
-        for _ in 0 ..< numberOfUsers + 5 {
+        for _ in 0 ..< numberOfUsers {
             sut.selectPreviousUser()
         }
 
         // go to bottom most
-        for _ in 0 ..< numberOfUsers + 5 {
+        for _ in 0 ..< numberOfUsers {
             sut.selectNextUser()
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
@@ -53,8 +53,6 @@ final class UserSearchResultsViewController: UIViewController, KeyboardCollapseO
         }
     }
 
-    private lazy var collectionViewHeight: NSLayoutConstraint = collectionView.heightAnchor
-        .constraint(equalToConstant: 0)
     private let rowHeight: CGFloat = 56.0
     private var isKeyboardCollapsedFirstCalled = true
 
@@ -144,10 +142,10 @@ final class UserSearchResultsViewController: UIViewController, KeyboardCollapseO
     private func setupConstraints() {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
             collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            collectionViewHeight
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
 
@@ -171,16 +169,13 @@ final class UserSearchResultsViewController: UIViewController, KeyboardCollapseO
     private func resizeTable() {
         let viewHeight = view.bounds.size.height
         let contentHeight = CGFloat(searchResults.count) * rowHeight
-        let minValue = min(viewHeight, contentHeight)
-        collectionViewHeight.constant = minValue
-        collectionView.isScrollEnabled = (contentHeight > viewHeight)
 
-        if searchResults.count == 1 {
-            let bottomInset = viewHeight - rowHeight
-            collectionView.contentInset = UIEdgeInsets(top: bottomInset, left: 0, bottom: 0, right: 0)
-        } else {
-            collectionView.contentInset = .zero
-        }
+        // If there are more rows that can fix on screen, enable scroll.
+        collectionView.isScrollEnabled = contentHeight > viewHeight
+
+        // Push the rows down to be flush with the bottom of the view.
+        let bottomInset = max(0, viewHeight - contentHeight)
+        collectionView.contentInset = UIEdgeInsets(top: bottomInset, left: 0, bottom: 0, right: 0)
     }
 
     private func scrollToLastItem() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25192" title="WPB-25192" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25192</a>  [iOS] [Mentions] Empty space between input bar and mention list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry-pick of #4665 onto the 4.16 release branch.

## Summary

- Fix empty space between input bar and mention list when filtered results don't fill the screen (WPB-25192)

## Issue

The mention list fills the entire conversation screen, but when the number of filtered users is small enough to not fill the screen, the results appear at the top leaving empty space between the list and the input bar. Fixed by ensuring the collection view has a top content inset that pushes results flush against the input bar.

## Testing

1. Open a conversation with many participants and type @ to show the mention list. Assert the list is full and can be scrolled.
2. Start to type a name and observe the list being filtered, asserting the results are flush against the input bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)