### PR TITLE
fix: move meetings networking code to v16 - WPB-20279

### DIFF
--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/MeetingsAPI/MeetingsAPI.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/MeetingsAPI/MeetingsAPI.swift
@@ -18,7 +18,7 @@
 
 // sourcery: AutoMockable
 /// An API access object for endpoints concerning meetings.
-public protocol MeetingsAPI {
+public protocol MeetingsAPI: Sendable {
 
     /// Fetch all meetings for the authenticated user.
     ///
@@ -41,5 +41,11 @@ public protocol MeetingsAPI {
     /// - Returns: The updated meeting.
 
     func updateMeeting(meetingID: QualifiedID, parameters: UpdateMeetingParameters) async throws -> MeetingResponse
+
+    /// Delete a meeting for a given conference.
+    ///
+    /// - Parameter meetingID: The id of the conference.
+
+    func deleteMeeting(meetingID: QualifiedID) async throws
 
 }

--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/MeetingsAPI/MeetingsAPI.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/MeetingsAPI/MeetingsAPI.swift
@@ -42,9 +42,9 @@ public protocol MeetingsAPI: Sendable {
 
     func updateMeeting(meetingID: QualifiedID, parameters: UpdateMeetingParameters) async throws -> MeetingResponse
 
-    /// Delete a meeting for a given conference.
+    /// Delete a meeting.
     ///
-    /// - Parameter meetingID: The id of the conference.
+    /// - Parameter meetingID: The id of the meeting to delete.
 
     func deleteMeeting(meetingID: QualifiedID) async throws
 

--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/MeetingsAPI/MeetingsAPIV0.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/MeetingsAPI/MeetingsAPIV0.swift
@@ -46,4 +46,10 @@ class MeetingsAPIV0: MeetingsAPI, VersionedAPI {
         throw MeetingsAPIError.unsupportedEndpointForAPIVersion
     }
 
+    // MARK: - Delete meeting
+
+    func deleteMeeting(meetingID: QualifiedID) async throws {
+        throw MeetingsAPIError.unsupportedEndpointForAPIVersion
+    }
+
 }

--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/MeetingsAPI/MeetingsAPIV15.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/MeetingsAPI/MeetingsAPIV15.swift
@@ -16,62 +16,10 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
-
 class MeetingsAPIV15: MeetingsAPIV14 {
 
     override var apiVersion: APIVersion {
         .v15
-    }
-
-    // MARK: - Create meeting
-
-    override func createMeeting(parameters: CreateMeetingParameters) async throws -> MeetingResponse {
-        let body = try JSONEncoder.defaultEncoder.encode(parameters)
-        let path = "\(pathPrefix)/meetings"
-
-        let request = try URLRequestBuilder(path: path)
-            .withMethod(.post)
-            .withBody(body, contentType: .json)
-            .build()
-
-        let (data, response) = try await apiService.executeRequest(
-            request,
-            requiringAccessToken: true
-        )
-
-        return try ResponseParser()
-            .success(code: .created, type: MeetingResponseV15.self)
-            .failure(code: .forbidden, label: "invalid-op", error: MeetingsAPIError.invalidOperation)
-            .failure(code: .unreachable, error: MeetingsAPIError.unreachableBackends)
-            .parse(code: response.statusCode, data: data)
-    }
-
-    // MARK: - Update meeting
-
-    override func updateMeeting(
-        meetingID: QualifiedID,
-        parameters: UpdateMeetingParameters
-    ) async throws -> MeetingResponse {
-        let body = try JSONEncoder.defaultEncoder.encode(parameters)
-        let path = "\(pathPrefix)/meetings/\(meetingID.domain)/\(meetingID.id.uuidString.lowercased())"
-
-        let request = try URLRequestBuilder(path: path)
-            .withMethod(.put)
-            .withBody(body, contentType: .json)
-            .build()
-
-        let (data, response) = try await apiService.executeRequest(
-            request,
-            requiringAccessToken: true
-        )
-
-        return try ResponseParser()
-            .success(code: .ok, type: MeetingResponseV15.self)
-            .failure(code: .forbidden, label: "invalid-op", error: MeetingsAPIError.invalidOperation)
-            .failure(code: .forbidden, label: "access-denied", error: MeetingsAPIError.accessDenied)
-            .failure(code: .notFound, label: "meeting-not-found", error: MeetingsAPIError.meetingNotFound)
-            .parse(code: response.statusCode, data: data)
     }
 
 }

--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/MeetingsAPI/MeetingsAPIV16.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/MeetingsAPI/MeetingsAPIV16.swift
@@ -16,6 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import Foundation
+
 final class MeetingsAPIV16: MeetingsAPIV15 {
 
     override var apiVersion: APIVersion {
@@ -37,7 +39,78 @@ final class MeetingsAPIV16: MeetingsAPIV15 {
         )
 
         return try ResponseParser()
-            .success(code: .ok, type: MeetingListResponseV15.self)
+            .success(code: .ok, type: MeetingListResponseV16.self)
+            .parse(code: response.statusCode, data: data)
+    }
+
+    // MARK: - Create meeting
+
+    override func createMeeting(parameters: CreateMeetingParameters) async throws -> MeetingResponse {
+        let body = try JSONEncoder.defaultEncoder.encode(parameters)
+        let path = "\(pathPrefix)/meetings"
+
+        let request = try URLRequestBuilder(path: path)
+            .withMethod(.post)
+            .withBody(body, contentType: .json)
+            .build()
+
+        let (data, response) = try await apiService.executeRequest(
+            request,
+            requiringAccessToken: true
+        )
+
+        return try ResponseParser()
+            .success(code: .created, type: MeetingResponseV16.self)
+            .failure(code: .forbidden, label: "invalid-op", error: MeetingsAPIError.invalidOperation)
+            .failure(code: .unreachable, error: MeetingsAPIError.unreachableBackends)
+            .parse(code: response.statusCode, data: data)
+    }
+
+    // MARK: - Update meeting
+
+    override func updateMeeting(
+        meetingID: QualifiedID,
+        parameters: UpdateMeetingParameters
+    ) async throws -> MeetingResponse {
+        let body = try JSONEncoder.defaultEncoder.encode(parameters)
+        let path = "\(pathPrefix)/meetings/\(meetingID.domain)/\(meetingID.id.uuidString.lowercased())"
+
+        let request = try URLRequestBuilder(path: path)
+            .withMethod(.put)
+            .withBody(body, contentType: .json)
+            .build()
+
+        let (data, response) = try await apiService.executeRequest(
+            request,
+            requiringAccessToken: true
+        )
+
+        return try ResponseParser()
+            .success(code: .ok, type: MeetingResponseV16.self)
+            .failure(code: .forbidden, label: "invalid-op", error: MeetingsAPIError.invalidOperation)
+            .failure(code: .forbidden, label: "access-denied", error: MeetingsAPIError.accessDenied)
+            .failure(code: .notFound, label: "meeting-not-found", error: MeetingsAPIError.meetingNotFound)
+            .parse(code: response.statusCode, data: data)
+    }
+
+    // MARK: - Delete meeting
+
+    override func deleteMeeting(meetingID: QualifiedID) async throws {
+        let path = "\(pathPrefix)/meetings/\(meetingID.domain)/\(meetingID.id.uuidString.lowercased())"
+
+        let request = try URLRequestBuilder(path: path)
+            .withMethod(.delete)
+            .build()
+
+        let (data, response) = try await apiService.executeRequest(
+            request,
+            requiringAccessToken: true
+        )
+
+        try ResponseParser()
+            .success(code: .ok)
+            .failure(code: .forbidden, label: "access-denied", error: MeetingsAPIError.accessDenied)
+            .failure(code: .notFound, label: "meeting-not-found", error: MeetingsAPIError.meetingNotFound)
             .parse(code: response.statusCode, data: data)
     }
 

--- a/WireNetwork/Sources/WireNetwork/Models/Meetings/MeetingResponse.swift
+++ b/WireNetwork/Sources/WireNetwork/Models/Meetings/MeetingResponse.swift
@@ -117,15 +117,15 @@ public struct MeetingResponse {
     }
 }
 
-// MARK: - MeetingListResponseV15 (internal, for decoding an array response)
+// MARK: - MeetingListResponseV16 (internal, for decoding an array response)
 
-struct MeetingListResponseV15: Decodable, ToAPIModelConvertible {
+struct MeetingListResponseV16: Decodable, ToAPIModelConvertible {
 
-    private let meetings: [MeetingResponseV15]
+    private let meetings: [MeetingResponseV16]
 
     init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.meetings = try container.decode([MeetingResponseV15].self)
+        self.meetings = try container.decode([MeetingResponseV16].self)
     }
 
     func toAPIModel() -> [MeetingResponse] {
@@ -133,9 +133,9 @@ struct MeetingListResponseV15: Decodable, ToAPIModelConvertible {
     }
 }
 
-// MARK: - MeetingResponseV15 (internal, for decoding)
+// MARK: - MeetingResponseV16 (internal, for decoding)
 
-struct MeetingResponseV15: Decodable, ToAPIModelConvertible {
+struct MeetingResponseV16: Decodable, ToAPIModelConvertible {
 
     let qualifiedID: QualifiedIDV0
     let title: String

--- a/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/MeetingsAPITests.swift
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/MeetingsAPITests.swift
@@ -50,8 +50,8 @@ final class MeetingsAPITests: XCTestCase {
         }
     }
 
-    func testCreateMeeting_Request_Generation_V15() async throws {
-        let apiVersions = APIVersion.v15.andNextVersions
+    func testCreateMeeting_Request_Generation_V16() async throws {
+        let apiVersions = APIVersion.v16.andNextVersions
         let apiService = MockAPIServiceProtocol.withResponses(
             .init(repeating: (.created, "MeetingResponse"), count: apiVersions.count)
         )
@@ -61,8 +61,8 @@ final class MeetingsAPITests: XCTestCase {
         }
     }
 
-    func testUpdateMeeting_Request_Generation_V15() async throws {
-        let apiVersions = APIVersion.v15.andNextVersions
+    func testUpdateMeeting_Request_Generation_V16() async throws {
+        let apiVersions = APIVersion.v16.andNextVersions
         let apiService = MockAPIServiceProtocol.withResponses(
             .init(repeating: (.ok, "MeetingResponse"), count: apiVersions.count)
         )
@@ -80,12 +80,12 @@ final class MeetingsAPITests: XCTestCase {
         }
     }
 
-    // MARK: - createMeeting V15+
+    // MARK: - createMeeting V16+
 
-    func testCreateMeeting_SuccessResponse_201_V15() async throws {
+    func testCreateMeeting_SuccessResponse_201_V16() async throws {
         // Given
         let apiService = MockAPIServiceProtocol.withResponses([(.created, "MeetingResponse")])
-        let sut = APIVersion.v15.buildAPI(apiService: apiService)
+        let sut = APIVersion.v16.buildAPI(apiService: apiService)
 
         // When
         let result = try await sut.createMeeting(parameters: Scaffolding.createParameters)
@@ -110,13 +110,13 @@ final class MeetingsAPITests: XCTestCase {
         }
     }
 
-    func testCreateMeeting_ThrowsInvalidOperation_403_V15() async throws {
+    func testCreateMeeting_ThrowsInvalidOperation_403_V16() async throws {
         // Given
         let apiService = MockAPIServiceProtocol.withError(
             statusCode: .forbidden,
             label: "invalid-op"
         )
-        let sut = APIVersion.v15.buildAPI(apiService: apiService)
+        let sut = APIVersion.v16.buildAPI(apiService: apiService)
 
         // When / Then
         await XCTAssertThrowsErrorAsync(MeetingsAPIError.invalidOperation) {
@@ -124,10 +124,10 @@ final class MeetingsAPITests: XCTestCase {
         }
     }
 
-    func testCreateMeeting_ThrowsUnreachableBackends_533_V15() async throws {
+    func testCreateMeeting_ThrowsUnreachableBackends_533_V16() async throws {
         // Given
         let apiService = MockAPIServiceProtocol.withError(statusCode: .unreachable)
-        let sut = APIVersion.v15.buildAPI(apiService: apiService)
+        let sut = APIVersion.v16.buildAPI(apiService: apiService)
 
         // When / Then
         await XCTAssertThrowsErrorAsync(MeetingsAPIError.unreachableBackends) {
@@ -135,12 +135,12 @@ final class MeetingsAPITests: XCTestCase {
         }
     }
 
-    // MARK: - updateMeeting V15+
+    // MARK: - updateMeeting V16+
 
-    func testUpdateMeeting_SuccessResponse_200_V15() async throws {
+    func testUpdateMeeting_SuccessResponse_200_V16() async throws {
         // Given
         let apiService = MockAPIServiceProtocol.withResponses([(.ok, "MeetingResponse")])
-        let sut = APIVersion.v15.buildAPI(apiService: apiService)
+        let sut = APIVersion.v16.buildAPI(apiService: apiService)
 
         // When
         let result = try await sut.updateMeeting(
@@ -171,13 +171,13 @@ final class MeetingsAPITests: XCTestCase {
         }
     }
 
-    func testUpdateMeeting_ThrowsInvalidOperation_403_V15() async throws {
+    func testUpdateMeeting_ThrowsInvalidOperation_403_V16() async throws {
         // Given
         let apiService = MockAPIServiceProtocol.withError(
             statusCode: .forbidden,
             label: "invalid-op"
         )
-        let sut = APIVersion.v15.buildAPI(apiService: apiService)
+        let sut = APIVersion.v16.buildAPI(apiService: apiService)
 
         // When / Then
         await XCTAssertThrowsErrorAsync(MeetingsAPIError.invalidOperation) {
@@ -185,13 +185,13 @@ final class MeetingsAPITests: XCTestCase {
         }
     }
 
-    func testUpdateMeeting_ThrowsAccessDenied_403_V15() async throws {
+    func testUpdateMeeting_ThrowsAccessDenied_403_V16() async throws {
         // Given
         let apiService = MockAPIServiceProtocol.withError(
             statusCode: .forbidden,
             label: "access-denied"
         )
-        let sut = APIVersion.v15.buildAPI(apiService: apiService)
+        let sut = APIVersion.v16.buildAPI(apiService: apiService)
 
         // When / Then
         await XCTAssertThrowsErrorAsync(MeetingsAPIError.accessDenied) {
@@ -199,13 +199,13 @@ final class MeetingsAPITests: XCTestCase {
         }
     }
 
-    func testUpdateMeeting_ThrowsMeetingNotFound_404_V15() async throws {
+    func testUpdateMeeting_ThrowsMeetingNotFound_404_V16() async throws {
         // Given
         let apiService = MockAPIServiceProtocol.withError(
             statusCode: .notFound,
             label: "meeting-not-found"
         )
-        let sut = APIVersion.v15.buildAPI(apiService: apiService)
+        let sut = APIVersion.v16.buildAPI(apiService: apiService)
 
         // When / Then
         await XCTAssertThrowsErrorAsync(MeetingsAPIError.meetingNotFound) {
@@ -230,8 +230,8 @@ final class MeetingsAPITests: XCTestCase {
         XCTAssertEqual(result[1].title, "Design Review")
     }
 
-    func testListMeetings_ThrowsUnsupportedEndpoint_V0_to_V15() async throws {
-        let unsupportedVersions = APIVersion.allCasesUpTo(.v15)
+    func testListMeetings_ThrowsUnsupportedEndpoint_V0_to_V16() async throws {
+        let unsupportedVersions = APIVersion.allCasesUpTo(.v16)
 
         for version in unsupportedVersions {
             // Given
@@ -256,8 +256,8 @@ final class MeetingsAPITests: XCTestCase {
         try await sut.deleteMeeting(meetingID: Scaffolding.meetingID)
     }
 
-    func testDeleteMeeting_ThrowsUnsupportedEndpoint_V0_to_V15() async throws {
-        let unsupportedVersions = APIVersion.allCasesUpTo(.v15)
+    func testDeleteMeeting_ThrowsUnsupportedEndpoint_V0_to_V16() async throws {
+        let unsupportedVersions = APIVersion.allCasesUpTo(.v16)
 
         for version in unsupportedVersions {
             // Given

--- a/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/MeetingsAPITests.swift
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/MeetingsAPITests.swift
@@ -95,8 +95,8 @@ final class MeetingsAPITests: XCTestCase {
         XCTAssertEqual(result.title, "Engineering Sync")
     }
 
-    func testCreateMeeting_ThrowsUnsupportedEndpoint_V0_to_V14() async throws {
-        let unsupportedVersions = APIVersion.allCasesUpTo(.v14)
+    func testCreateMeeting_ThrowsUnsupportedEndpoint_V0_to_V15() async throws {
+        let unsupportedVersions = APIVersion.allCasesUpTo(.v16)
 
         for version in unsupportedVersions {
             // Given
@@ -153,8 +153,8 @@ final class MeetingsAPITests: XCTestCase {
         XCTAssertEqual(result.title, "Engineering Sync")
     }
 
-    func testUpdateMeeting_ThrowsUnsupportedEndpoint_V0_to_V14() async throws {
-        let unsupportedVersions = APIVersion.allCasesUpTo(.v14)
+    func testUpdateMeeting_ThrowsUnsupportedEndpoint_V0_to_V15() async throws {
+        let unsupportedVersions = APIVersion.allCasesUpTo(.v16)
 
         for version in unsupportedVersions {
             // Given
@@ -230,7 +230,7 @@ final class MeetingsAPITests: XCTestCase {
         XCTAssertEqual(result[1].title, "Design Review")
     }
 
-    func testListMeetings_ThrowsUnsupportedEndpoint_V0_to_V16() async throws {
+    func testListMeetings_ThrowsUnsupportedEndpoint_V0_to_V15() async throws {
         let unsupportedVersions = APIVersion.allCasesUpTo(.v16)
 
         for version in unsupportedVersions {
@@ -256,7 +256,7 @@ final class MeetingsAPITests: XCTestCase {
         try await sut.deleteMeeting(meetingID: Scaffolding.meetingID)
     }
 
-    func testDeleteMeeting_ThrowsUnsupportedEndpoint_V0_to_V16() async throws {
+    func testDeleteMeeting_ThrowsUnsupportedEndpoint_V0_to_V15() async throws {
         let unsupportedVersions = APIVersion.allCasesUpTo(.v16)
 
         for version in unsupportedVersions {

--- a/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/MeetingsAPITests.swift
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/MeetingsAPITests.swift
@@ -72,6 +72,14 @@ final class MeetingsAPITests: XCTestCase {
         }
     }
 
+    func testDeleteMeeting_Request_Generation_V16() async throws {
+        let apiService = MockAPIServiceProtocol.withResponses([(.ok, nil)])
+
+        try await apiSnapshotHelper.verifyRequest(for: [.v16], apiService: apiService) { sut in
+            try await sut.deleteMeeting(meetingID: Scaffolding.meetingID)
+        }
+    }
+
     // MARK: - createMeeting V15+
 
     func testCreateMeeting_SuccessResponse_201_V15() async throws {
@@ -234,6 +242,60 @@ final class MeetingsAPITests: XCTestCase {
             await XCTAssertThrowsErrorAsync(MeetingsAPIError.unsupportedEndpointForAPIVersion) {
                 _ = try await sut.listMeetings()
             }
+        }
+    }
+
+    // MARK: - deleteMeeting V16
+
+    func testDeleteMeeting_SuccessResponse_200_V16() async throws {
+        // Given
+        let apiService = MockAPIServiceProtocol.withResponses([(.ok, nil)])
+        let sut = APIVersion.v16.buildAPI(apiService: apiService)
+
+        // When / Then - no throw expected
+        try await sut.deleteMeeting(meetingID: Scaffolding.meetingID)
+    }
+
+    func testDeleteMeeting_ThrowsUnsupportedEndpoint_V0_to_V15() async throws {
+        let unsupportedVersions = APIVersion.allCasesUpTo(.v15)
+
+        for version in unsupportedVersions {
+            // Given
+            let apiService = MockAPIServiceProtocol()
+            let sut = version.buildAPI(apiService: apiService)
+
+            // When / Then
+            await XCTAssertThrowsErrorAsync(MeetingsAPIError.unsupportedEndpointForAPIVersion) {
+                try await sut.deleteMeeting(meetingID: Scaffolding.meetingID)
+            }
+        }
+    }
+
+    func testDeleteMeeting_ThrowsAccessDenied_403_V16() async throws {
+        // Given
+        let apiService = MockAPIServiceProtocol.withError(
+            statusCode: .forbidden,
+            label: "access-denied"
+        )
+        let sut = APIVersion.v16.buildAPI(apiService: apiService)
+
+        // When / Then
+        await XCTAssertThrowsErrorAsync(MeetingsAPIError.accessDenied) {
+            try await sut.deleteMeeting(meetingID: Scaffolding.meetingID)
+        }
+    }
+
+    func testDeleteMeeting_ThrowsMeetingNotFound_404_V16() async throws {
+        // Given
+        let apiService = MockAPIServiceProtocol.withError(
+            statusCode: .notFound,
+            label: "meeting-not-found"
+        )
+        let sut = APIVersion.v16.buildAPI(apiService: apiService)
+
+        // When / Then
+        await XCTAssertThrowsErrorAsync(MeetingsAPIError.meetingNotFound) {
+            try await sut.deleteMeeting(meetingID: Scaffolding.meetingID)
         }
     }
 

--- a/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testCreateMeeting_Request_Generation_V15.request-0-v15.txt
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testCreateMeeting_Request_Generation_V15.request-0-v15.txt
@@ -1,5 +1,0 @@
-curl \
-	--request POST \
-	--header "Content-Type: application/json" \
-	--data "{\"end_time\":\"2025-06-25T11:00:00Z\",\"start_time\":\"2025-06-25T10:00:00Z\",\"title\":\"Engineering Sync\"}" \
-	"/v15/meetings"

--- a/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testCreateMeeting_Request_Generation_V15.request-0-v16.txt
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testCreateMeeting_Request_Generation_V15.request-0-v16.txt
@@ -1,5 +1,0 @@
-curl \
-	--request POST \
-	--header "Content-Type: application/json" \
-	--data "{\"end_time\":\"2025-06-25T11:00:00Z\",\"start_time\":\"2025-06-25T10:00:00Z\",\"title\":\"Engineering Sync\"}" \
-	"/v16/meetings"

--- a/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testDeleteMeeting_Request_Generation_V16.request-0-v16.txt
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testDeleteMeeting_Request_Generation_V16.request-0-v16.txt
@@ -1,0 +1,3 @@
+curl \
+	--request DELETE \
+	"/v16/meetings/wire.com/9c2e5e1a-1234-5678-abcd-0123456789ab"

--- a/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testUpdateMeeting_Request_Generation_V15.request-0-v15.txt
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testUpdateMeeting_Request_Generation_V15.request-0-v15.txt
@@ -1,5 +1,0 @@
-curl \
-	--request PUT \
-	--header "Content-Type: application/json" \
-	--data "{\"end_time\":\"2025-06-25T11:00:00Z\",\"start_time\":\"2025-06-25T10:00:00Z\",\"title\":\"Engineering Sync (Updated)\"}" \
-	"/v15/meetings/wire.com/9c2e5e1a-1234-5678-abcd-0123456789ab"

--- a/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testUpdateMeeting_Request_Generation_V15.request-0-v16.txt
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testUpdateMeeting_Request_Generation_V15.request-0-v16.txt
@@ -1,5 +1,0 @@
-curl \
-	--request PUT \
-	--header "Content-Type: application/json" \
-	--data "{\"end_time\":\"2025-06-25T11:00:00Z\",\"start_time\":\"2025-06-25T10:00:00Z\",\"title\":\"Engineering Sync (Updated)\"}" \
-	"/v16/meetings/wire.com/9c2e5e1a-1234-5678-abcd-0123456789ab"

--- a/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testUpdateMeeting_Request_Generation_V16.request-0-v16.txt
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/Rest/MeetingsAPI/__Snapshots__/MeetingsAPITests/testUpdateMeeting_Request_Generation_V16.request-0-v16.txt
@@ -2,4 +2,4 @@ curl \
 	--request PUT \
 	--header "Content-Type: application/json" \
 	--data "{\"end_time\":\"2025-06-25T11:00:00Z\",\"start_time\":\"2025-06-25T10:00:00Z\",\"title\":\"Engineering Sync (Updated)\"}" \
-	"/v16/meetings/example.com/9c2e5e1a-1234-5678-abcd-0123456789ab"
+	"/v16/meetings/wire.com/9c2e5e1a-1234-5678-abcd-0123456789ab"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20279" title="WPB-20279" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20279</a>  [iOS] Deleting a Meeting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR moves some code from v15 to v16.
Also the delete endpoint implementation is added here.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
