### PR TITLE
chore: reduce CI runner queue by bin-packing frameworks and inlining xcresult analysis - WPB-26561

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -225,6 +225,27 @@ jobs:
         run: |
           echo "xcresult files: ${{ steps.find-xcresults.outputs.xcresult_files }}"
 
+      - name: Annotate test failures
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        continue-on-error: true
+        run: |
+          python3 -c "
+import xml.etree.ElementTree as ET, glob, sys
+files = glob.glob('build/reports/*.junit') + glob.glob('artifacts/**/*.junit', recursive=True)
+for f in files:
+    try:
+        for tc in ET.parse(f).iter('testcase'):
+            failure = tc.find('failure')
+            if failure is not None:
+                classname = tc.get('classname', '')
+                name = tc.get('name', 'Unknown')
+                msg = (failure.get('message') or failure.text or '').replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
+                title = f'{classname}.{name}'.replace(',', '')
+                print(f'::error title={title}::{msg}')
+    except Exception as e:
+        print(f'::warning::Cannot parse {f}: {e}', file=sys.stderr)
+"
+
       - name: Extract test summary
         if: ${{ always() }}
         id: test-summary
@@ -388,45 +409,6 @@ jobs:
             ${{ steps.html-report-link.outputs.html_report_url != '' && format('**HTML report:** [download zip]({0})', steps.html-report-link.outputs.html_report_url) || '' }}
 
             ${{ steps.test-summary.outputs.report_message }}
-
-  analyze-xcresults:
-    needs: run-tests
-    name: Analyze xcresults
-    if: ${{ always() && github.event_name == 'pull_request' && needs.run-tests.result != 'skipped' && needs.run-tests.outputs.xcresult_files != '' && needs.run-tests.outputs.xcresult_files != '[]' }}
-    runs-on: ghcr.io/cirruslabs/macos-runner:sequoia
-    strategy:
-      matrix:
-        xcresult_file: ${{ fromJson(needs.run-tests.outputs.xcresult_files) }}
-      fail-fast: false # avoid to fail one job
-    steps:
-      - name: Sanitize branch name
-        run: |
-          if [ -n "${{ inputs.branch }}" ]; then
-            BRANCH="${{ inputs.branch }}"
-          elif [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "merge_group" ]; then
-            BRANCH="${{ github.head_ref }}"
-          else
-            BRANCH="${GITHUB_REF#refs/heads/}"
-          fi
-          SANITIZED_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/_/g')
-          echo "SANITIZED_BRANCH=$SANITIZED_BRANCH" >> $GITHUB_ENV
-
-      - name: Download .xcresult files
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: XCResults for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
-          path: ./artifacts
-
-      - name: Display downloaded files
-        run: ls -R
-      
-      - name: Analyze .xcresult file
-        continue-on-error: true
-        uses: wireapp/analyze-xcoderesults-action@228125b6d1488f02b1d80e2040cbfac88c2b1cb3
-        with:
-          results: ${{ matrix.xcresult_file }}
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   upload-test-results-datadadog:
     name: Upload to Datadog

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -228,23 +228,7 @@ jobs:
       - name: Annotate test failures
         if: ${{ always() && github.event_name == 'pull_request' }}
         continue-on-error: true
-        run: |
-          python3 -c "
-import xml.etree.ElementTree as ET, glob, sys
-files = glob.glob('build/reports/*.junit') + glob.glob('artifacts/**/*.junit', recursive=True)
-for f in files:
-    try:
-        for tc in ET.parse(f).iter('testcase'):
-            failure = tc.find('failure')
-            if failure is not None:
-                classname = tc.get('classname', '')
-                name = tc.get('name', 'Unknown')
-                msg = (failure.get('message') or failure.text or '').replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
-                title = f'{classname}.{name}'.replace(',', '')
-                print(f'::error title={title}::{msg}')
-    except Exception as e:
-        print(f'::warning::Cannot parse {f}: {e}', file=sys.stderr)
-"
+        run: ruby scripts/annotate_test_failures.rb
 
       - name: Extract test summary
         if: ${{ always() }}

