### PR TITLE
feat: restrict new auth flow to email login when ALLOW_ONLY_EMAIL_LOGIN is set - WPB-24853 🍒

### DIFF
--- a/WireAVS/Package.swift
+++ b/WireAVS/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WireAVS",
-            url: "https://github.com/wireapp/wire-avs/releases/download/10.1.51/avs.xcframework.zip",
-            checksum: "9e7d7c0dd553a5b624d8bb29f2d40997fe4e8c2fae59930ad7febe3d6dee237e"
+            url: "https://github.com/wireapp/wire-avs/releases/download/10.3.23/avs.xcframework.zip",
+            checksum: "1b93474d2a7b2978674e145d41129c6eb346493b468182a43cb61298f9447f9c"
         )
     ]
 )

--- a/WireAVS/Package.swift
+++ b/WireAVS/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WireAVS",
-            url: "https://github.com/wireapp/wire-avs/releases/download/10.3.23/avs.xcframework.zip",
-            checksum: "1b93474d2a7b2978674e145d41129c6eb346493b468182a43cb61298f9447f9c"
+            url: "https://github.com/wireapp/wire-avs/releases/download/10.1.51/avs.xcframework.zip",
+            checksum: "9e7d7c0dd553a5b624d8bb29f2d40997fe4e8c2fae59930ad7febe3d6dee237e"
         )
     ]
 )

--- a/WireAuthentication/Sources/WireAuthentication/Components/DetermineAuthMethodComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/DetermineAuthMethodComponent.swift
@@ -31,6 +31,7 @@ protocol DetermineAuthMethodComponentDependency: Dependency {
     var preferredAPIVersion: APIVersion? { get }
     var minTLSVersion: TLSVersion { get }
     var ssoCallbackURLScheme: String { get }
+    var overrideAllowEmailLoginOnly: Bool { get }
 }
 
 final class DetermineAuthMethodComponent: Component<DetermineAuthMethodComponentDependency> {
@@ -102,8 +103,8 @@ extension DetermineAuthMethodComponent: DetermineAuthMethodViewModel.Factory {
             bridge: dependency.bridge,
             environment: networkStack.backendEnvironment,
             existsAnotherAccount: existsAnotherAccount,
-            allowsMultipleBackends: allowsMultipleBackends,
-            existingBackendHosts: existingBackendHosts
+            existingBackendHosts: existingBackendHosts,
+            overrideAllowEmailLoginOnly: dependency.overrideAllowEmailLoginOnly
         )
     }
 

