### PR TITLE
fix: conversation wrongly marked as read - WPB-24856

### DIFF
--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
@@ -469,7 +469,8 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
         _ conversation: Conversation,
         timestamp: Date,
         isFederationEnabled: Bool,
-        isMLSEnabled: Bool
+        isMLSEnabled: Bool,
+        markAsRead: Bool
     ) async {
         guard let conversationType = conversation.type else {
             return
@@ -500,7 +501,8 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
                 withID: id,
                 serverTimestamp: timestamp,
                 isFederationEnabled: isFederationEnabled,
-                isMLSEnabled: isMLSEnabled
+                isMLSEnabled: isMLSEnabled,
+                markAsRead: markAsRead
             )
 
         case .`self`:
@@ -1068,14 +1070,20 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
     ///
     /// - Parameter conversation: The up-to-date conversation object.
     /// - Parameter id: The conversation ID.
-    /// - Parameter isFederationEnabled: A flag indicating whether a federation is enabled.
+    /// - Parameter serverTimestamp: The timestamp associated with the server update used to set last server/modified
+    /// dates.
+    /// - Parameter isFederationEnabled: A flag indicating whether federation is enabled (controls whether the domain is
+    /// stored).
+    /// - Parameter isMLSEnabled: A flag indicating whether MLS features are enabled (controls MLS status updates).
+    /// - Parameter markAsRead: When true, marks the conversation as read on initial fetch (e.g. slow sync).
 
     private func updateOrCreateGroupConversation(
         from conversation: Conversation,
         withID id: UUID,
         serverTimestamp: Date,
         isFederationEnabled: Bool,
-        isMLSEnabled: Bool
+        isMLSEnabled: Bool,
+        markAsRead: Bool
     ) async {
         var isInitialFetch = false
 
@@ -1169,8 +1177,12 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
                     users: localConversation.localParticipants
                 )
 
-                // Slow synced conversations should be considered read from the start
-                localConversation.lastReadServerTimeStamp = localConversation.lastModifiedDate
+                // Slow synced conversations should be considered read from the start,
+                // but only when called from the slow sync path (not from UpdateConversationItem,
+                // which also runs for new conversations created while the app is backgrounded).
+                if markAsRead {
+                    localConversation.lastReadServerTimeStamp = localConversation.lastModifiedDate
+                }
 
                 Flow.createGroup.checkpoint(
                     description: "new system message for conversation inserted"

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
@@ -54,13 +54,16 @@ public protocol ConversationLocalStoreProtocol {
     /// Stores a given conversation locally.
     /// - Parameter conversation: The conversation to store locally.
     /// - Parameter timestamp: The date the conversation was created or last modified.
-    /// - Parameter isFederationEnabled: A flag indicating whether a `Federation` is enabled.
+    /// - Parameter isFederationEnabled: A flag indicating whether federation is enabled.
+    /// - Parameter isMLSEnabled: A flag indicating whether MLS features are enabled (affects MLS status updates).
+    /// - Parameter markAsRead: When true, marks the conversation as read on initial fetch (e.g. during slow sync).
 
     func storeConversation(
         _ conversation: WireDomain.Conversation,
         timestamp: Date,
         isFederationEnabled: Bool,
-        isMLSEnabled: Bool
+        isMLSEnabled: Bool,
+        markAsRead: Bool
     ) async
 
     /// Stores a flag indicating whether a conversation requires an update from backend.

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
@@ -87,7 +87,8 @@ public final class ConversationRepository: ConversationRepositoryProtocol {
                 conversation.toDomainModel(),
                 timestamp: .now,
                 isFederationEnabled: isFederationEnabled,
-                isMLSEnabled: isMLSEnabled
+                isMLSEnabled: isMLSEnabled,
+                markAsRead: false
             )
         } else if conversationList.notFound.contains(qualifiedID) {
             throw ConversationRepositoryError.conversationNotFound
@@ -125,7 +126,8 @@ public final class ConversationRepository: ConversationRepositoryProtocol {
             conversation,
             timestamp: timestamp,
             isFederationEnabled: isFederationEnabled,
-            isMLSEnabled: isMLSEnabled
+            isMLSEnabled: isMLSEnabled,
+            markAsRead: false
         )
     }
 
@@ -147,7 +149,8 @@ public final class ConversationRepository: ConversationRepositoryProtocol {
             mlsConversation.toDomainModel(),
             timestamp: .now,
             isFederationEnabled: isFederationEnabled,
-            isMLSEnabled: isMLSEnabled
+            isMLSEnabled: isMLSEnabled,
+            markAsRead: false
         )
 
         return (mlsGroupID, mlsPublicKeys)

--- a/WireDomain/Sources/WireDomain/Synchronization/PullAllConversationsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullAllConversationsSync.swift
@@ -99,7 +99,8 @@ public final class PullAllConversationsSync: PullAllConversationsSyncProtocol {
                 conversation.toDomainModel(),
                 timestamp: conversation.lastEventTime ?? Date.distantPast,
                 isFederationEnabled: isFederationEnabled,
-                isMLSEnabled: isMLSEnabled
+                isMLSEnabled: isMLSEnabled,
+                markAsRead: true
             )
         }
 

--- a/WireDomain/Sources/WireDomain/Synchronization/PullMLSOneOnOneSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullMLSOneOnOneSync.swift
@@ -59,7 +59,8 @@ public struct PullMLSOneOnOneSync: PullMLSOneOnOneSyncProtocol {
             conversation.toDomainModel(),
             timestamp: .now,
             isFederationEnabled: isFederationEnabled,
-            isMLSEnabled: isMLSEnabled
+            isMLSEnabled: isMLSEnabled,
+            markAsRead: false
         )
 
         return (mlsGroupID, publicKeys)

--- a/WireDomain/Sources/WireDomain/UseCases/CreateChannelUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/CreateChannelUseCase.swift
@@ -384,7 +384,8 @@ public struct CreateChannelUseCase: CreateChannelUseCaseProtocol {
             conversation.toDomainModel(),
             timestamp: .now,
             isFederationEnabled: isFederationEnabled,
-            isMLSEnabled: true
+            isMLSEnabled: true,
+            markAsRead: false
         )
 
         let qualifiedID = conversation.qualifiedID?.id

--- a/WireDomain/Sources/WireDomain/UseCases/CreateGroupConversationUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/CreateGroupConversationUseCase.swift
@@ -396,7 +396,8 @@ public struct CreateGroupConversationUseCase: CreateGroupConversationUseCaseProt
             conversation.toDomainModel(),
             timestamp: .now,
             isFederationEnabled: isFederationEnabled,
-            isMLSEnabled: isMLSEnabled
+            isMLSEnabled: isMLSEnabled,
+            markAsRead: false
         )
 
         let qualifiedID = conversation.qualifiedID?.id

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -739,17 +739,17 @@ public class MockConversationLocalStoreProtocol: ConversationLocalStoreProtocol 
 
     // MARK: - storeConversation
 
