### PR TITLE
revert: background tasks starting in background - WPB-23511

### DIFF
--- a/wire-ios-system/Source/BackgroundTasks.swift
+++ b/wire-ios-system/Source/BackgroundTasks.swift
@@ -28,7 +28,7 @@ public func withBackgroundTask<T: Sendable>(
     try await executer.execute(name: name, operation: operation)
 }
 
-/// A ``BackgroundTaskExecuter`` that simply executes the operation without any background task management.
+/// A `BackgroundTaskExecuter` that simply executes the operation without any background task management.
 public struct PassthroughTaskExecuter: BackgroundTaskExecuter {
 
     public init() {}

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -29,15 +29,13 @@ struct AppBackgroundTaskExecuterTests {
     let application: MockBackgroundTaskApplication
     let sut: AppBackgroundTaskExecuter
 
-    @MainActor
     init() {
         self.application = MockBackgroundTaskApplication()
         application.beginBackgroundTaskWithNameExpirationHandler_MockMethod = { _, _ in
             UIBackgroundTaskIdentifier(rawValue: 99)
         }
         application.endBackgroundTask_MockMethod = { _ in }
-
-        self.sut = AppBackgroundTaskExecuter(application: application, isInBackground: false)
+        self.sut = AppBackgroundTaskExecuter(application: application)
     }
 
     @Test
@@ -122,61 +120,6 @@ struct AppBackgroundTaskExecuterTests {
         await #expect(throws: CancellationError.self) {
             _ = try await task.value
         }
-    }
-
-    @Test
-    @MainActor
-    func `throws CancellationError when the app is in the background`() async throws {
-        // given
-        let sut = AppBackgroundTaskExecuter(application: application, isInBackground: true)
-        let didRunOperation = OSAllocatedUnfairLock(initialState: false)
-
-        // then
-        await #expect(throws: CancellationError.self) {
-            // when
-            try await sut.execute(name: "task") {
-                didRunOperation.withLock { $0 = true }
-            }
-        }
-        #expect(didRunOperation.withLock { $0 } == false)
-        #expect(application.beginBackgroundTaskWithNameExpirationHandler_Invocations.isEmpty)
-    }
-
-    @Test
-    func `throws CancellationError when beginBackgroundTask returns invalid`() async throws {
-        // given
-        application.beginBackgroundTaskWithNameExpirationHandler_MockMethod = { _, _ in .invalid }
-        let didRunOperation = OSAllocatedUnfairLock(initialState: false)
-
-        // then
-        await #expect(throws: CancellationError.self) {
-            // when
-            try await sut.execute(name: "task") {
-                didRunOperation.withLock { $0 = true }
-            }
-        }
-        #expect(didRunOperation.withLock { $0 } == false)
-    }
-
-    @Test
-    @MainActor
-    func `throws CancellationError when the expiration handler fires before the task starts`() async throws {
-        // given
-        let didRunOperation = OSAllocatedUnfairLock(initialState: false)
-        application.beginBackgroundTaskWithNameExpirationHandler_MockMethod = { _, handler in
-            handler?()
-            return UIBackgroundTaskIdentifier(rawValue: 30)
-        }
-
-        // then
-        await #expect(throws: CancellationError.self) {
-            // when
-            try await sut.execute(name: "task") {
-                didRunOperation.withLock { $0 = true }
-            }
-        }
-        #expect(didRunOperation.withLock { $0 } == false)
-        #expect(application.endBackgroundTask_Invocations == [UIBackgroundTaskIdentifier(rawValue: 30)])
     }
 
     @Test

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -41,39 +41,19 @@ extension UIApplication: BackgroundTaskApplication {}
 /// - warning: This executer should only be used from the main app.
 public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
