### PR TITLE
chore: reduce CI runner queue depth - WPB-26561

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -225,6 +225,27 @@ jobs:
         run: |
           echo "xcresult files: ${{ steps.find-xcresults.outputs.xcresult_files }}"
 
+      - name: Annotate test failures
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        continue-on-error: true
+        run: |
+          python3 -c "
+import xml.etree.ElementTree as ET, glob, sys
+files = glob.glob('build/reports/*.junit') + glob.glob('artifacts/**/*.junit', recursive=True)
+for f in files:
+    try:
+        for tc in ET.parse(f).iter('testcase'):
+            failure = tc.find('failure')
+            if failure is not None:
+                classname = tc.get('classname', '')
+                name = tc.get('name', 'Unknown')
+                msg = (failure.get('message') or failure.text or '').replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
+                title = f'{classname}.{name}'.replace(',', '')
+                print(f'::error title={title}::{msg}')
+    except Exception as e:
+        print(f'::warning::Cannot parse {f}: {e}', file=sys.stderr)
+"
+
       - name: Extract test summary
         if: ${{ always() }}
         id: test-summary
@@ -388,45 +409,6 @@ jobs:
             ${{ steps.html-report-link.outputs.html_report_url != '' && format('**HTML report:** [download zip]({0})', steps.html-report-link.outputs.html_report_url) || '' }}
 
             ${{ steps.test-summary.outputs.report_message }}
-
-  analyze-xcresults:
-    needs: run-tests
-    name: Analyze xcresults
-    if: ${{ always() && github.event_name == 'pull_request' && needs.run-tests.result != 'skipped' && needs.run-tests.outputs.xcresult_files != '' && needs.run-tests.outputs.xcresult_files != '[]' }}
-    runs-on: ghcr.io/cirruslabs/macos-runner:sequoia
-    strategy:
-      matrix:
-        xcresult_file: ${{ fromJson(needs.run-tests.outputs.xcresult_files) }}
-      fail-fast: false # avoid to fail one job
-    steps:
-      - name: Sanitize branch name
-        run: |
-          if [ -n "${{ inputs.branch }}" ]; then
-            BRANCH="${{ inputs.branch }}"
-          elif [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "merge_group" ]; then
-            BRANCH="${{ github.head_ref }}"
-          else
-            BRANCH="${GITHUB_REF#refs/heads/}"
-          fi
-          SANITIZED_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/_/g')
-          echo "SANITIZED_BRANCH=$SANITIZED_BRANCH" >> $GITHUB_ENV
-
-      - name: Download .xcresult files
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: XCResults for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
-          path: ./artifacts
-
-      - name: Display downloaded files
-        run: ls -R
-      
-      - name: Analyze .xcresult file
-        continue-on-error: true
-        uses: wireapp/analyze-xcoderesults-action@228125b6d1488f02b1d80e2040cbfac88c2b1cb3
-        with:
-          results: ${{ matrix.xcresult_file }}
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   upload-test-results-datadadog:
     name: Upload to Datadog

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -228,23 +228,7 @@ jobs:
       - name: Annotate test failures
         if: ${{ always() && github.event_name == 'pull_request' }}
         continue-on-error: true
-        run: |
-          python3 -c "
-import xml.etree.ElementTree as ET, glob, sys
-files = glob.glob('build/reports/*.junit') + glob.glob('artifacts/**/*.junit', recursive=True)
-for f in files:
-    try:
-        for tc in ET.parse(f).iter('testcase'):
-            failure = tc.find('failure')
-            if failure is not None:
-                classname = tc.get('classname', '')
-                name = tc.get('name', 'Unknown')
-                msg = (failure.get('message') or failure.text or '').replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
-                title = f'{classname}.{name}'.replace(',', '')
-                print(f'::error title={title}::{msg}')
-    except Exception as e:
-        print(f'::warning::Cannot parse {f}: {e}', file=sys.stderr)
-"
+        run: ruby scripts/annotate_test_failures.rb
 
       - name: Extract test summary
         if: ${{ always() }}