-    public var storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations: [(conversation: WireDomain.Conversation, timestamp: Date, isFederationEnabled: Bool, isMLSEnabled: Bool)] = []
-    public var storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod: ((WireDomain.Conversation, Date, Bool, Bool) async -> Void)?
+    public var storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations: [(conversation: WireDomain.Conversation, timestamp: Date, isFederationEnabled: Bool, isMLSEnabled: Bool, markAsRead: Bool)] = []
+    public var storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod: ((WireDomain.Conversation, Date, Bool, Bool, Bool) async -> Void)?
 
-    public func storeConversation(_ conversation: WireDomain.Conversation, timestamp: Date, isFederationEnabled: Bool, isMLSEnabled: Bool) async {
-        storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.append((conversation: conversation, timestamp: timestamp, isFederationEnabled: isFederationEnabled, isMLSEnabled: isMLSEnabled))
+    public func storeConversation(_ conversation: WireDomain.Conversation, timestamp: Date, isFederationEnabled: Bool, isMLSEnabled: Bool, markAsRead: Bool) async {
+        storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations.append((conversation: conversation, timestamp: timestamp, isFederationEnabled: isFederationEnabled, isMLSEnabled: isMLSEnabled, markAsRead: markAsRead))
 
-        guard let mock = storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod else {
-            fatalError("no mock for `storeConversationTimestampIsFederationEnabledIsMLSEnabled`")
+        guard let mock = storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod else {
+            fatalError("no mock for `storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead`")
         }
 
-        await mock(conversation, timestamp, isFederationEnabled, isMLSEnabled)
+        await mock(conversation, timestamp, isFederationEnabled, isMLSEnabled, markAsRead)
     }
 
     // MARK: - storeConversation

--- a/WireDomain/Tests/WireDomainTests/LocalStores/ConversationLocalStoreTests.swift
+++ b/WireDomain/Tests/WireDomainTests/LocalStores/ConversationLocalStoreTests.swift
@@ -85,7 +85,8 @@ final class ConversationLocalStoreTests: XCTestCase {
             groupConversation.toDomainModel(),
             timestamp: .distantPast,
             isFederationEnabled: false,
-            isMLSEnabled: true
+            isMLSEnabled: true,
+            markAsRead: false
         )
 
         // Then

--- a/WireDomain/Tests/WireDomainTests/Repositories/ConversationRepositoryTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Repositories/ConversationRepositoryTests.swift
@@ -427,7 +427,7 @@ final class ConversationRepositoryTests: XCTestCase {
         }
 
         conversationsLocalStore.fetchConversationIdDomain_MockValue = conversation
-        conversationsLocalStore.addParticipantsAddedByAtDateConversation_MockMethod = { _, _, _, _, _ in }
+        conversationsLocalStore.addParticipantsAddedByAtDateConversation_MockMethod = { _, _, _, _ in }
 
         // When
 

--- a/WireDomain/Tests/WireDomainTests/Repositories/ConversationRepositoryTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Repositories/ConversationRepositoryTests.swift
@@ -93,7 +93,8 @@ final class ConversationRepositoryTests: XCTestCase {
             Scaffolding.conversation,
             Scaffolding.mlsPublicKeys
         )
-        conversationsLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationsLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         // When
 
@@ -108,7 +109,8 @@ final class ConversationRepositoryTests: XCTestCase {
         XCTAssertEqual(pubKeys, Scaffolding.mlsPublicKeys)
         XCTAssertEqual(conversationsAPI.getMLSOneToOneConversationUserIDIn_Invocations.count, 1)
         XCTAssertEqual(
-            conversationsLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationsLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
     }
@@ -145,7 +147,8 @@ final class ConversationRepositoryTests: XCTestCase {
             failed: []
         )
 
-        conversationsLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationsLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         // When
 
@@ -158,7 +161,8 @@ final class ConversationRepositoryTests: XCTestCase {
 
         XCTAssertEqual(conversationsAPI.getConversationsFor_Invocations.count, 1)
         XCTAssertEqual(
-            conversationsLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationsLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
     }
@@ -286,7 +290,8 @@ final class ConversationRepositoryTests: XCTestCase {
     func testStoreConversation_It_Invokes_Local_Store_Method() async {
         // Mock
 
-        conversationsLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationsLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         // When
 
@@ -298,7 +303,8 @@ final class ConversationRepositoryTests: XCTestCase {
         // Then
 
         XCTAssertEqual(
-            conversationsLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationsLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
     }
@@ -421,7 +427,7 @@ final class ConversationRepositoryTests: XCTestCase {
         }
 
         conversationsLocalStore.fetchConversationIdDomain_MockValue = conversation
-        conversationsLocalStore.addParticipantsAddedByAtDateConversation_MockMethod = { _, _, _, _ in }
+        conversationsLocalStore.addParticipantsAddedByAtDateConversation_MockMethod = { _, _, _, _, _ in }
 
         // When
 

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
@@ -70,7 +70,7 @@ final class PullAllConversationsSyncTests: XCTestCase {
             failed: [Scaffolding.conversationID3]
         )
 
-        store.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        store.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
         store.storeConversationNeedsBackendUpdateConversationIDConversationDomain_MockMethod = { _, _, _ in }
         store.storeFailedConversationConversationIDConversationDomain_MockMethod = { _, _ in }
 
@@ -83,7 +83,8 @@ final class PullAllConversationsSyncTests: XCTestCase {
         try XCTAssertCount(api.getConversationsFor_Invocations, count: 1)
         XCTAssertEqual(api.getConversationsFor_Invocations[0], Scaffolding.conversationIDs)
 
-        let storeFoundInvocations = store.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations
+        let storeFoundInvocations = store
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
         try XCTAssertCount(storeFoundInvocations, count: 2)
         XCTAssertEqual(storeFoundInvocations[0].conversation, Scaffolding.localConversation1)
         XCTAssertEqual(storeFoundInvocations[0].isFederationEnabled, Scaffolding.isFederationEnabled)
@@ -164,7 +165,7 @@ final class PullAllConversationsSyncTests: XCTestCase {
             failed: [Scaffolding.conversationID3]
         )
 
-        store.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        store.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
         store.storeConversationNeedsBackendUpdateConversationIDConversationDomain_MockMethod = { _, _, _ in }
         store.storeFailedConversationConversationIDConversationDomain_MockMethod = { _, _ in }
 
@@ -174,7 +175,7 @@ final class PullAllConversationsSyncTests: XCTestCase {
         // Then
         XCTAssertEqual(api.getConversationsFor_Invocations.count, 1)
         XCTAssertEqual(
-            store.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            store.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations.count,
             1
         )
 
@@ -184,7 +185,8 @@ final class PullAllConversationsSyncTests: XCTestCase {
         try XCTAssertCount(api.getConversationsFor_Invocations, count: 1)
         XCTAssertEqual(api.getConversationsFor_Invocations[0], Scaffolding.conversationIDs)
 
-        let storeFoundInvocations = store.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations
+        let storeFoundInvocations = store
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
         try XCTAssertCount(storeFoundInvocations, count: 1)
         XCTAssertEqual(storeFoundInvocations[0].conversation, Scaffolding.localConversation1)
         XCTAssertEqual(storeFoundInvocations[0].isFederationEnabled, Scaffolding.isFederationEnabled)

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullMLSOneOnOneSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullMLSOneOnOneSyncTests.swift
@@ -51,7 +51,7 @@ final class PullMLSOneOnOneSyncTests: XCTestCase {
     func testPull() async throws {
         // Mock
         api.getMLSOneToOneConversationUserIDIn_MockValue = (Scaffolding.conversation, Scaffolding.mlsPublicKeys)
-        store.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        store.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         // When
         let (mlsGroupID, publicKeys) = try await sut.pull(
@@ -65,7 +65,7 @@ final class PullMLSOneOnOneSyncTests: XCTestCase {
         XCTAssertEqual(apiInvocations[0].userID, Scaffolding.userID.uuidString.lowercased())
         XCTAssertEqual(apiInvocations[0].domain, Scaffolding.userDomain)
 
-        let storeInvocations = store.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations
+        let storeInvocations = store.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
         try XCTAssertCount(storeInvocations, count: 1)
         XCTAssertEqual(storeInvocations[0].conversation, Scaffolding.conversation.toDomainModel())
         XCTAssertEqual(storeInvocations[0].isFederationEnabled, Scaffolding.isFederationEnabled)

--- a/WireDomain/Tests/WireDomainTests/UseCases/CreateChannelUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/CreateChannelUseCaseTests.swift
@@ -91,7 +91,8 @@ final class CreateChannelUseCaseTests: XCTestCase {
 
         conversationsAPI.createGroupConversationParameters_MockValue = Scaffolding.conversation
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = mlsConversation
         mlsService.addMembersToConversationWithFor_MockMethod = { _, _ in }
@@ -120,7 +121,8 @@ final class CreateChannelUseCaseTests: XCTestCase {
             1
         )
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)
@@ -167,7 +169,8 @@ final class CreateChannelUseCaseTests: XCTestCase {
             }
         }
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = mlsConversation
         mlsService.addMembersToConversationWithFor_MockMethod = { _, _ in }
@@ -196,7 +199,8 @@ final class CreateChannelUseCaseTests: XCTestCase {
             2
         ) // called twice, first try then retry excluding non federated domains
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)
@@ -227,7 +231,8 @@ final class CreateChannelUseCaseTests: XCTestCase {
             .createGroupConversationParameters_MockValue =
             Scaffolding.conversation
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = mlsConversation
         mlsService.addMembersToConversationWithFor_MockMethod = { [self] users, _ in
@@ -281,7 +286,8 @@ final class CreateChannelUseCaseTests: XCTestCase {
             1
         )
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)
@@ -325,7 +331,8 @@ final class CreateChannelUseCaseTests: XCTestCase {
             .createGroupConversationParameters_MockValue =
             Scaffolding.conversation
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = mlsConversation
         mlsService.addMembersToConversationWithFor_MockMethod = { [self] users, _ in
@@ -374,7 +381,8 @@ final class CreateChannelUseCaseTests: XCTestCase {
             1
         )
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)
@@ -409,7 +417,8 @@ final class CreateChannelUseCaseTests: XCTestCase {
             .createGroupConversationParameters_MockValue =
             Scaffolding.conversation
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = mlsConversation
         mlsService.addMembersToConversationWithFor_MockMethod = { [self] users, _ in
@@ -458,7 +467,8 @@ final class CreateChannelUseCaseTests: XCTestCase {
             1
         )
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)

--- a/WireDomain/Tests/WireDomainTests/UseCases/CreateGroupConversationUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/CreateGroupConversationUseCaseTests.swift
@@ -93,7 +93,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             .createGroupConversationParameters_MockValue =
             Scaffolding.conversation
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = proteusConversation
         mlsService.addMembersToConversationWithFor_MockMethod = { _, _ in }
@@ -123,7 +124,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             1
         )
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)
@@ -178,7 +180,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
                 }
             }
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = proteusConversation
 
@@ -206,7 +209,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             2
         ) // called twice, first try then retry excluding non federated domains
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)
@@ -234,7 +238,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             .createGroupConversationParameters_MockValue =
             Scaffolding.conversation
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = mlsConversation
         mlsService.addMembersToConversationWithFor_MockMethod = { _, _ in }
@@ -264,7 +269,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             1
         )
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)
@@ -312,7 +318,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
                 }
             }
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = mlsConversation
         mlsService.addMembersToConversationWithFor_MockMethod = { _, _ in }
@@ -342,7 +349,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             2
         ) // called twice, first try then retry excluding non federated domains
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)
@@ -373,7 +381,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             .createGroupConversationParameters_MockValue =
             Scaffolding.conversation
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = mlsConversation
         mlsService.addMembersToConversationWithFor_MockMethod = { [self] users, _ in
@@ -428,7 +437,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             1
         )
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)
@@ -472,7 +482,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             .createGroupConversationParameters_MockValue =
             Scaffolding.conversation
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = mlsConversation
         mlsService.addMembersToConversationWithFor_MockMethod = { [self] users, _ in
@@ -522,7 +533,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             1
         )
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)
@@ -557,7 +569,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             .createGroupConversationParameters_MockValue =
             Scaffolding.conversation
 
-        conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_MockMethod = { _, _, _, _ in }
+        conversationLocalStore
+            .storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_MockMethod = { _, _, _, _, _ in }
 
         conversationLocalStore.fetchConversationIdDomain_MockValue = mlsConversation
         mlsService.addMembersToConversationWithFor_MockMethod = { [self] users, _ in
@@ -607,7 +620,8 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
             1
         )
         XCTAssertEqual(
-            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations.count,
+            conversationLocalStore.storeConversationTimestampIsFederationEnabledIsMLSEnabledMarkAsRead_Invocations
+                .count,
             1
         )
         XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 1)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24856" title="WPB-24856" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24856</a>  [iOS] [Messaging] Messages are not displayed correctly when receiving new chats by user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

