### PR TITLE
fix: nightly to pick only non critical tests - WPB-26534

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -621,6 +621,7 @@ platform :ios do
             xcargs: ci_args
         }
         run_tests_options[:only_testing] = options[:only_testing] if options[:only_testing]&.any?
+        run_tests_options[:skip_testing] = options[:skip_testing] if options[:skip_testing]&.any?
 
         run_tests(run_tests_options)
     end


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26534" title="WPB-26534" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26534</a>  [iOS] Fix nightly to run only non critical tests on develop
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

_Please describe the issue._

Nightly test run (test_develop.yml) is configured with ui_test_tags: "!critical",to run all non-critical UI tests and skip the critical ones. Instead, it runs all UI tests.
skip_testing was unfortunately missed here, so xcodebuild ran the all UI test suite not just the !critical.

**Changeset**

Forward skip_testing to run_tests in test_plan:

`run_tests_options[:skip_testing] = options[:skip_testing] if options[:skip_testing]&.any?`

### Testing

_Describe how to test._

Only affects nightly tests runs.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