--- a/WireAuthentication/Sources/WireAuthentication/Components/RootComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/RootComponent.swift
@@ -44,6 +44,7 @@ final class RootComponent: BootstrapComponent {
     public let appStoreURL: URL
     public let accountsPublisher: CurrentValuePublisher<[AccountUIModel]>
     public let registrationAnalyticsTracker: (any RegistrationAnalyticsTrackerProtocol)?
+    public let overrideAllowEmailLoginOnly: Bool
 
     @MainActor public var bridge: WireAuthenticationBridge {
         shared {
@@ -72,7 +73,8 @@ final class RootComponent: BootstrapComponent {
         ssoCallbackURLScheme: String,
         appStoreURL: URL,
         accountsPublisher: CurrentValuePublisher<[AccountUIModel]>,
-        registrationAnalyticsTracker: (any RegistrationAnalyticsTrackerProtocol)?
+        registrationAnalyticsTracker: (any RegistrationAnalyticsTrackerProtocol)?,
+        overrideAllowEmailLoginOnly: Bool
     ) {
         self.authenticationType = authenticationType
         self.environment = environment
@@ -90,6 +92,7 @@ final class RootComponent: BootstrapComponent {
         self.appStoreURL = appStoreURL
         self.accountsPublisher = accountsPublisher
         self.registrationAnalyticsTracker = registrationAnalyticsTracker
+        self.overrideAllowEmailLoginOnly = overrideAllowEmailLoginOnly
     }
 
     // MARK: - Children

--- a/WireAuthentication/Sources/WireAuthentication/Needle.generated.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Needle.generated.swift
@@ -145,6 +145,9 @@ private class DetermineAuthMethodComponentDependency527e70b5dbcfcb8f2023Provider
     var ssoCallbackURLScheme: String {
         return rootComponent.ssoCallbackURLScheme
     }
+    var overrideAllowEmailLoginOnly: Bool {
+        return rootComponent.overrideAllowEmailLoginOnly
+    }
     private let rootComponent: RootComponent
     init(rootComponent: RootComponent) {
         self.rootComponent = rootComponent
@@ -366,6 +369,7 @@ extension DetermineAuthMethodComponent: NeedleFoundation.Registration {
         keyPathToName[\DetermineAuthMethodComponentDependency.preferredAPIVersion] = "preferredAPIVersion-APIVersion?"
         keyPathToName[\DetermineAuthMethodComponentDependency.minTLSVersion] = "minTLSVersion-TLSVersion"
         keyPathToName[\DetermineAuthMethodComponentDependency.ssoCallbackURLScheme] = "ssoCallbackURLScheme-String"
+        keyPathToName[\DetermineAuthMethodComponentDependency.overrideAllowEmailLoginOnly] = "overrideAllowEmailLoginOnly-Bool"
         localTable["networkStack-NetworkStack"] = { [unowned self] in self.networkStack as Any }
         localTable["didReauthenticate-Bool"] = { [unowned self] in self.didReauthenticate as Any }
     }
@@ -397,6 +401,7 @@ extension RootComponent: NeedleFoundation.Registration {
         localTable["appStoreURL-URL"] = { [unowned self] in self.appStoreURL as Any }
         localTable["accountsPublisher-CurrentValuePublisher<[AccountUIModel]>"] = { [unowned self] in self.accountsPublisher as Any }
         localTable["registrationAnalyticsTracker-(any RegistrationAnalyticsTrackerProtocol)?"] = { [unowned self] in self.registrationAnalyticsTracker as Any }
+        localTable["overrideAllowEmailLoginOnly-Bool"] = { [unowned self] in self.overrideAllowEmailLoginOnly as Any }
         localTable["bridge-WireAuthenticationBridge"] = { [unowned self] in self.bridge as Any }
         localTable["router-any Router"] = { [unowned self] in self.router as Any }
     }

--- a/WireAuthentication/Sources/WireAuthentication/WireAuthenticationAssembly.swift
+++ b/WireAuthentication/Sources/WireAuthentication/WireAuthenticationAssembly.swift
@@ -52,7 +52,8 @@ public struct WireAuthenticationAssembly {
         ssoCallbackURLScheme: String,
         appStoreURL: URL,
         accountsPublisher: CurrentValuePublisher<[AccountUIModel]>,
-        registrationAnalyticsTracker: (any RegistrationAnalyticsTrackerProtocol)?
+        registrationAnalyticsTracker: (any RegistrationAnalyticsTrackerProtocol)?,
+        overrideAllowEmailLoginOnly: Bool
     ) -> (view: some View, bridge: WireAuthenticationBridge) {
         let rootComponent = RootComponent(
             authenticationType: authenticationType,
@@ -69,7 +70,8 @@ public struct WireAuthenticationAssembly {
             ssoCallbackURLScheme: ssoCallbackURLScheme,
             appStoreURL: appStoreURL,
             accountsPublisher: accountsPublisher,
-            registrationAnalyticsTracker: registrationAnalyticsTracker
+            registrationAnalyticsTracker: registrationAnalyticsTracker,
+            overrideAllowEmailLoginOnly: overrideAllowEmailLoginOnly
         )
 
         return (view: RootView(factory: rootComponent), bridge: rootComponent.bridge)

--- a/WireAuthentication/Sources/WireAuthenticationUI/Mocks/FakeDetermineAuthMethodFactory.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Mocks/FakeDetermineAuthMethodFactory.swift
@@ -41,9 +41,11 @@ struct FakeDetermineAuthMethodFactory: DetermineAuthMethodFactory,
             router: FakeRootFactory().viewModel,
             bridge: WireAuthenticationBridge(),
             environment: mockDependencies.backendEnvironment,
+            emailOrSSOCode: emailOrSSOCode,
             existsAnotherAccount: existsAnotherAccount,
             allowsMultipleBackends: allowsMultipleBackends,
-            existingBackendHosts: existingBackendHosts
+            existingBackendHosts: existingBackendHosts,
+            overrideAllowEmailLoginOnly: false
         )
         viewModel.emailOrSSOCode = emailOrSSOCode
         return viewModel

--- a/WireAuthentication/Sources/WireAuthenticationUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Resources/Localization/de.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "authentication.identity.input.body" = "Geben Sie Ihre E-Mail-Adresse ein, um zu beginnen.";
 "authentication.identity.input.field.placeholder" = "E-Mail-Adresse oder SSO-Code";
 "authentication.identity.input.field.title" = "E-Mail-Adresse oder SSO-Code";
+"authentication.identity.input.field.email_only.placeholder" = "E-Mail";
+"authentication.identity.input.field.email_only.title" = "E-Mail";
 "authentication.identity.input.submit" = "Weiter";
 
 "cloud_user_login.title" = "Geben Sie Ihr Passwort ein, um sich anzumelden ";

--- a/WireAuthentication/Sources/WireAuthenticationUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Resources/Localization/en.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "authentication.identity.input.body" = "Simply enter your email address to start!";
 "authentication.identity.input.field.placeholder" = "Email or SSO code";
 "authentication.identity.input.field.title" = "Email or SSO code";
+"authentication.identity.input.field.email_only.placeholder" = "Email";
+"authentication.identity.input.field.email_only.title" = "Email";
 "authentication.identity.input.submit" = "Next";
 
 "cloud_user_login.title" = "Enter your password to log in";

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
@@ -121,8 +121,8 @@ package struct DetermineAuthMethodView: View {
         VStack(alignment: .leading, spacing: 8) {
             LabeledTextField(
                 isMandatory: false,
-                placeholder: Strings.Identity.Input.Field.placeholder,
-                title: Strings.Identity.Input.Field.title,
+                placeholder: inputFieldPlaceholder,
+                title: inputFieldTitle,
                 string: $viewModel.emailOrSSOCode,
                 keyboardType: .emailAddress,
                 textContentType: .username
@@ -131,6 +131,22 @@ package struct DetermineAuthMethodView: View {
             .lineLimit(nil)
             .fixedSize(horizontal: false, vertical: true)
             .accessibilityIdentifier(Locators.WelcomePage.emailTextField.rawValue)
+        }
+    }
+
+    private var inputFieldTitle: String {
+        if viewModel.overrideAllowEmailLoginOnly {
+            Strings.Identity.Input.Field.EmailOnly.title
+        } else {
+            Strings.Identity.Input.Field.title
+        }
+    }
+
+    private var inputFieldPlaceholder: String {
+        if viewModel.overrideAllowEmailLoginOnly {
+            Strings.Identity.Input.Field.EmailOnly.placeholder
+        } else {
+            Strings.Identity.Input.Field.placeholder
         }
     }
 
@@ -150,7 +166,7 @@ package struct DetermineAuthMethodView: View {
             }
         })
         .wireButtonStyle(.primary)
-        .disabled(viewModel.isNextButtonEnabled || viewModel.isLoading)
+        .disabled(!viewModel.isNextButtonEnabled || viewModel.isLoading)
         .accessibilityIdentifier(Locators.WelcomePage.nextButton.rawValue)
     }
 

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodViewModel.swift
@@ -42,12 +42,18 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
     @Published var existsAnotherAccount: Bool
 
     var isNextButtonEnabled: Bool {
-        !isValidEmailOrSSOCode()
+        if overrideAllowEmailLoginOnly {
+            isValidEmail
+        } else {
+            isValidEmail || isValidSSOCode
+        }
     }
 
     var isOnPremiseBackend: Bool {
         environment.environmentType != .default
     }
+
+    let overrideAllowEmailLoginOnly: Bool
 
     // MARK: - Dependencies
 
@@ -76,6 +82,7 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
         allowsMultipleBackends: Bool = true,
         existingBackendHosts: Set<String>,
         isLoading: Bool = false,
+        overrideAllowEmailLoginOnly: Bool
     ) {
         self.factory = factory
         self.router = router
@@ -86,6 +93,7 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
         self.allowsMultipleBackends = allowsMultipleBackends
         self.existingBackendHosts = existingBackendHosts
         self.isLoading = isLoading
+        self.overrideAllowEmailLoginOnly = overrideAllowEmailLoginOnly
 
         self.cancellable = bridge.inboundEvents.sink { [weak self] event in
             switch event {
@@ -107,6 +115,19 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
         isLoading = true
         defer {
             isLoading = false
+        }
+
+        // When only email login is allowed, validate the input as an email before
+        // navigating to the login flow. An SSO code or otherwise invalid input is ignored
+        // (the submit button is also disabled for it).
+        if overrideAllowEmailLoginOnly {
+            guard let validatedEmail else { return }
+            router.navigate(to: DetermineAuthMethodDestination.login(
+                email: validatedEmail,
+                didDetectDomainConflict: false,
+                environment: environment
+            ))
+            return
         }
 
         do {
@@ -314,14 +335,33 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
         }
     }
 
-    private func isValidEmailOrSSOCode() -> Bool {
+    private var isValidEmail: Bool {
+        validatedEmail != nil
+    }
+
+    /// The trimmed, validated email entered by the user, or `nil` if the input is not a valid email.
+    private var validatedEmail: String? {
+        guard case let .email(email, _) = try? validateEmailOrSSOCode() else {
+            return nil
+        }
+        return email
+    }
+
+    private var isValidSSOCode: Bool {
         do {
-            let useCase = factory.validateEmailOrSSOCodeUseCase()
-            _ = try useCase.invoke(input: emailOrSSOCode.trimmingCharacters(in: .whitespaces))
-            return true
+            if case .ssoCode = try validateEmailOrSSOCode() {
+                return true
+            } else {
+                return false
+            }
         } catch {
             return false
         }
+    }
+
+    private func validateEmailOrSSOCode() throws -> ValidatedEmailOrSSOCode {
+        let useCase = factory.validateEmailOrSSOCodeUseCase()
+        return try useCase.invoke(input: emailOrSSOCode.trimmingCharacters(in: .whitespaces))
     }
 
 }

--- a/WireAuthentication/Tests/WireAuthenticationUITests/Views/DetermineAuthMethod/DetermineAuthMethodViewModelTests.swift
+++ b/WireAuthentication/Tests/WireAuthenticationUITests/Views/DetermineAuthMethod/DetermineAuthMethodViewModelTests.swift
@@ -156,7 +156,12 @@ final class DetermineAuthMethodViewModelTests: XCTestCase, DetermineAuthMethodVi
     // MARK: - Helpers
 
     @MainActor
-    private func makeSUT(allowsMultipleBackends: Bool, existingBackendHosts: Set<String>) {
+    private func makeSUT(
+        allowsMultipleBackends: Bool,
+        existingBackendHosts: Set<String>,
+        emailOrSSOCode: String = "",
+        overrideAllowEmailLoginOnly: Bool = false
+    ) {
         sut = DetermineAuthMethodViewModel(
             factory: self,
             router: router,
@@ -164,7 +169,8 @@ final class DetermineAuthMethodViewModelTests: XCTestCase, DetermineAuthMethodVi
             environment: Self.backendEnvironment(host: "flow.example.com"),
             existsAnotherAccount: !existingBackendHosts.isEmpty,
             allowsMultipleBackends: allowsMultipleBackends,
-            existingBackendHosts: existingBackendHosts
+            existingBackendHosts: existingBackendHosts,
+            overrideAllowEmailLoginOnly: overrideAllowEmailLoginOnly
         )
     }
 

--- a/WirePreviewApps/WireAuthenticationApp/ContentView.swift
+++ b/WirePreviewApps/WireAuthenticationApp/ContentView.swift
@@ -80,7 +80,8 @@ struct ContentView: View {
                         ]
                     )
                 ),
-                registrationAnalyticsTracker: MockPersonalAccountCreationAnalyticsTracker()
+                registrationAnalyticsTracker: MockPersonalAccountCreationAnalyticsTracker(),
+                overrideAllowEmailLoginOnly: false
             ).view
     }
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
@@ -347,7 +347,8 @@ final class AuthenticationInterfaceBuilder {
             ssoCallbackURLScheme: Bundle.ssoURLScheme ?? "wire-sso",
             appStoreURL: WireURLs.shared.appOnItunes,
             accountsPublisher: CurrentValuePublisher(subject: CurrentValueSubject(accounts)),
-            registrationAnalyticsTracker: registrationAnalyticsTracker
+            registrationAnalyticsTracker: registrationAnalyticsTracker,
+            overrideAllowEmailLoginOnly: featureProvider.allowOnlyEmailLogin
         )
 
         return (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24853" title="WPB-24853" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24853</a>  [iOS] [Registration] Account creation error occurs when attempting signup by user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry-pick of #4856 onto the 4.16 release branch.
apply cherry-pick for localizations: https://github.com/wireapp/wire-ios/pull/4903/commits/5403ad3a3f3165b9f0bd8c956a17221bef9b43fb

## Summary

- Restrict the new SwiftUI auth flow to email login only when `ALLOW_ONLY_EMAIL_LOGIN` is set (WPB-24853)

## Issue

When the build is configured for email-login only, the new `WireAuthentication` flow still presented the generic "Email or SSO code" entry point and could route users into registration. This wires the existing `ALLOW_ONLY_EMAIL_LOGIN` flag through to the new auth module.

## Testing

1. Build with `ALLOW_ONLY_EMAIL_LOGIN` set — confirm the field reads "Email", SSO code does not enable "Next", and a valid email goes straight to login.
2. Build without the flag — confirm default email-or-SSO behaviour is unchanged.


🤖 Generated with [Claude Code](https://claude.com/claude-code)