### PR TITLE
fix: disabled multi-backend value dismissed by default value - WPB-26079

### DIFF
--- a/WireAuthentication/Sources/WireAuthentication/Components/DetermineAuthMethodComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/DetermineAuthMethodComponent.swift
@@ -103,6 +103,7 @@ extension DetermineAuthMethodComponent: DetermineAuthMethodViewModel.Factory {
             bridge: dependency.bridge,
             environment: networkStack.backendEnvironment,
             existsAnotherAccount: existsAnotherAccount,
+            allowsMultipleBackends: allowsMultipleBackends,
             existingBackendHosts: existingBackendHosts,
             overrideAllowEmailLoginOnly: dependency.overrideAllowEmailLoginOnly
         )

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodViewModel.swift
@@ -79,7 +79,7 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
         environment: BackendEnvironment2,
         emailOrSSOCode: String = "",
         existsAnotherAccount: Bool,
-        allowsMultipleBackends: Bool = true,
+        allowsMultipleBackends: Bool,
         existingBackendHosts: Set<String>,
         isLoading: Bool = false,
         overrideAllowEmailLoginOnly: Bool


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26079" title="WPB-26079" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26079</a>  [iOS] Make Multi-Backend usage configurable at build time
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes an issue that happen when porting PR https://github.com/wireapp/wire-ios/pull/4903.

* remove default value of allowsMultipleBackends

### Testing

Disable multibackend

1. login into 1 backend
2. try to switch to another backend

it should show an alert
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - iOS26 1 - 2026-06-26 at 11 53 53" src="https://github.com/user-attachments/assets/b45f4af6-0610-4673-8e4c-46e0025ed8da" />

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