-    private final class OperationState<T>: Sendable {
-        let _taskID = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
-        let _task = OSAllocatedUnfairLock(initialState: Task<T, any Error>?.none)
-        let _isExpired = OSAllocatedUnfairLock(initialState: false)
+    private final class TaskID: Sendable {
+        let state = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
 
-        var taskID: UIBackgroundTaskIdentifier {
-            get { _taskID.withLock { $0 } }
-            set { _taskID.withLock { $0 = newValue } }
-        }
-
-        var task: Task<T, any Error>? {
-            get { _task.withLock { $0 } }
-            set { _task.withLock { $0 = newValue } }
-        }
-
-        var isExpired: Bool {
-            get { _isExpired.withLock { $0 } }
-            set { _isExpired.withLock { $0 = newValue } }
+        var value: UIBackgroundTaskIdentifier {
+            get { state.withLock { $0 } }
+            set { state.withLock { $0 = newValue } }
         }
     }
 
     private let application: any BackgroundTaskApplication
-    private let applicationState: ApplicationState
 
-    @MainActor
-    public init(application: any BackgroundTaskApplication, isInBackground: Bool) {
+    public init(application: any BackgroundTaskApplication) {
         self.application = application
-        self.applicationState = ApplicationState(isInBackground: isInBackground)
-    }
-
-    @MainActor
-    public func startObservingLifecycleNotifications() {
-        applicationState.startObservingLifecycleNotifications()
     }
 
     public func execute<T: Sendable>(
@@ -82,37 +62,27 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
     ) async throws -> T {
         let name = name ?? "unnamed"
 
-        guard applicationState.isInBackground != true else {
-            WireLogger.backgroundActivity.debug("background task \(name) cannot begin in the background")
-            throw CancellationError()
-        }
-
-        let operationState = OperationState<T>()
-        operationState.taskID = application.beginBackgroundTask(withName: name) {
-            operationState.isExpired = true
-
-            WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
-            operationState.task?.cancel()
-
-            // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
-            endBackgroundTask(operationState)
-        }
-        defer { endBackgroundTask(operationState) }
-
-        if operationState.taskID == .invalid || operationState.isExpired {
-            WireLogger.backgroundActivity.warn("begin background task \(name) failed or expired before starting")
-            throw CancellationError()
-        }
-
-        // Don't start the task until we have a valid background task ID.
         let task = Task {
             WireLogger.backgroundActivity.debug("will start background task: \(name)")
             let result = try await operation()
             WireLogger.backgroundActivity.debug("did end background task: \(name)")
             return result
         }
-        operationState.task = task
 
+        let taskID = TaskID()
+        taskID.value = application.beginBackgroundTask(withName: name) {
+            WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
+
+            task.cancel()
+
+            // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
+            endBackgroundTask(taskID)
+        }
+        if taskID.value == .invalid {
+            WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
+        }
+
+        defer { endBackgroundTask(taskID) }
         return try await withTaskCancellationHandler {
             try await task.value
         } onCancel: {
@@ -120,54 +90,10 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         }
     }
 
-    // MARK: - Private
+    private nonisolated func endBackgroundTask(_ identifier: TaskID) {
+        guard identifier.value != .invalid else { return }
 
-    private nonisolated func endBackgroundTask(_ operationState: OperationState<some Any>) {
-        guard operationState.taskID != .invalid else { return }
-
-        application.endBackgroundTask(operationState.taskID)
-        operationState.taskID = .invalid
-    }
-}
-
-@MainActor
-private final class ApplicationState: AnyObject {
-
-    private nonisolated let _isInBackground: OSAllocatedUnfairLock<Bool>
-
-    init(isInBackground: Bool) {
-        self._isInBackground = OSAllocatedUnfairLock(initialState: isInBackground)
-    }
-
-    func startObservingLifecycleNotifications() {
-        let center = NotificationCenter.default
-        center.addObserver(
-            self,
-            selector: #selector(didEnterBackground),
-            name: UIApplication.didEnterBackgroundNotification,
-            object: nil
-        )
-        center.addObserver(
-            self,
-            selector: #selector(willEnterForeground),
-            name: UIApplication.willEnterForegroundNotification,
-            object: nil
-        )
-    }
-
-    nonisolated var isInBackground: Bool {
-        _isInBackground.withLock { $0 }
-    }
-
-    // MARK: - Notification Handling
-
-    @objc
-    private func didEnterBackground() {
-        _isInBackground.withLock { $0 = true }
-    }
-
-    @objc
-    private func willEnterForeground() {
-        _isInBackground.withLock { $0 = false }
+        application.endBackgroundTask(identifier.value)
+        identifier.value = .invalid
     }
 }

--- a/wire-ios/Wire-iOS/Sources/AppDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/AppDelegate.swift
@@ -398,14 +398,9 @@ private extension AppDelegate {
         queueInitializationOperations(launchOptions: launchOptions)
     }
 
-    @MainActor
     private func createAppRootRouter() {
         let defaultEnvironment = fetchDefaultEnvironment()
-        let appTaskExecuter = AppBackgroundTaskExecuter(
-            application: UIApplication.shared,
-            isInBackground: UIApplication.shared.applicationState == .background
-        )
-        appTaskExecuter.startObservingLifecycleNotifications()
+        let appTaskExecuter = AppBackgroundTaskExecuter(application: UIApplication.shared)
 
         let sessionManager: SessionManager
         do {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23511" title="WPB-23511" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23511</a>  [iOS] NSE is often getting stuck and expiring
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Reverts wireapp/wire-ios#4935

#4935 introduced some issues due to the app not handling cancellation well resulting in messages that couldn't be decrypted. 

I will revert this for now but hope to build upon it. 