### PR TITLE
chore: cancel superseded build runs on same branch - WPB-26561

### DIFF
--- a/.github/workflows/beta_app_release.yml
+++ b/.github/workflows/beta_app_release.yml
@@ -10,7 +10,11 @@ on:
         type: boolean
         description: 'Distribute externally: Wire Employees and Externals - Non Wire Employees (Public Beta)'
         default: false
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
   checks: write
 
 jobs:

--- a/.github/workflows/c1_c2_c3_app_release_production.yml
+++ b/.github/workflows/c1_c2_c3_app_release_production.yml
@@ -19,7 +19,11 @@ on:
         required: true
         default: false
 
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
   checks: write
 
 jobs:

--- a/.github/workflows/c1_c2_c3_app_release_restricted.yml
+++ b/.github/workflows/c1_c2_c3_app_release_restricted.yml
@@ -26,7 +26,11 @@ on:
         description: 'Distribute externally: Wire Employees'
         default: true
       
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
   checks: write
 
 jobs:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -6,7 +6,11 @@ on:
     branches:
       - 'develop'
 
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
   checks: write
 
 jobs:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26561" title="WPB-26561" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26561</a>  [iOS] reduce CI bottleneck
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


### Issue

When two commits land on the same branch in quick succession, the older build run is not cancelled — both occupy a macOS runner for the full duration. This affects Edge (push to `develop`), Beta (push to `release/cycle-*`), and the C1/C2/C3 builds (manual dispatches).

### Changes

Added `concurrency: cancel-in-progress: true` keyed on `${{ github.workflow }}-${{ github.ref }}` to four workflows:

- `development.yml` (Edge)
- `beta_app_release.yml` (Beta)
- `c1_c2_c3_app_release_production.yml`
- `c1_c2_c3_app_release_restricted.yml`

The `github.ref` key ensures builds on different release branches (`cycle-4.16` vs `cycle-4.22`) remain independent and never cancel each other.

### Testing

- Push two commits in quick succession to `develop` — confirm the first Edge build is cancelled.
- Trigger two Beta builds on the same release branch — confirm the first is cancelled.
- Trigger a Beta build on `cycle-4.16` and one on `cycle-4.22` — confirm they run independently.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.