--- a/.github/workflows/_reusable_run_tests_parallel.yml
+++ b/.github/workflows/_reusable_run_tests_parallel.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       schemes: ${{ steps.list-schemes.outputs.schemes }}
-      batches: ${{ steps.bin-pack.outputs.batches }}
+      batches: ${{ steps.list-schemes.outputs.batches }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/_reusable_run_tests_parallel.yml
+++ b/.github/workflows/_reusable_run_tests_parallel.yml
@@ -17,6 +17,10 @@ on:
         type: string
         required: true
         default: 'failure' # values: always | failure | never
+      max_parallel:
+        type: number
+        default: 4
+        required: false
 
     secrets:
       ZENKINS_USERNAME:
@@ -40,6 +44,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       schemes: ${{ steps.list-schemes.outputs.schemes }}
+      batches: ${{ steps.bin-pack.outputs.batches }}
 
     steps:
       - name: Checkout
@@ -64,32 +69,38 @@ jobs:
           FOLDERS: ${{ inputs.folders }}
           ALL: ${{ inputs.all }}
           TEST_DEPENDENCIES: ${{ inputs.test_dependencies }}
+          MAX_PARALLEL: ${{ inputs.max_parallel }}
         run: |
           bundle exec fastlane list_schemes_json \
             folders:"$FOLDERS" \
             all:$ALL \
-            test_dependencies:$TEST_DEPENDENCIES
+            test_dependencies:$TEST_DEPENDENCIES \
+            max_parallel:$MAX_PARALLEL
           RAW=$(cat /tmp/schemes.json)
           echo "schemes=$RAW" >> "$GITHUB_OUTPUT"
           echo "Schemes to test: $RAW"
+          BATCHES=$(cat /tmp/batches.json)
+          echo "batches=$BATCHES" >> "$GITHUB_OUTPUT"
+          echo "Batches to test: $BATCHES"
 
-  # ── 2. One job per framework, all in parallel ───────────────────────────────
+  # ── 2. One job per batch (bin-packed frameworks), up to max_parallel runners ─
   test-framework:
-    name: "Test ${{ matrix.scheme }}"
+    name: "Test batch ${{ matrix.batch_index }} (${{ matrix.schemes }})"
     needs: generate-framework-list
-    if: ${{ needs.generate-framework-list.outputs.schemes != '[]' && needs.generate-framework-list.outputs.schemes != '' }}
+    if: ${{ needs.generate-framework-list.outputs.batches != '[]' && needs.generate-framework-list.outputs.batches != '' }}
     runs-on: ghcr.io/cirruslabs/macos-runner:tahoe
     permissions:
       contents: read
       pull-requests: write
       checks: write
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.scheme }}
+      group: ${{ github.workflow }}-${{ github.ref }}-batch-${{ matrix.batch_index }}
       cancel-in-progress: true
     strategy:
       matrix:
-        include: ${{ fromJson(needs.generate-framework-list.outputs.schemes) }}
+        include: ${{ fromJson(needs.generate-framework-list.outputs.batches) }}
       fail-fast: false
+      max-parallel: ${{ inputs.max_parallel }}
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_USERNAME: ${{ secrets.ZENKINS_USERNAME }}
@@ -105,43 +116,53 @@ jobs:
       - name: Setup test environment
         uses: ./.github/actions/setup-test-environment
 
-      - name: "Test ${{ matrix.scheme }}"
-        timeout-minutes: 15
-        run: bundle exec fastlane select_framework scheme:${{ matrix.scheme }}
+      - name: "Test batch ${{ matrix.batch_index }}"
+        timeout-minutes: 90
+        env:
+          SCHEMES: ${{ matrix.schemes }}
+        run: |
+          for scheme in $SCHEMES; do
+            bundle exec fastlane select_framework scheme:$scheme
+          done
 
       - name: Check for duplicate symbol implementations
         if: always()
         continue-on-error: true
         run: ./scripts/check_duplicate_classes.sh .
 
-      - name: Find .xcresult path
+      - name: Annotate test failures
         if: always()
