### PR TITLE
chore: skip building beta on LTS branch - WPB-26561

### DIFF
--- a/.github/workflows/beta_app_release.yml
+++ b/.github/workflows/beta_app_release.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   testflight_beta:
+    if: ${{ github.ref != format('refs/heads/{0}', vars.LTS_RELEASE) }}
     uses: ./.github/workflows/_reusable_app_release.yml
     with:
       countly_enabled: true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26561" title="WPB-26561" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26561</a>  [iOS] reduce CI bottleneck
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Skip building Beta builds automatically on LTS branch

### Testing

Merge and check that LTS branch don't produce Beta builds 4.16.4

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
