### PR TITLE
chore: inline xcresult analysis, remove per-framework macOS runners - WPB-26561

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -180,6 +180,27 @@ jobs:
         run: |
           echo "xcresult files: ${{ steps.find-xcresults.outputs.xcresult_files }}"
 
+      - name: Annotate test failures
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        continue-on-error: true
+        run: |
+          python3 -c "
+import xml.etree.ElementTree as ET, glob, sys
+files = glob.glob('build/reports/*.junit') + glob.glob('artifacts/**/*.junit', recursive=True)
+for f in files:
+    try:
+        for tc in ET.parse(f).iter('testcase'):
+            failure = tc.find('failure')
+            if failure is not None:
+                classname = tc.get('classname', '')
+                name = tc.get('name', 'Unknown')
+                msg = (failure.get('message') or failure.text or '').replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
+                title = f'{classname}.{name}'.replace(',', '')
+                print(f'::error title={title}::{msg}')
+    except Exception as e:
+        print(f'::warning::Cannot parse {f}: {e}', file=sys.stderr)
+"
+
       - name: Upload .xcresult files as artifact
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -304,44 +325,6 @@ jobs:
             **Commit:** [${{ env.commit_sha }}](https://github.com/wireapp/wire-ios/commit/${{ env.commit_sha }})
             **Triggered by:** ${{ github.triggering_actor }}
             **Build log:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-  analyze-xcresults:
-    needs: run-tests
-    name: Analyze xcresults
-    if: ${{ always() && github.event_name == 'pull_request' }}
-    runs-on: ghcr.io/cirruslabs/macos-runner:sequoia
-    strategy:
-      matrix:
-        xcresult_file: ${{ fromJson(needs.run-tests.outputs.xcresult_files) }}
-      fail-fast: false # avoid to fail one job
-    steps:
-      - name: Sanitize branch name
-        run: |
-          if [ -n "${{ inputs.branch }}" ]; then
-            BRANCH="${{ inputs.branch }}"
-          elif [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "merge_group" ]; then
-            BRANCH="${{ github.head_ref }}"
-          else
-            BRANCH="${GITHUB_REF#refs/heads/}"
-          fi
-          SANITIZED_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/_/g')
-          echo "SANITIZED_BRANCH=$SANITIZED_BRANCH" >> $GITHUB_ENV
-
-      - name: Download .xcresult files
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: XCResults for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
-          path: ./artifacts
-
-      - name: Display downloaded files
-        run: ls -R
-      
-      - name: Analyze .xcresult file
-        uses: wireapp/analyze-xcoderesults-action@6d612319f44cb3d1e3d3a9beaf9495670e7c4077 # v1.0.0
-        with:
-          results: ${{ matrix.xcresult_file }}
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   upload-test-results-datadadog:
     name: Upload to Datadog

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -183,23 +183,7 @@ jobs:
       - name: Annotate test failures
         if: ${{ always() && github.event_name == 'pull_request' }}
         continue-on-error: true
-        run: |
-          python3 -c "
-import xml.etree.ElementTree as ET, glob, sys
-files = glob.glob('build/reports/*.junit') + glob.glob('artifacts/**/*.junit', recursive=True)
-for f in files:
-    try:
-        for tc in ET.parse(f).iter('testcase'):
-            failure = tc.find('failure')
-            if failure is not None:
-                classname = tc.get('classname', '')
-                name = tc.get('name', 'Unknown')
-                msg = (failure.get('message') or failure.text or '').replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
-                title = f'{classname}.{name}'.replace(',', '')
-                print(f'::error title={title}::{msg}')
-    except Exception as e:
-        print(f'::warning::Cannot parse {f}: {e}', file=sys.stderr)
-"
+        run: ruby scripts/annotate_test_failures.rb
 
       - name: Upload .xcresult files as artifact
         if: always()

--- a/scripts/annotate_test_failures.rb
+++ b/scripts/annotate_test_failures.rb
@@ -2,6 +2,14 @@
 # Parses JUnit XML test results and emits GitHub Actions error annotations.
 require 'rexml/document'
 
+def encode_property(str)
+  str.gsub('%', '%25').gsub("\r", '%0D').gsub("\n", '%0A').gsub(':', '%3A').gsub(',', '%2C')
+end
+
+def encode_data(str)
+  str.gsub('%', '%25').gsub("\r", '%0D').gsub("\n", '%0A')
+end
+
 files = Dir.glob('build/reports/*.junit') + Dir.glob('artifacts/**/*.junit')
 files.each do |f|
   begin
@@ -9,12 +17,11 @@ files.each do |f|
       next unless (failure = tc.elements['failure'])
       classname = tc.attributes['classname'] || ''
       name      = tc.attributes['name'] || 'Unknown'
-      msg = (failure.attributes['message'] || failure.text || '')
-              .gsub('%', '%25').gsub("\r", '%0D').gsub("\n", '%0A')
-      title = "#{classname}.#{name}".gsub(',', '')
+      title = encode_property("#{classname}.#{name}")
+      msg   = encode_data(failure.attributes['message'] || failure.text || '')
       puts "::error title=#{title}::#{msg}"
     end
   rescue => e
-    warn "::warning::Cannot parse #{f}: #{e}"
+    warn "::warning::#{encode_data(e.to_s)}"
   end
 end

--- a/scripts/annotate_test_failures.rb
+++ b/scripts/annotate_test_failures.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# Parses JUnit XML test results and emits GitHub Actions error annotations.
+require 'rexml/document'
+
+files = Dir.glob('build/reports/*.junit') + Dir.glob('artifacts/**/*.junit')
+files.each do |f|
+  begin
+    REXML::Document.new(File.read(f)).elements.each('//testcase') do |tc|
+      next unless (failure = tc.elements['failure'])
+      classname = tc.attributes['classname'] || ''
+      name      = tc.attributes['name'] || 'Unknown'
+      msg = (failure.attributes['message'] || failure.text || '')
+              .gsub('%', '%25').gsub("\r", '%0D').gsub("\n", '%0A')
+      title = "#{classname}.#{name}".gsub(',', '')
+      puts "::error title=#{title}::#{msg}"
+    end
+  rescue => e
+    warn "::warning::Cannot parse #{f}: #{e}"
+  end
+end


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26561" title="WPB-26561" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26561</a>  [iOS] reduce CI bottleneck
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


### Issue

The `analyze-xcresults` job in `_reusable_run_tests.yml` spawned one dedicated macOS Cirrus CI runner (`ghcr.io/cirruslabs/macos-runner:sequoia`) per xcresult file (one per framework under test) via a matrix strategy. On a PR touching many frameworks this created N extra `sequoia` runner jobs purely for annotation — adding to the runner queue and wasting capacity.

The analysis is now an inline step inside the existing `run-tests` job. It parses all JUnit XML files produced during the test run and emits `::error` annotations via GitHub's workflow commands, covering every framework at zero additional runner cost.

### Testing

- Open a PR against `release/cycle-4.16` that touches at least one framework.
- Confirm the `analyze-xcresults` job no longer appears in the Actions run.
- Confirm test failure annotations still appear on the PR diff.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.