### PR TITLE
chore: remove `periphery` dependency - WPB-26651

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,2 @@
-tap "peripheryapp/periphery"
-
 # Common dependencies for both CI and local development
 brew "git-lfs"
-
-# Development-only dependencies
-brew "periphery" unless ENV['CI'] # no version support for periphery, using the latest


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26651" title="WPB-26651" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26651</a>  [iOS] Remove `periphery` from Brewfile
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR removes `peripheryapp/periphery` from our Brewfile as:

- It doesn't seem to be used
- It is currently causing the ./setup script to fail locally unless it has already been trusted in Homebrew

### Testing

Run ./setup script

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