-        id: find-xcresult
-        run: |
-          XCRESULT=$(find artifacts -type d -name "*.xcresult" | head -n 1)
-          echo "path=$XCRESULT" >> "$GITHUB_OUTPUT"
-
-      - name: Analyze .xcresult
-        if: ${{ always() && steps.find-xcresult.outputs.path != '' }}
         continue-on-error: true
-        uses: wireapp/analyze-xcoderesults-action@228125b6d1488f02b1d80e2040cbfac88c2b1cb3
-        with:
-          results: ${{ steps.find-xcresult.outputs.path }}
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 -c "
+import xml.etree.ElementTree as ET, glob, sys
+files = glob.glob('build/reports/*.junit') + glob.glob('artifacts/**/*.junit', recursive=True)
+for f in files:
+    try:
+        for tc in ET.parse(f).iter('testcase'):
+            failure = tc.find('failure')
+            if failure is not None:
+                classname = tc.get('classname', '')
+                name = tc.get('name', 'Unknown')
+                msg = (failure.get('message') or failure.text or '').replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
+                title = f'{classname}.{name}'.replace(',', '')
+                print(f'::error title={title}::{msg}')
+    except Exception as e:
+        print(f'::warning::Cannot parse {f}: {e}', file=sys.stderr)
+"
 
       - name: Upload .xcresult as artifact
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: "xcresult-${{ matrix.scheme }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
+          name: "xcresult-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: artifacts/**/*.xcresult
 
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: "test-reports-${{ matrix.scheme }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
+          name: "test-reports-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: |
             build/reports/*.junit
             artifacts/**/*.junit
@@ -150,7 +171,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: "snapshots-${{ matrix.scheme }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
+          name: "snapshots-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: |
             **/SnapshotResults/
             xcodebuild*.log
@@ -162,14 +183,14 @@ jobs:
           files: |
             build/reports/*.junit
             artifacts/**/*.junit
-          check_name: "Test Results – ${{ matrix.scheme }}"
+          check_name: "Test Results – batch ${{ matrix.batch_index }}"
           compare_to_earlier_commit: false
 
       - name: Archive DerivedData logs
         if: failure() || cancelled()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: "deriveddata-${{ matrix.scheme }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
+          name: "deriveddata-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: |
             /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/**
             ~/Library/Logs/DiagnosticReports/**

--- a/.github/workflows/_reusable_run_tests_parallel.yml
+++ b/.github/workflows/_reusable_run_tests_parallel.yml
@@ -133,23 +133,7 @@ jobs:
       - name: Annotate test failures
         if: always()
         continue-on-error: true
-        run: |
-          python3 -c "
-import xml.etree.ElementTree as ET, glob, sys
-files = glob.glob('build/reports/*.junit') + glob.glob('artifacts/**/*.junit', recursive=True)
-for f in files:
-    try:
-        for tc in ET.parse(f).iter('testcase'):
-            failure = tc.find('failure')
-            if failure is not None:
-                classname = tc.get('classname', '')
-                name = tc.get('name', 'Unknown')
-                msg = (failure.get('message') or failure.text or '').replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
-                title = f'{classname}.{name}'.replace(',', '')
-                print(f'::error title={title}::{msg}')
-    except Exception as e:
-        print(f'::warning::Cannot parse {f}: {e}', file=sys.stderr)
-"
+        run: ruby scripts/annotate_test_failures.rb
 
       - name: Upload .xcresult as artifact
         if: always()

--- a/.github/workflows/_reusable_run_tests_parallel.yml
+++ b/.github/workflows/_reusable_run_tests_parallel.yml
@@ -19,7 +19,7 @@ on:
         default: 'failure' # values: always | failure | never
       max_parallel:
         type: number
-        default: 4
+        default: 3
         required: false
 
     secrets:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -211,7 +211,7 @@ platform :ios do
         end
         File.write("/tmp/schemes.json", matrix_entries.to_json)
 
-        max_parallel = (options[:max_parallel] || 4).to_i
+        max_parallel = (options[:max_parallel] || 3).to_i
         n = matrix_entries.length
         bins = [max_parallel, n].min
         if bins > 0

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -213,7 +213,7 @@ platform :ios do
 
         max_parallel = (options[:max_parallel] || 3).to_i
         n = matrix_entries.length