--- a/.github/workflows/_reusable_run_tests_parallel.yml
+++ b/.github/workflows/_reusable_run_tests_parallel.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       schemes: ${{ steps.list-schemes.outputs.schemes }}
-      batches: ${{ steps.bin-pack.outputs.batches }}
+      batches: ${{ steps.list-schemes.outputs.batches }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/_reusable_run_tests_parallel.yml
+++ b/.github/workflows/_reusable_run_tests_parallel.yml
@@ -17,6 +17,10 @@ on:
         type: string
         required: true
         default: 'failure' # values: always | failure | never
+      max_parallel:
+        type: number
+        default: 4
+        required: false
 
     secrets:
       ZENKINS_USERNAME:
@@ -40,6 +44,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       schemes: ${{ steps.list-schemes.outputs.schemes }}
+      batches: ${{ steps.bin-pack.outputs.batches }}
 
     steps:
       - name: Checkout
@@ -64,32 +69,38 @@ jobs:
           FOLDERS: ${{ inputs.folders }}
           ALL: ${{ inputs.all }}
           TEST_DEPENDENCIES: ${{ inputs.test_dependencies }}
+          MAX_PARALLEL: ${{ inputs.max_parallel }}
         run: |
           bundle exec fastlane list_schemes_json \
             folders:"$FOLDERS" \
             all:$ALL \
-            test_dependencies:$TEST_DEPENDENCIES
+            test_dependencies:$TEST_DEPENDENCIES \
+            max_parallel:$MAX_PARALLEL
           RAW=$(cat /tmp/schemes.json)
           echo "schemes=$RAW" >> "$GITHUB_OUTPUT"
           echo "Schemes to test: $RAW"
+          BATCHES=$(cat /tmp/batches.json)
+          echo "batches=$BATCHES" >> "$GITHUB_OUTPUT"
+          echo "Batches to test: $BATCHES"
 
-  # ── 2. One job per framework, all in parallel ───────────────────────────────
+  # ── 2. One job per batch (bin-packed frameworks), up to max_parallel runners ─
   test-framework:
-    name: "Test ${{ matrix.scheme }}"
+    name: "Test batch ${{ matrix.batch_index }} (${{ matrix.schemes }})"
     needs: generate-framework-list
-    if: ${{ needs.generate-framework-list.outputs.schemes != '[]' && needs.generate-framework-list.outputs.schemes != '' }}
+    if: ${{ needs.generate-framework-list.outputs.batches != '[]' && needs.generate-framework-list.outputs.batches != '' }}
     runs-on: ghcr.io/cirruslabs/macos-runner:tahoe
     permissions:
       contents: read
       pull-requests: write
       checks: write
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.scheme }}
+      group: ${{ github.workflow }}-${{ github.ref }}-batch-${{ matrix.batch_index }}
       cancel-in-progress: true
     strategy:
       matrix:
-        include: ${{ fromJson(needs.generate-framework-list.outputs.schemes) }}
+        include: ${{ fromJson(needs.generate-framework-list.outputs.batches) }}
       fail-fast: false
+      max-parallel: ${{ inputs.max_parallel }}
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_USERNAME: ${{ secrets.ZENKINS_USERNAME }}
@@ -105,43 +116,53 @@ jobs:
       - name: Setup test environment
         uses: ./.github/actions/setup-test-environment
 
-      - name: "Test ${{ matrix.scheme }}"
-        timeout-minutes: 15
-        run: bundle exec fastlane select_framework scheme:${{ matrix.scheme }}
+      - name: "Test batch ${{ matrix.batch_index }}"
+        timeout-minutes: 90
+        env:
+          SCHEMES: ${{ matrix.schemes }}
+        run: |
+          for scheme in $SCHEMES; do
+            bundle exec fastlane select_framework scheme:$scheme
+          done
 
       - name: Check for duplicate symbol implementations
         if: always()
         continue-on-error: true
         run: ./scripts/check_duplicate_classes.sh .
 
-      - name: Find .xcresult path
+      - name: Annotate test failures
         if: always()
-        id: find-xcresult
-        run: |
-          XCRESULT=$(find artifacts -type d -name "*.xcresult" | head -n 1)
-          echo "path=$XCRESULT" >> "$GITHUB_OUTPUT"
-
-      - name: Analyze .xcresult
-        if: ${{ always() && steps.find-xcresult.outputs.path != '' }}
         continue-on-error: true
-        uses: wireapp/analyze-xcoderesults-action@228125b6d1488f02b1d80e2040cbfac88c2b1cb3
-        with:
-          results: ${{ steps.find-xcresult.outputs.path }}
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 -c "
+import xml.etree.ElementTree as ET, glob, sys
+files = glob.glob('build/reports/*.junit') + glob.glob('artifacts/**/*.junit', recursive=True)
+for f in files:
+    try:
+        for tc in ET.parse(f).iter('testcase'):
+            failure = tc.find('failure')
+            if failure is not None:
+                classname = tc.get('classname', '')
+                name = tc.get('name', 'Unknown')
+                msg = (failure.get('message') or failure.text or '').replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
+                title = f'{classname}.{name}'.replace(',', '')
+                print(f'::error title={title}::{msg}')
+    except Exception as e:
+        print(f'::warning::Cannot parse {f}: {e}', file=sys.stderr)
+"
 
       - name: Upload .xcresult as artifact
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: "xcresult-${{ matrix.scheme }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
+          name: "xcresult-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: artifacts/**/*.xcresult
 
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: "test-reports-${{ matrix.scheme }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
+          name: "test-reports-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: |
             build/reports/*.junit
             artifacts/**/*.junit
