### PR TITLE
fix: background tasks starting in background - WPB-23511

### DIFF
--- a/wire-ios-system/Source/BackgroundTasks.swift
+++ b/wire-ios-system/Source/BackgroundTasks.swift
@@ -28,7 +28,7 @@ public func withBackgroundTask<T: Sendable>(
     try await executer.execute(name: name, operation: operation)
 }
 
-/// A `BackgroundTaskExecuter` that simply executes the operation without any background task management.
+/// A ``BackgroundTaskExecuter`` that simply executes the operation without any background task management.
 public struct PassthroughTaskExecuter: BackgroundTaskExecuter {
 
     public init() {}
@@ -40,4 +40,14 @@ public struct PassthroughTaskExecuter: BackgroundTaskExecuter {
         try await operation()
     }
 
+}
+
+public enum BackgroundTaskError: Error {
+
+    /// The background task was instantiated in while the app is int the background. This may not be allowed by a given
+    /// ``BackgroundTaskExecuter``.
+    case taskInstantiatedInBackground
+
+    /// The system returned `UIBackgroundTaskIdentifier.invalid` when beginning a background task.
+    case invalidTaskIdentifier
 }

--- a/wire-ios-system/Source/BackgroundTasks.swift
+++ b/wire-ios-system/Source/BackgroundTasks.swift
@@ -41,13 +41,3 @@ public struct PassthroughTaskExecuter: BackgroundTaskExecuter {
     }
 
 }
-
-public enum BackgroundTaskError: Error {
-
-    /// The background task was instantiated in while the app is int the background. This may not be allowed by a given
-    /// ``BackgroundTaskExecuter``.
-    case taskInstantiatedInBackground
-
-    /// The system returned `UIBackgroundTaskIdentifier.invalid` when beginning a background task.
-    case invalidTaskIdentifier
-}

--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -205,15 +205,6 @@ public class MockBackgroundTaskApplication: BackgroundTaskApplication, @unchecke
 
     public init() {}
 
-    // MARK: - applicationState
-
-    public var applicationState: UIApplication.State {
-        get { return underlyingApplicationState }
-        set(value) { underlyingApplicationState = value }
-    }
-
-    public var underlyingApplicationState: UIApplication.State!
-
 
     // MARK: - beginBackgroundTask
 

--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -205,6 +205,15 @@ public class MockBackgroundTaskApplication: BackgroundTaskApplication, @unchecke
 
     public init() {}
 
+    // MARK: - applicationState
+
+    public var applicationState: UIApplication.State {
+        get { return underlyingApplicationState }
+        set(value) { underlyingApplicationState = value }
+    }
+
+    public var underlyingApplicationState: UIApplication.State!
+
 
     // MARK: - beginBackgroundTask
 

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -159,6 +159,26 @@ struct AppBackgroundTaskExecuterTests {
     }
 
     @Test
+    @MainActor
+    func `throws CancellationError when the expiration handler fires before the task starts`() async throws {
+        // given
+        let didRunOperation = OSAllocatedUnfairLock(initialState: false)
+        application.beginBackgroundTaskWithNameExpirationHandler_MockMethod = { _, handler in
+            handler?()
+            return UIBackgroundTaskIdentifier(rawValue: 30)
+        }
+
+        // then
+        await #expect(throws: CancellationError.self) {
+            // when
+            try await sut.execute(name: "task") {
+                didRunOperation.withLock { $0 = true }
+            }
+        }
+        #expect(didRunOperation.withLock { $0 } == false)
+    }
+
+    @Test
     func `external cancellation cancels the operation and ends the background task`() async throws {
         // given
         let didCancel = OSAllocatedUnfairLock(initialState: false)

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -35,6 +35,8 @@ struct AppBackgroundTaskExecuterTests {
             UIBackgroundTaskIdentifier(rawValue: 99)
         }
         application.endBackgroundTask_MockMethod = { _ in }
+        application.applicationState = .active
+
         self.sut = AppBackgroundTaskExecuter(application: application)
     }
 

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -29,15 +29,15 @@ struct AppBackgroundTaskExecuterTests {
     let application: MockBackgroundTaskApplication
     let sut: AppBackgroundTaskExecuter
 
+    @MainActor
     init() {
         self.application = MockBackgroundTaskApplication()
         application.beginBackgroundTaskWithNameExpirationHandler_MockMethod = { _, _ in
             UIBackgroundTaskIdentifier(rawValue: 99)
         }
         application.endBackgroundTask_MockMethod = { _ in }
-        application.applicationState = .active
 
-        self.sut = AppBackgroundTaskExecuter(application: application)
+        self.sut = AppBackgroundTaskExecuter(application: application, isInBackground: false)
     }
 
     @Test
@@ -125,9 +125,10 @@ struct AppBackgroundTaskExecuterTests {
     }
 
     @Test
+    @MainActor
     func `throws CancellationError when the app is in the background`() async throws {
         // given
-        application.applicationState = .background
+        let sut = AppBackgroundTaskExecuter(application: application, isInBackground: true)
         let didRunOperation = OSAllocatedUnfairLock(initialState: false)
 
         // then
@@ -139,18 +140,6 @@ struct AppBackgroundTaskExecuterTests {
         }
         #expect(didRunOperation.withLock { $0 } == false)
         #expect(application.beginBackgroundTaskWithNameExpirationHandler_Invocations.isEmpty)
-    }
-
-    @Test
-    func `does not throw when the app is inactive`() async throws {
-        // given
-        application.applicationState = .inactive
-
-        // when
-        let result = try await sut.execute(name: "task") { "result" }
-
-        // then
-        #expect(result == "result")
     }
 
     @Test

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -176,6 +176,7 @@ struct AppBackgroundTaskExecuterTests {
             }
         }
         #expect(didRunOperation.withLock { $0 } == false)
