### PR TITLE
fix: sharing link over share extension - WPB-24816

### DIFF
--- a/wire-ios/Wire-iOS Share Extension/Sources/Content/SendController.swift
+++ b/wire-ios/Wire-iOS Share Extension/Sources/Content/SendController.swift
@@ -67,19 +67,19 @@ final class SendController {
     ) {
         var sendables: [UnsentSendable] = attachments.compactMap {
             if $0.hasGifImage {
-                return UnsentGifImageSendable(
+                UnsentGifImageSendable(
                     conversation: conversation,
                     sharingSession: sharingSession,
                     attachment: $0
                 )
             } else if $0.hasImage {
-                return UnsentImageSendable(conversation: conversation, sharingSession: sharingSession, attachment: $0)
+                UnsentImageSendable(conversation: conversation, sharingSession: sharingSession, attachment: $0)
             } else if $0.hasURL {
                 // If it's just a link, it should have already been fetched
                 // and included in `text`. Nothing more to add here.
-                return nil
+                nil
             } else {
-                return UnsentFileSendable(conversation: conversation, sharingSession: sharingSession, attachment: $0)
+                UnsentFileSendable(conversation: conversation, sharingSession: sharingSession, attachment: $0)
             }
         }
 

--- a/wire-ios/Wire-iOS Share Extension/Sources/Content/SendController.swift
+++ b/wire-ios/Wire-iOS Share Extension/Sources/Content/SendController.swift
@@ -65,9 +65,6 @@ final class SendController {
         conversation: WireShareEngine.Conversation,
         sharingSession: SharingSession
     ) {
-
-        var linkAttachment: NSItemProvider?
-
         var sendables: [UnsentSendable] = attachments.compactMap {
             if $0.hasGifImage {
                 return UnsentGifImageSendable(
@@ -78,7 +75,8 @@ final class SendController {
             } else if $0.hasImage {
                 return UnsentImageSendable(conversation: conversation, sharingSession: sharingSession, attachment: $0)
             } else if $0.hasURL {
-                linkAttachment = $0
+                // If it's just a link, it should have already been fetched
+                // and included in `text`. Nothing more to add here.
                 return nil
             } else {
                 return UnsentFileSendable(conversation: conversation, sharingSession: sharingSession, attachment: $0)
@@ -89,8 +87,7 @@ final class SendController {
             UnsentTextSendable(
                 conversation: conversation,
                 sharingSession: sharingSession,
-                text: text,
-                attachment: linkAttachment
+                text: text
             ),
             at: 0
         )

--- a/wire-ios/Wire-iOS Share Extension/Sources/Content/UnsentSendable.swift
+++ b/wire-ios/Wire-iOS Share Extension/Sources/Content/UnsentSendable.swift
@@ -94,20 +94,14 @@ class UnsentSendableBase {
 final class UnsentTextSendable: UnsentSendableBase, UnsentSendable {
 
     private var text: String
-    private let attachment: NSItemProvider?
 
     init(
         conversation: WireShareEngine.Conversation,
         sharingSession: SharingSession,
-        text: String,
-        attachment: NSItemProvider? = nil
+        text: String
     ) {
         self.text = text
-        self.attachment = attachment
         super.init(conversation: conversation, sharingSession: sharingSession)
-        if attachment != nil {
-            needsPreparation = true
-        }
     }
 
     func send(completion: @escaping (Sendable?) -> Void) {
@@ -122,15 +116,7 @@ final class UnsentTextSendable: UnsentSendableBase, UnsentSendable {
     func prepare(completion: @escaping () -> Void) {
         precondition(needsPreparation, "Ensure this objects needs preparation, c.f. `needsPreparation`")
         needsPreparation = false
-
-        if let attachment, attachment.hasURL {
-
-            self.attachment?.fetchURL(completion: { _ in
-                completion()
-            })
-        } else {
-            completion()
-        }
+        completion()
     }
 }
 

--- a/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ShareExtensionViewController.swift
+++ b/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ShareExtensionViewController.swift
@@ -162,12 +162,12 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
         currentAccount = accountManager?.selectedAccount
         ExtensionBackupExcluder.exclude()
 
+        if let sortedAttachments = extensionContext?.attachments.sorted {
+            attachments = sortedAttachments
+        }
+
         Task { @MainActor in
             await updateAccount(currentAccount)
-
-            if let sortedAttachments = extensionContext?.attachments.sorted {
-                attachments = sortedAttachments
-            }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24816" title="WPB-24816" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24816</a>  [iOS] [Share ext] Sharing website from Safari doesn't include link
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
When sharing a link from Safari via the Wire share extension, the link isn't included in the text. The issue appears to be a timing issue:
1. Sharing attachments are stored locally, but this doesn't happen immediately because it was moved inside a task that loads the current account.
2. Meanwhile the when the view appears, we try to read the stored attachment to display the link in the text field, but since none are found no link is added.

The solution is to store the attachment earlier. But this created other problems, as it seems that you can only load the attachment once which happens when fetching the URL to append to the text field. When sending the message containing the link, another code path would try to load the attachment again and get stuck, preventing the message from being sent.

But I found that this second load of the attachment wasn't even necessary, so I deleted it.

### Testing
1. Go to www.apple.com in Safari
2. Open the share sheet, tap Wire, see that the link is in the text field.
3. Choose a conversation and tap send.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