@@ -150,7 +171,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: "snapshots-${{ matrix.scheme }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
+          name: "snapshots-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: |
             **/SnapshotResults/
             xcodebuild*.log
@@ -162,14 +183,14 @@ jobs:
           files: |
             build/reports/*.junit
             artifacts/**/*.junit
-          check_name: "Test Results – ${{ matrix.scheme }}"
+          check_name: "Test Results – batch ${{ matrix.batch_index }}"
           compare_to_earlier_commit: false
 
       - name: Archive DerivedData logs
         if: failure() || cancelled()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: "deriveddata-${{ matrix.scheme }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
+          name: "deriveddata-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: |
             /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/**
             ~/Library/Logs/DiagnosticReports/**

--- a/.github/workflows/_reusable_run_tests_parallel.yml
+++ b/.github/workflows/_reusable_run_tests_parallel.yml
@@ -133,23 +133,7 @@ jobs:
       - name: Annotate test failures
         if: always()
         continue-on-error: true
-        run: |
-          python3 -c "
-import xml.etree.ElementTree as ET, glob, sys
-files = glob.glob('build/reports/*.junit') + glob.glob('artifacts/**/*.junit', recursive=True)
-for f in files:
-    try:
-        for tc in ET.parse(f).iter('testcase'):
-            failure = tc.find('failure')
-            if failure is not None:
-                classname = tc.get('classname', '')
-                name = tc.get('name', 'Unknown')
-                msg = (failure.get('message') or failure.text or '').replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
-                title = f'{classname}.{name}'.replace(',', '')
-                print(f'::error title={title}::{msg}')
-    except Exception as e:
-        print(f'::warning::Cannot parse {f}: {e}', file=sys.stderr)
-"
+        run: ruby scripts/annotate_test_failures.rb
 
       - name: Upload .xcresult as artifact
         if: always()

--- a/.github/workflows/_reusable_run_tests_parallel.yml
+++ b/.github/workflows/_reusable_run_tests_parallel.yml
@@ -19,7 +19,7 @@ on:
         default: 'failure' # values: always | failure | never
       max_parallel:
         type: number
-        default: 4
+        default: 3
         required: false
 
     secrets:

--- a/.github/workflows/beta_app_release.yml
+++ b/.github/workflows/beta_app_release.yml
@@ -10,7 +10,11 @@ on:
         type: boolean
         description: 'Distribute externally: Wire Employees and Externals - Non Wire Employees (Public Beta)'
         default: false
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
   checks: write
 
 jobs:

--- a/.github/workflows/c1_c2_c3_app_release_production.yml
+++ b/.github/workflows/c1_c2_c3_app_release_production.yml
@@ -19,7 +19,11 @@ on:
         required: true
         default: false
 
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
   checks: write
 
 jobs:

--- a/.github/workflows/c1_c2_c3_app_release_restricted.yml
+++ b/.github/workflows/c1_c2_c3_app_release_restricted.yml
@@ -26,7 +26,11 @@ on:
         description: 'Distribute externally: Wire Employees'
         default: true
       
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
   checks: write
 
 jobs:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -6,7 +6,11 @@ on:
     branches:
       - 'develop'
 
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
   checks: write
 
 jobs:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -211,7 +211,7 @@ platform :ios do
         end
         File.write("/tmp/schemes.json", matrix_entries.to_json)
 
-        max_parallel = (options[:max_parallel] || 4).to_i
+        max_parallel = (options[:max_parallel] || 3).to_i
         n = matrix_entries.length
         bins = [max_parallel, n].min
         if bins > 0

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -213,7 +213,7 @@ platform :ios do
 
         max_parallel = (options[:max_parallel] || 3).to_i
         n = matrix_entries.length
-        bins = [max_parallel, n].min
+        bins = [[max_parallel, n].min, 1].max
         if bins > 0
             size = (n.to_f / bins).ceil
             batches = matrix_entries.each_slice(size).each_with_index.map do |chunk, i|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -210,6 +210,19 @@ platform :ios do
             { scheme: scheme_name, needs_lfs: fw&.needs_lfs || false }
         end
         File.write("/tmp/schemes.json", matrix_entries.to_json)
+
+        max_parallel = (options[:max_parallel] || 4).to_i
+        n = matrix_entries.length
+        bins = [max_parallel, n].min
+        if bins > 0
+            size = (n.to_f / bins).ceil
+            batches = matrix_entries.each_slice(size).each_with_index.map do |chunk, i|
+                { batch_index: i, schemes: chunk.map { |s| s[:scheme] }.join(' '), needs_lfs: chunk.any? { |s| s[:needs_lfs] } }
+            end
+        else
+            batches = []
+        end
+        File.write("/tmp/batches.json", batches.to_json)
     end
 
     desc "Prepare for tests"