-        bins = [max_parallel, n].min
+        bins = [[max_parallel, n].min, 1].max
         if bins > 0
             size = (n.to_f / bins).ceil
             batches = matrix_entries.each_slice(size).each_with_index.map do |chunk, i|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -210,6 +210,19 @@ platform :ios do
             { scheme: scheme_name, needs_lfs: fw&.needs_lfs || false }
         end
         File.write("/tmp/schemes.json", matrix_entries.to_json)
+
+        max_parallel = (options[:max_parallel] || 4).to_i
+        n = matrix_entries.length
+        bins = [max_parallel, n].min
+        if bins > 0
+            size = (n.to_f / bins).ceil
+            batches = matrix_entries.each_slice(size).each_with_index.map do |chunk, i|
+                { batch_index: i, schemes: chunk.map { |s| s[:scheme] }.join(' '), needs_lfs: chunk.any? { |s| s[:needs_lfs] } }
+            end
+        else
+            batches = []
+        end
+        File.write("/tmp/batches.json", batches.to_json)
     end
 
     desc "Prepare for tests"

--- a/scripts/annotate_test_failures.rb
+++ b/scripts/annotate_test_failures.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# Parses JUnit XML test results and emits GitHub Actions error annotations.
+require 'rexml/document'
+
+files = Dir.glob('build/reports/*.junit') + Dir.glob('artifacts/**/*.junit')
+files.each do |f|
+  begin
+    REXML::Document.new(File.read(f)).elements.each('//testcase') do |tc|
+      next unless (failure = tc.elements['failure'])
+      classname = tc.attributes['classname'] || ''
+      name      = tc.attributes['name'] || 'Unknown'
+      msg = (failure.attributes['message'] || failure.text || '')
+              .gsub('%', '%25').gsub("\r", '%0D').gsub("\n", '%0A')
+      title = "#{classname}.#{name}".gsub(',', '')
+      puts "::error title=#{title}::#{msg}"
+    end
+  rescue => e
+    warn "::warning::Cannot parse #{f}: #{e}"
+  end
+end


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26561" title="WPB-26561" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26561</a>  [iOS] reduce CI bottleneck
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


### Issue

Two sources of Cirrus CI macOS runner waste were identified with 53+ jobs queued against 4 available runners:

**1. Parallel workflow — unbounded matrix**
`_reusable_run_tests_parallel.yml` spawned one macOS runner per touched framework with no cap. A single PR touching 10 frameworks would claim 10 runner slots simultaneously; multiple concurrent PRs multiplied this linearly.

Fix: frameworks are now bin-packed into `max_parallel` batches (default 3) directly in the `list_schemes_json` Fastlane lane, which writes `/tmp/batches.json` alongside the existing `/tmp/schemes.json`. The matrix runs over batches instead of individual schemes, capping runner consumption per workflow to 3. A `max_parallel` input is exposed on the reusable workflow for future tuning via the `MAX_PARALLEL_RUNNERS` repo variable.

**2. Sequential workflow — `analyze-xcresults` matrix job**
`_reusable_run_tests.yml` had a separate `analyze-xcresults` job that spawned one dedicated `ghcr.io/cirruslabs/macos-runner:sequoia` Cirrus CI runner per xcresult file to call `wireapp/analyze-xcoderesults-action`. N frameworks = N extra macOS runners just for annotation.

Fix: the job is removed. An inline `Annotate test failures` step inside `run-tests` parses all JUnit XML files already present in the workspace and emits `::error` annotations via GitHub workflow commands, covering every framework at zero additional runner cost.

### Testing

- Trigger a PR run touching 3+ frameworks with `SMART_TESTING_ENABLED=1` and confirm the Actions view shows at most 3 concurrent macOS jobs.
- Confirm `analyze-xcresults` no longer appears as a separate job.
- Confirm test failure annotations still appear on the PR diff.
- Confirm Datadog JUnit upload and Slack notifications still fire in `post-tests`.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.