+        #expect(application.endBackgroundTask_Invocations == [UIBackgroundTaskIdentifier(rawValue: 30)])
     }
 
     @Test

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -125,6 +125,51 @@ struct AppBackgroundTaskExecuterTests {
     }
 
     @Test
+    func `throws CancellationError when the app is in the background`() async throws {
+        // given
+        application.applicationState = .background
+        let didRunOperation = OSAllocatedUnfairLock(initialState: false)
+
+        // then
+        await #expect(throws: CancellationError.self) {
+            // when
+            try await sut.execute(name: "task") {
+                didRunOperation.withLock { $0 = true }
+            }
+        }
+        #expect(didRunOperation.withLock { $0 } == false)
+        #expect(application.beginBackgroundTaskWithNameExpirationHandler_Invocations.isEmpty)
+    }
+
+    @Test
+    func `does not throw when the app is inactive`() async throws {
+        // given
+        application.applicationState = .inactive
+
+        // when
+        let result = try await sut.execute(name: "task") { "result" }
+
+        // then
+        #expect(result == "result")
+    }
+
+    @Test
+    func `throws CancellationError when beginBackgroundTask returns invalid`() async throws {
+        // given
+        application.beginBackgroundTaskWithNameExpirationHandler_MockMethod = { _, _ in .invalid }
+        let didRunOperation = OSAllocatedUnfairLock(initialState: false)
+
+        // then
+        await #expect(throws: CancellationError.self) {
+            // when
+            try await sut.execute(name: "task") {
+                didRunOperation.withLock { $0 = true }
+            }
+        }
+        #expect(didRunOperation.withLock { $0 } == false)
+    }
+
+    @Test
     func `external cancellation cancels the operation and ends the background task`() async throws {
         // given
         let didCancel = OSAllocatedUnfairLock(initialState: false)

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -43,7 +43,7 @@ extension UIApplication: BackgroundTaskApplication {}
 /// - warning: This executer should only be used from the main app.
 public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
-    private final class Operation<T>: Sendable {
+    private final class OperationState<T>: Sendable {
         let _taskID = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
         let _task = OSAllocatedUnfairLock(initialState: Optional<Task<T, any Error>>.none)
 
@@ -75,17 +75,17 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
             throw CancellationError()
         }
 
-        let backgroundOperation = Operation<T>()
-        backgroundOperation.taskID = application.beginBackgroundTask(withName: name) {
+        let operationState = OperationState<T>()
+        operationState.taskID = application.beginBackgroundTask(withName: name) {
             WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
 
-            backgroundOperation.task?.cancel()
+            operationState.task?.cancel()
 
             // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
-            endBackgroundTask(backgroundOperation)
+            endBackgroundTask(operationState)
         }
 
-        if backgroundOperation.taskID == .invalid {
+        if operationState.taskID == .invalid {
             WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
             throw CancellationError()
         }
@@ -97,9 +97,9 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
             WireLogger.backgroundActivity.debug("did end background task: \(name)")
             return result
         }
-        backgroundOperation.task = task
+        operationState.task = task
 
-        defer { endBackgroundTask(backgroundOperation) }
+        defer { endBackgroundTask(operationState) }
         return try await withTaskCancellationHandler {
             try await task.value
         } onCancel: {
@@ -107,10 +107,10 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         }
     }
 
-    private nonisolated func endBackgroundTask<T>(_ operation: Operation<T>) {
-        guard operation.taskID != .invalid else { return }
+    private nonisolated func endBackgroundTask<T>(_ operationState: OperationState<T>) {
+        guard operationState.taskID != .invalid else { return }
 
-        application.endBackgroundTask(operation.taskID)
-        operation.taskID = .invalid
+        application.endBackgroundTask(operationState.taskID)
+        operationState.taskID = .invalid
     }
 }

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -32,8 +32,6 @@ public protocol BackgroundTaskApplication: AnyObject, Sendable {
     ) -> UIBackgroundTaskIdentifier
 
     nonisolated func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier)
-
-    var applicationState: UIApplication.State { get }
 }
 
 extension UIApplication: BackgroundTaskApplication {}