--- a/scripts/annotate_test_failures.rb
+++ b/scripts/annotate_test_failures.rb
@@ -2,6 +2,14 @@
 # Parses JUnit XML test results and emits GitHub Actions error annotations.
 require 'rexml/document'
 
+def encode_property(str)
+  str.gsub('%', '%25').gsub("\r", '%0D').gsub("\n", '%0A').gsub(':', '%3A').gsub(',', '%2C')
+end
+
+def encode_data(str)
+  str.gsub('%', '%25').gsub("\r", '%0D').gsub("\n", '%0A')
+end
+
 files = Dir.glob('build/reports/*.junit') + Dir.glob('artifacts/**/*.junit')
 files.each do |f|
   begin
@@ -9,12 +17,11 @@ files.each do |f|
       next unless (failure = tc.elements['failure'])
       classname = tc.attributes['classname'] || ''
       name      = tc.attributes['name'] || 'Unknown'
-      msg = (failure.attributes['message'] || failure.text || '')
-              .gsub('%', '%25').gsub("\r", '%0D').gsub("\n", '%0A')
-      title = "#{classname}.#{name}".gsub(',', '')
+      title = encode_property("#{classname}.#{name}")
+      msg   = encode_data(failure.attributes['message'] || failure.text || '')
       puts "::error title=#{title}::#{msg}"
     end
   rescue => e
-    warn "::warning::Cannot parse #{f}: #{e}"
+    warn "::warning::#{encode_data(e.to_s)}"
   end
 end

--- a/scripts/annotate_test_failures.rb
+++ b/scripts/annotate_test_failures.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# Parses JUnit XML test results and emits GitHub Actions error annotations.
+require 'rexml/document'
+
+files = Dir.glob('build/reports/*.junit') + Dir.glob('artifacts/**/*.junit')
+files.each do |f|
+  begin
+    REXML::Document.new(File.read(f)).elements.each('//testcase') do |tc|
+      next unless (failure = tc.elements['failure'])
+      classname = tc.attributes['classname'] || ''
+      name      = tc.attributes['name'] || 'Unknown'
+      msg = (failure.attributes['message'] || failure.text || '')
+              .gsub('%', '%25').gsub("\r", '%0D').gsub("\n", '%0A')
+      title = "#{classname}.#{name}".gsub(',', '')
+      puts "::error title=#{title}::#{msg}"
+    end
+  rescue => e
+    warn "::warning::Cannot parse #{f}: #{e}"
+  end
+end


### PR DESCRIPTION
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26561">WPB-26561</a> [iOS] reduce CI bottleneck
</td>
</table>

<!--jira-description-action-hidden-marker-end-->

### Issue

With 4 macOS runners and 53+ queued jobs, the CI pipeline was severely starved. Multiple root causes:

1. **No `max-parallel` cap** on the parallel test matrix — one runner per framework, so N frameworks × M concurrent PRs = N×M runner slots requested simultaneously.
2. **`analyze-xcresults` job** spawned one dedicated Cirrus CI `sequoia` macOS runner per xcresult file just for annotations.
3. **Superseded build runs** (Edge, Beta, C1/C2/C3) were not cancelled when a newer commit pushed to the same branch.

### Changes

**Bin-pack framework tests into batches (`_reusable_run_tests_parallel.yml`)**
- Added `max_parallel` input (default 3, leaving 1 runner free for build jobs)
- Fastlane `list_schemes_json` lane now bin-packs schemes into ≤`max_parallel` batches and writes `/tmp/batches.json`
- Matrix switches from per-scheme to per-batch; each batch runner executes its schemes sequentially
- Fixed step ID reference (`steps.bin-pack` → `steps.list-schemes`) that would have silently skipped all batched tests

**Replace `analyze-xcresults` matrix job with inline annotation step**
- Removed the separate job that used a matrix of Cirrus CI `sequoia` runners (one per xcresult)
- Added `ruby scripts/annotate_test_failures.rb` as an inline step in the existing test job
- Ruby script uses only `rexml/document` from stdlib — no gem dependencies
- Workflow command properties are correctly percent-encoded (`%`, `\r`, `\n`, `:`, `,`)

**Cancel superseded build runs**
- Added `concurrency: cancel-in-progress: true` keyed on `${{ github.workflow }}-${{ github.ref }}` to Edge, Beta, C1/C2/C3 Production, and C1/C2/C3 Restricted workflows
- A newer push/dispatch on the same branch cancels the older run; different release branches (`cycle-4.16` vs `cycle-4.22`) remain independent

### Testing

- Open a PR touching multiple frameworks and confirm at most 3 parallel macOS test jobs are active at once
- Confirm the `analyze-xcresults` job no longer appears in Actions runs
- Push two commits in quick succession to `develop` and confirm the first Edge build is cancelled

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.