New group conversations created while the app is backgrounded show no unread indicator after the user opens the app, even though the message is visible when entering the conversation.

### Causes

When a new group conversation is first fetched from the backend via `UpdateConversationItem`, `updateOrCreateGroupConversation` runs with `isInitialFetch = true` and unconditionally sets `lastReadServerTimeStamp = lastModifiedDate`. Because `lastModifiedDate` is derived from the conversation's `lastEventTime` — which the backend sets to the timestamp of the most recent event — it ends up equal to the incoming message's `serverTimestamp`.

When the stored `conversation.proteusMessageAdd` event is then processed, `calculateLastUnreadMessages` queries for messages where `serverTimestamp > lastReadServerTimeStamp`. Since both timestamps are equal, the message is excluded and `internalEstimatedUnreadCount` stays 0.

The `isInitialFetch` flag was originally intended to mark conversations as read during slow sync (fresh install / re-login), where no messages exist in Core Data yet and marking as read prevents badge flooding. However, `isInitialFetch` is true for any conversation first seen by the device, including newly created ones arriving via the NSE while the app is backgrounded.

### Solution

Added a `markAsRead: Bool` parameter to `storeConversation` and `updateOrCreateGroupConversation`. The `lastReadServerTimeStamp` assignment is now gated behind this flag. Only `PullAllConversationsSync` — the genuine slow sync path — passes `markAsRead: true`. All other callers, including `UpdateConversationItem` via `ConversationRepository`, pass `markAsRead: false`.

### Testing

**Requirements:** two Proteus accounts on the same backend.

**Steps:**
1. Log in as User A, background the app and lock the phone.
2. Log in as User B, create a new group conversation with User A and send a message.
3. Unlock the phone and open the Wire app as User A.

**Expected result:** the new conversation appears at the top of the list with an unread indicator.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.