@@ -59,9 +57,17 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
     }
 
     private let application: any BackgroundTaskApplication
+    private let applicationState: ApplicationState
 
-    public init(application: any BackgroundTaskApplication) {
+    @MainActor
+    public init(application: any BackgroundTaskApplication, isInBackground: Bool) {
         self.application = application
+        self.applicationState = ApplicationState(isInBackground: isInBackground)
+    }
+
+    @MainActor
+    public func startObservingLifecycleNotifications() {
+        applicationState.startObservingLifecycleNotifications()
     }
 
     public func execute<T: Sendable>(
@@ -70,7 +76,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
     ) async throws -> T {
         let name = name ?? "unnamed"
 
-        guard application.applicationState != .background else {
+        guard applicationState.isInBackground != true else {
             WireLogger.backgroundActivity.debug("background task \(name) cannot begin in the background")
             throw CancellationError()
         }
@@ -82,7 +88,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
             operationState.task?.cancel()
 
             // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
-            endBackgroundTask(operationState)
+            self.endBackgroundTask(operationState)
         }
 
         if operationState.taskID == .invalid {
@@ -107,10 +113,54 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         }
     }
 
+    // MARK: - Private
+
     private nonisolated func endBackgroundTask<T>(_ operationState: OperationState<T>) {
         guard operationState.taskID != .invalid else { return }
 
         application.endBackgroundTask(operationState.taskID)
         operationState.taskID = .invalid
+    }
+}
+
+@MainActor
+private final class ApplicationState: AnyObject {
+
+    nonisolated private let _isInBackground: OSAllocatedUnfairLock<Bool>
+
+    init(isInBackground: Bool) {
+        _isInBackground = OSAllocatedUnfairLock(initialState: isInBackground)
+    }
+
+    func startObservingLifecycleNotifications() {
+        let center = NotificationCenter.default
+        center.addObserver(
+            self,
+            selector: #selector(didEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(willEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+    }
+
+    nonisolated var isInBackground: Bool {
+        _isInBackground.withLock { $0 }
+    }
+
+    // MARK: - Notification Handling
+
+    @objc
+    private func didEnterBackground() {
+        _isInBackground.withLock { $0 = true }
+    }
+
+    @objc
+    private func willEnterForeground() {
+        _isInBackground.withLock { $0 = false }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -97,14 +97,10 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
             // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
             endBackgroundTask(operationState)
         }
+        defer { endBackgroundTask(operationState) }
 
-        if operationState.taskID == .invalid {
-            WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
-            throw CancellationError()
-        }
-
-        if operationState.isExpired {
-            WireLogger.backgroundActivity.debug("background task \(name) expired before starting")
+        if operationState.taskID == .invalid || operationState.isExpired {
+            WireLogger.backgroundActivity.warn("begin background task \(name) failed or expired before starting")
             throw CancellationError()
         }
 
@@ -117,7 +113,6 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         }
         operationState.task = task
 
-        defer { endBackgroundTask(operationState) }
         return try await withTaskCancellationHandler {
             try await task.value
         } onCancel: {

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -71,8 +71,8 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         let name = name ?? "unnamed"
 
         guard application.applicationState != .background else {
-            WireLogger.backgroundActivity.debug("background task \(name) cannot be started in the background")
-            throw BackgroundTaskError.taskInstantiatedInBackground
+            WireLogger.backgroundActivity.debug("background task \(name) cannot begin in the background")
+            throw CancellationError()
         }
 
         let backgroundOperation = Operation<T>()
@@ -87,7 +87,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
         if backgroundOperation.taskID == .invalid {
             WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
-            throw BackgroundTaskError.invalidTaskIdentifier
+            throw CancellationError()
         }
 
         // Don't start the task until we have a valid background task ID.

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -32,6 +32,8 @@ public protocol BackgroundTaskApplication: AnyObject, Sendable {
     ) -> UIBackgroundTaskIdentifier
 
     nonisolated func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier)
+
+    var applicationState: UIApplication.State { get }
 }
 
 extension UIApplication: BackgroundTaskApplication {}
@@ -41,12 +43,18 @@ extension UIApplication: BackgroundTaskApplication {}
 /// - warning: This executer should only be used from the main app.
 public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
-    private final class TaskID: Sendable {
-        let state = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
+    private final class Operation<T>: Sendable {
+        let _taskID = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
+        let _task = OSAllocatedUnfairLock(initialState: Optional<Task<T, any Error>>.none)
 
-        var value: UIBackgroundTaskIdentifier {
-            get { state.withLock { $0 } }
-            set { state.withLock { $0 = newValue } }
+        var taskID: UIBackgroundTaskIdentifier {
+            get { _taskID.withLock { $0 } }
+            set { _taskID.withLock { $0 = newValue } }
+        }
+
+        var task: Task<T, any Error>? {
+            get { _task.withLock { $0 } }
+            set { _task.withLock { $0 = newValue } }
         }
     }
 
@@ -62,27 +70,36 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
     ) async throws -> T {
         let name = name ?? "unnamed"
 
+        guard application.applicationState != .background else {
+            WireLogger.backgroundActivity.debug("background task \(name) cannot be started in the background")
+            throw BackgroundTaskError.taskInstantiatedInBackground
+        }
+
+        let backgroundOperation = Operation<T>()
+        backgroundOperation.taskID = application.beginBackgroundTask(withName: name) {
+            WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
+
+            backgroundOperation.task?.cancel()
+
+            // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
+            endBackgroundTask(backgroundOperation)
+        }
+
+        if backgroundOperation.taskID == .invalid {
+            WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
+            throw BackgroundTaskError.invalidTaskIdentifier
+        }
+
+        // Don't start the task until we have a valid background task ID.
         let task = Task {
             WireLogger.backgroundActivity.debug("will start background task: \(name)")
             let result = try await operation()
             WireLogger.backgroundActivity.debug("did end background task: \(name)")
             return result
         }
+        backgroundOperation.task = task
 
-        let taskID = TaskID()
-        taskID.value = application.beginBackgroundTask(withName: name) {
-            WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
-
-            task.cancel()
-
-            // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
-            endBackgroundTask(taskID)
-        }
-        if taskID.value == .invalid {
-            WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
-        }
-
-        defer { endBackgroundTask(taskID) }
+        defer { endBackgroundTask(backgroundOperation) }
         return try await withTaskCancellationHandler {
             try await task.value
         } onCancel: {
@@ -90,10 +107,10 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         }
     }
 
-    private nonisolated func endBackgroundTask(_ identifier: TaskID) {
-        guard identifier.value != .invalid else { return }
+    private nonisolated func endBackgroundTask<T>(_ operation: Operation<T>) {
+        guard operation.taskID != .invalid else { return }
 
-        application.endBackgroundTask(identifier.value)
-        identifier.value = .invalid
+        application.endBackgroundTask(operation.taskID)
+        operation.taskID = .invalid
     }
 }

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -44,6 +44,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
     private final class OperationState<T>: Sendable {
         let _taskID = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
         let _task = OSAllocatedUnfairLock(initialState: Task<T, any Error>?.none)
+        let _isExpired = OSAllocatedUnfairLock(initialState: false)
 
         var taskID: UIBackgroundTaskIdentifier {
             get { _taskID.withLock { $0 } }
@@ -53,6 +54,11 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         var task: Task<T, any Error>? {
             get { _task.withLock { $0 } }
             set { _task.withLock { $0 = newValue } }
+        }
+
+        var isExpired: Bool {
+            get { _isExpired.withLock { $0 } }
+            set { _isExpired.withLock { $0 = newValue } }
         }
     }
 
@@ -83,8 +89,9 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
         let operationState = OperationState<T>()
         operationState.taskID = application.beginBackgroundTask(withName: name) {
-            WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
+            operationState.isExpired = true
 
+            WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
             operationState.task?.cancel()
 
             // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
@@ -93,6 +100,11 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
         if operationState.taskID == .invalid {
             WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
+            throw CancellationError()
+        }
+
+        if operationState.isExpired {
+            WireLogger.backgroundActivity.debug("background task \(name) expired before starting")
             throw CancellationError()
         }
 

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -43,7 +43,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
     private final class OperationState<T>: Sendable {
         let _taskID = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
-        let _task = OSAllocatedUnfairLock(initialState: Optional<Task<T, any Error>>.none)
+        let _task = OSAllocatedUnfairLock(initialState: Task<T, any Error>?.none)
 
         var taskID: UIBackgroundTaskIdentifier {
             get { _taskID.withLock { $0 } }
@@ -88,7 +88,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
             operationState.task?.cancel()
 
             // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
-            self.endBackgroundTask(operationState)
+            endBackgroundTask(operationState)
         }
 
         if operationState.taskID == .invalid {
@@ -115,7 +115,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
     // MARK: - Private
 
-    private nonisolated func endBackgroundTask<T>(_ operationState: OperationState<T>) {
+    private nonisolated func endBackgroundTask(_ operationState: OperationState<some Any>) {
         guard operationState.taskID != .invalid else { return }
 
         application.endBackgroundTask(operationState.taskID)
@@ -126,10 +126,10 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 @MainActor
 private final class ApplicationState: AnyObject {
 
-    nonisolated private let _isInBackground: OSAllocatedUnfairLock<Bool>
+    private nonisolated let _isInBackground: OSAllocatedUnfairLock<Bool>
 
     init(isInBackground: Bool) {
-        _isInBackground = OSAllocatedUnfairLock(initialState: isInBackground)
+        self._isInBackground = OSAllocatedUnfairLock(initialState: isInBackground)
     }
 
     func startObservingLifecycleNotifications() {

--- a/wire-ios/Wire-iOS/Sources/AppDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/AppDelegate.swift
@@ -398,9 +398,14 @@ private extension AppDelegate {
         queueInitializationOperations(launchOptions: launchOptions)
     }
 
+    @MainActor
     private func createAppRootRouter() {
         let defaultEnvironment = fetchDefaultEnvironment()
-        let appTaskExecuter = AppBackgroundTaskExecuter(application: UIApplication.shared)
+        let appTaskExecuter = AppBackgroundTaskExecuter(
+            application: UIApplication.shared,
+            isInBackground: UIApplication.shared.applicationState == .background
+        )
+        appTaskExecuter.startObservingLifecycleNotifications()
 
         let sessionManager: SessionManager
         do {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23511" title="WPB-23511" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23511</a>  [iOS] NSE is often getting stuck and expiring
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR builds on top of the NSE background activity fix from https://github.com/wireapp/wire-ios/pull/4880 which was found in practice not to work satisfactory.

From logs I realized that a we were starting background tasks. Furthermore it appeared that these tasks started in the background did not have their expiration handlers called meaning that tasks that didn't complete when the apps process froze leading to a broken NSE due to a file lock being acquired but not released in core crypto in the main app.

The documentation for [beginbackgroundtask](https://developer.apple.com/documentation/uikit/uiapplication/beginbackgroundtask(expirationhandler:)) states that we should call this method before entering the background.

> Call this method as early as possible before starting your task, preferably before your app actually enters the background. The method requests the task assertion for your app asynchronously. If you call this method shortly before your app is due to be suspended, there’s a chance that the system might suspend your app before that task assertion is granted.

I did further tests in a dummy app to better understand the behavior of `beginbackgroundtask` when called in the background. I found that although `beginbackgroundtask` started from the background often returned a valid background task ID, in practice these tasks never had their expiration handlers called. Therefore it is not enough to rely on the task ID returned from `beginbackgroundtask` to decide if it is safe to begin a background task.

In this PR I update the code to:

1. Disallow starting a background task if the app is already in the background. Instead throw a cancellation error.
2. If `beginbackgroundtask` returns an invalid ID also throw a cancellation error.

Cancellation errors were chosen rather the more specific errors as callers are often already prepared to handle cancellation errors and in my mind this is a form a cancellation.

### Testing

Observing logs in beta.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
