### PR TITLE
fix: mls decrypted messages not shown in NSE - WPB-23426 🍒

### DIFF
--- a/WireAVS/Package.swift
+++ b/WireAVS/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WireAVS",
-            url: "https://github.com/wireapp/wire-avs/releases/download/10.1.51/avs.xcframework.zip",
-            checksum: "9e7d7c0dd553a5b624d8bb29f2d40997fe4e8c2fae59930ad7febe3d6dee237e"
+            url: "https://github.com/wireapp/wire-avs/releases/download/10.3.23/avs.xcframework.zip",
+            checksum: "1b93474d2a7b2978674e145d41129c6eb346493b468182a43cb61298f9447f9c"
         )
     ]
 )

--- a/WireAVS/Package.swift
+++ b/WireAVS/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WireAVS",
-            url: "https://github.com/wireapp/wire-avs/releases/download/10.3.23/avs.xcframework.zip",
-            checksum: "1b93474d2a7b2978674e145d41129c6eb346493b468182a43cb61298f9447f9c"
+            url: "https://github.com/wireapp/wire-avs/releases/download/10.1.51/avs.xcframework.zip",
+            checksum: "9e7d7c0dd553a5b624d8bb29f2d40997fe4e8c2fae59930ad7febe3d6dee237e"
         )
     ]
 )

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationEventNotificationBuilder.swift
@@ -24,7 +24,7 @@ import WireNetwork
 protocol ConversationEventNotificationBuilderProtocol {
     func buildContent(
         event: ConversationEvent
-    ) async throws -> UserNotification?
+    ) async throws -> [UserNotification]?
 }
 
 struct ConversationEventNotificationBuilder: ConversationEventNotificationBuilderProtocol {
@@ -39,7 +39,7 @@ struct ConversationEventNotificationBuilder: ConversationEventNotificationBuilde
 
     func buildContent(
         event: ConversationEvent
-    ) async throws -> UserNotification? {
+    ) async throws -> [UserNotification]? {
         let canDisplayNotification = await validator.validate(
             conversationID: event.conversationID,
             senderID: event.senderID,
@@ -65,33 +65,38 @@ struct ConversationEventNotificationBuilder: ConversationEventNotificationBuilde
 
         case let .memberLeave(memberLeaveEvent):
 
-            return await conversationMemberLeaveEventNotificationBuilder.buildContent(
+            let notification = await conversationMemberLeaveEventNotificationBuilder.buildContent(
                 event: memberLeaveEvent
             )
+            return notification.flatMap { [$0] }
 
         case let .memberJoin(memberJoinEvent):
 
-            return await conversationMemberJoinEventNotificationBuilder.buildContent(
+            let notification = await conversationMemberJoinEventNotificationBuilder.buildContent(
                 event: memberJoinEvent
             )
+            return notification.flatMap { [$0] }
 
         case let .create(conversationCreateEvent):
 
-            return await conversationCreateEventNotificationBuilder.buildContent(
+            let notification = await conversationCreateEventNotificationBuilder.buildContent(
                 event: conversationCreateEvent
             )
+            return notification.flatMap { [$0] }
 
         case let .delete(conversationDeleteEvent):
 
-            return await conversationDeleteEventNotificationBuilder.buildContent(
+            let notification = await conversationDeleteEventNotificationBuilder.buildContent(
                 event: conversationDeleteEvent
             )
+            return notification.flatMap { [$0] }
 
         case let .messageTimerUpdate(messageTimerUpdateEvent):
 
-            return await conversationMessageTimerUpdateEventNotificationBuilder.buildContent(
+            let notification = await conversationMessageTimerUpdateEventNotificationBuilder.buildContent(
                 event: messageTimerUpdateEvent
             )
+            return notification.flatMap { [$0] }
 
         default:
             return nil

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationMessageAddEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationMessageAddEventNotificationBuilder.swift
@@ -43,58 +43,82 @@ struct ConversationMessageAddEventNotificationBuilder: ConversationMessageAddEve
     let conversationTextMessageNotificationBuilder: any ConversationTextMessageNotificationBuilderProtocol
     let protobufMessageDecoder: ProtobufMessageDecoder
 
-    func buildContent(
-        event: Either<ConversationMLSMessageAddEvent, ConversationProteusMessageAddEvent>
-    ) async throws -> UserNotification? {
-
+    struct MessageContent {
         var message: GenericMessage
         var senderID: UserID
         var conversationID: ConversationID
         var timestamp: Date?
+    }
 
+    func buildContent(
+        event: Either<ConversationMLSMessageAddEvent, ConversationProteusMessageAddEvent>
+    ) async throws -> [UserNotification]? {
         switch event {
         case let .left(mlsMessageEvent):
-            guard let decryptedMessage = mlsMessageEvent.decryptedMessages.first else {
-                // TODO: [WPB-23426] get all messages
-                // The event may have contained only mls protocol messages so it's not
-                // unexpected to find no decrypted application messages.
-                return nil
+            var userNotifications = [UserNotification]()
+
+            for decryptedMessage in mlsMessageEvent.decryptedMessages {
+                do {
+                    let message = try protobufMessageDecoder.extractMLSMessageContent(
+                        from: decryptedMessage.message
+                    )
+
+                    let messageContent =
+                        MessageContent(
+                            message: message,
+                            senderID: mlsMessageEvent.senderID,
+                            conversationID: mlsMessageEvent.conversationID,
+                            timestamp: mlsMessageEvent.timestamp
+                        )
+
+                    if let userNotification = try await buildUserNotification(for: messageContent) {
+                        userNotifications.append(userNotification)
+                    }
+                } catch {
+                    WireLogger.sync.error(
+                        "Failed to build notification for message",
+                        attributes: [.conversationId: mlsMessageEvent.conversationID.id.safeForLoggingDescription]
+                    )
+                }
             }
 
-            message = try protobufMessageDecoder.extractMLSMessageContent(
-                from: decryptedMessage.message
-            )
-            senderID = mlsMessageEvent.senderID
-            conversationID = mlsMessageEvent.conversationID
-            timestamp = mlsMessageEvent.timestamp
+            return userNotifications.isEmpty ? nil : userNotifications
 
         case let .right(proteusMessageEvent):
             guard let decryptedMessage = proteusMessageEvent.message.decryptedMessage else {
                 throw Failure.proteusMessageMissing
             }
 
-            message = try protobufMessageDecoder.extractProteusMessageContent(
+            var message = try protobufMessageDecoder.extractProteusMessageContent(
                 from: decryptedMessage,
                 externalData: proteusMessageEvent.externalData
             )
 
-            senderID = proteusMessageEvent.senderID
-            conversationID = proteusMessageEvent.conversationID
-            timestamp = proteusMessageEvent.timestamp
+            let messageContent = MessageContent(
+                message: message,
+                senderID: proteusMessageEvent.senderID,
+                conversationID: proteusMessageEvent.conversationID,
+                timestamp: proteusMessageEvent.timestamp
+            )
+            let userNotification = try await buildUserNotification(for: messageContent)
+            return userNotification.flatMap { [$0] }
         }
+    }
+
+    private func buildUserNotification(for content: MessageContent) async throws -> UserNotification? {
 
         if let callingNotification = await conversationCallingEventNotificationBuilder.buildContent(
-            calling: message.calling,
-            at: timestamp,
-            conversationID: conversationID,
-            senderID: senderID
+            calling: content.message.calling,
+            at: content.timestamp,
+            conversationID: content.conversationID,
+            senderID: content.senderID
         ) {
-            return callingNotification
+            callingNotification
         } else {
-            return await buildMessageContentNotification(
-                message: message,
-                senderID: senderID,
-                conversationID: conversationID
+            await buildMessageContentNotification(
+                message: content.message,
+                senderID: content.senderID,
+                conversationID: content.conversationID
             )
         }
     }

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Protocols/ConversationMessageAddEventNotificationBuilderProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Protocols/ConversationMessageAddEventNotificationBuilderProtocol.swift
@@ -23,5 +23,5 @@ import WireNetwork
 protocol ConversationMessageAddEventNotificationBuilderProtocol {
     func buildContent(
         event: Either<ConversationMLSMessageAddEvent, ConversationProteusMessageAddEvent>
-    ) async throws -> UserNotification?
+    ) async throws -> [UserNotification]?
 }

--- a/WireDomain/Sources/WireDomain/Notifications/GenerateNotificationUseCase.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/GenerateNotificationUseCase.swift
@@ -51,7 +51,7 @@ struct GenerateNotificationUseCase: GenerateNotificationUseCaseProtocol {
         updateEvents: AsyncStream<[UpdateEvent]>
     ) async throws -> [UserNotification] {
 
-        var notifications = [UserNotification]()
+        var allNotifications = [UserNotification]()
 
         for await events in updateEvents {
             logger.info(
@@ -63,22 +63,22 @@ struct GenerateNotificationUseCase: GenerateNotificationUseCaseProtocol {
                 // Abort if needed.
                 try Task.checkCancellation()
 
-                if let notification = await generateNotification(for: event) {
+                if let notifications = await generateNotification(for: event) {
                     logger.info(
-                        "Generated a notification from an event",
+                        "Generated \(notifications.count) notifications from an event",
                         attributes: .newNSE, .safePublic
                     )
-                    notifications.append(notification)
+                    allNotifications.append(contentsOf: notifications)
                 }
             }
         }
 
-        return notifications
+        return allNotifications
     }
 
     private func generateNotification(
         for event: UpdateEvent
-    ) async -> UserNotification? {
+    ) async -> [UserNotification]? {
         switch event {
         case let .conversation(conversationEvent):
             do {
@@ -102,9 +102,10 @@ struct GenerateNotificationUseCase: GenerateNotificationUseCaseProtocol {
             }
 
         case let .user(userEvent):
-            return await userEventBuilder.buildContent(
+            let notification = await userEventBuilder.buildContent(
                 event: userEvent
             )
+            return notification.flatMap { [$0] }
 
         default:
             var attributes = LogAttributes.newNSE

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -471,10 +471,10 @@ class MockConversationEventNotificationBuilderProtocol: ConversationEventNotific
 
     var buildContentEvent_Invocations: [ConversationEvent] = []
     var buildContentEvent_MockError: Error?
-    var buildContentEvent_MockMethod: ((ConversationEvent) async throws -> UserNotification?)?
-    var buildContentEvent_MockValue: UserNotification??
+    var buildContentEvent_MockMethod: ((ConversationEvent) async throws -> [UserNotification]?)?
+    var buildContentEvent_MockValue: [UserNotification]??
 
-    func buildContent(event: ConversationEvent) async throws -> UserNotification? {
+    func buildContent(event: ConversationEvent) async throws -> [UserNotification]? {
         buildContentEvent_Invocations.append(event)
 
         if let error = buildContentEvent_MockError {

--- a/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationMessageAddEventNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationMessageAddEventNotificationBuilderTests.swift
@@ -122,6 +122,30 @@ final class ConversationMessageAddEventNotificationBuilderTests: XCTestCase {
         XCTAssertEqual(conversationTextNotificationBuilder.buildContentTextConversationIDSenderID_Invocations.count, 1)
     }
 
+    func testGenerateNotifications_Multiple_MLS_Text_Message_Content_It_Invokes_Text_Notification_Builder(
+    ) async throws {
+
+        // Mock
+        let conversation = await context.perform { [self] in
+            modelHelper.createGroupConversation(in: context)
+        }
+        conversationCallingEventNotificationBuilder.buildContentCallingAtConversationIDSenderID_MockValue = .some(nil)
+        conversationTextNotificationBuilder
+            .buildContentTextConversationIDSenderID_MockValue = .text(UNMutableNotificationContent())
+        conversationLocalStore.fetchOrCreateConversationIdDomain_MockValue = conversation
+        conversationLocalStore.isMessageSilencedSenderIDConversation_MockValue = false
+        conversationLocalStore.shouldHideNotification_MockValue = false
+
+        // When
+
+        _ = try await sut.buildContent(
+            event: .left(Scaffolding.mlsTextMessageEvents)
+        )
+
+        // Then
+        XCTAssertEqual(conversationTextNotificationBuilder.buildContentTextConversationIDSenderID_Invocations.count, 2)
+    }
+
     func testGenerateNotification_MLS_Does_Not_Fail_If_No_Messages_Found() async throws {
         // When
         let result = try await sut.buildContent(
@@ -192,6 +216,24 @@ final class ConversationMessageAddEventNotificationBuilderTests: XCTestCase {
                 message: Scaffolding.base64EncodedString, // text content
                 senderClientID: UUID.mockID1.uuidString
             )]
+        )
+
+        static let mlsTextMessageEvents = ConversationMLSMessageAddEvent(
+            conversationID: conversationID,
+            senderID: userID,
+            subconversation: "",
+            message: messageContent,
+            timestamp: .now,
+            decryptedMessages: [
+                .init(
+                    message: Scaffolding.base64EncodedString, // text content
+                    senderClientID: UUID.mockID1.uuidString
+                ),
+                .init(
+                    message: Scaffolding.base64EncodedString, // text content
+                    senderClientID: UUID.mockID1.uuidString
+                )
+            ]
         )
 
         static let proteusTextMessageEvent = ConversationProteusMessageAddEvent(

--- a/WireDomain/Tests/WireDomainTests/Notifications/GenerateNotificationUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/GenerateNotificationUseCaseTests.swift
@@ -50,7 +50,7 @@ final class GenerateNotificationUseCaseTests: XCTestCase {
     func testProcess_It_Invokes_Notification_Content_Handler() async throws {
         // Mock
 
-        conversationEventBuilder.buildContentEvent_MockValue = .text(UNMutableNotificationContent())
+        conversationEventBuilder.buildContentEvent_MockValue = [.text(UNMutableNotificationContent())]
         userEventBuilder.buildContentEvent_MockValue = .text(UNMutableNotificationContent())
 
         let asyncStream = AsyncStream<[UpdateEvent]> {
@@ -69,7 +69,7 @@ final class GenerateNotificationUseCaseTests: XCTestCase {
 
     func testCancellation_stopsGeneratingNotifications() async throws {
         // Mock
-        conversationEventBuilder.buildContentEvent_MockValue = .text(UNMutableNotificationContent())
+        conversationEventBuilder.buildContentEvent_MockValue = [.text(UNMutableNotificationContent())]
         userEventBuilder.buildContentEvent_MockValue = .text(UNMutableNotificationContent())
 
         // Create multiple events to test partial processing


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23426" title="WPB-23426" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23426</a>  [iOS] mls decrypted messages not shown in NSE
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry-pick of #4316 onto the 4.16 release branch.

## Summary

- Fix MLS decrypted messages not shown in NSE (WPB-23426)

## Issue

Generates a notification for all decrypted messages returned from an MLS message add event, not only the first one.

## Testing

Unit tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)