### PR TITLE
fix: background tasks starting in background issue (v2) - WPB-23511

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -814,7 +814,8 @@ public final class ClientSessionComponent {
         userLocalStore: userLocalStore,
         conversationLocalStore: conversationLocalStore,
         pullMLSOneOnOneSync: pullMLSOneOnOneSync,
-        mlsProvider: mlsProvider
+        mlsProvider: mlsProvider,
+        backgroundTaskExecuter: backgroundTaskExecuter
     )
 
     private lazy var mlsProvider = MLSProvider(

--- a/WireDomain/Sources/WireDomain/Notifications/NotificationServiceExtension.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/NotificationServiceExtension.swift
@@ -37,6 +37,7 @@ public final class NotificationServiceExtension {
 
     private let logger = WireLogger.notifications
     private var onGoingTask: Task<Void, Never>?
+    private var contentHandler: ((UNNotificationContent) -> Void)?
 
     private let currentAppVersion: String
     private let currentBuildNumber: String
@@ -74,6 +75,7 @@ public final class NotificationServiceExtension {
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) {
+        self.contentHandler = contentHandler
 
         if onGoingTask != nil {
             logger.warn(
@@ -135,6 +137,13 @@ public final class NotificationServiceExtension {
 
     public func cancel() async {
         onGoingTask?.cancel()
+        if DeveloperFlag.showNSEErrors.isOn {
+            let content = UNMutableNotificationContent()
+            content.title = "NSE Error"
+            content.body = "NSE will expire"
+            content.interruptionLevel = .active
+            contentHandler?(content)
+        }
         await onGoingTask?.value
     }
 }

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -453,6 +453,7 @@ public struct IncrementalSync: IncrementalSyncProtocol {
 
         public func suspend() async {
             task.cancel()
+            await task.value
             await closePushChannel()
         }
     }

--- a/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
@@ -17,7 +17,7 @@
 //
 
 import CoreData
-import WireDataModel
+@preconcurrency import WireDataModel
 import WireLogging
 import WireNetwork
 
@@ -36,6 +36,7 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
     private let conversationLocalStore: any ConversationLocalStoreProtocol
     private let pullMLSOneOnOneSync: any PullMLSOneOnOneSyncProtocol
     private let mlsProvider: MLSProvider
+    private let backgroundTaskExecuter: any BackgroundTaskExecuter
 
     // MARK: - Object lifecycle
 
@@ -44,30 +45,49 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
         userLocalStore: any UserLocalStoreProtocol,
         conversationLocalStore: any ConversationLocalStoreProtocol,
         pullMLSOneOnOneSync: any PullMLSOneOnOneSyncProtocol,
-        mlsProvider: MLSProvider
+        mlsProvider: MLSProvider,
+        backgroundTaskExecuter: any BackgroundTaskExecuter
     ) {
         self.context = context
         self.userLocalStore = userLocalStore
         self.conversationLocalStore = conversationLocalStore
         self.pullMLSOneOnOneSync = pullMLSOneOnOneSync
         self.mlsProvider = mlsProvider
+        self.backgroundTaskExecuter = backgroundTaskExecuter
     }
 
     public func resolveAllOneOnOneConversations() async throws {
-        let usersIDs = try await userLocalStore.fetchAllUserIDsWithOneOnOneConversation()
+        let userIDs = try await userLocalStore.fetchAllUserIDsWithOneOnOneConversation()
 
-        await withTaskGroup(of: Void.self) { group in
-            for userID in usersIDs {
-                group.addTask {
-                    do {
-                        try await resolveOneOnOneConversation(with: userID)
-                    } catch {
-                        /// skip conversation migration for this user
-                        WireLogger.conversation.error(
-                            "resolve 1-1 conversation with userID \(userID) failed: \(error)",
-                            attributes: [.senderUserId: userID.safeForLoggingDescription]
-                        )
+        try await withBackgroundTask(name: "resolve all 1-1s" , executer: backgroundTaskExecuter) {
+            await withTaskGroup(of: Void.self) { group in
+                var iterator = userIDs.makeIterator()
+
+                func addNextTaskIfAvailable() {
+                    guard let userID = iterator.next() else { return }
+
+                    _ = group.addTaskUnlessCancelled {
+                        do {
+                            try await resolveOneOnOneConversation(with: userID)
+                        } catch {
+                            /// skip conversation migration for this user
+                            WireLogger.conversation.error(
+                                "resolve 1-1 conversation with userID \(userID) failed: \(error)",
+                                attributes: [.senderUserId: userID.safeForLoggingDescription]
+                            )
+                        }
                     }
+                }
+
+                // Start the first batch of up to `concurrentLimit`.
+                let concurrentLimit = 4
+                for _ in 0..<min(concurrentLimit, userIDs.count) {
+                    addNextTaskIfAvailable()
+                }
+
+                // Each time a task finishes, start one more if available.
+                while await group.next() != nil {
+                    addNextTaskIfAvailable()
                 }
             }
         }

--- a/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
@@ -59,7 +59,7 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
     public func resolveAllOneOnOneConversations() async throws {
         let userIDs = try await userLocalStore.fetchAllUserIDsWithOneOnOneConversation()
 
-        try await withBackgroundTask(name: "resolve all 1-1s" , executer: backgroundTaskExecuter) {
+        try await withBackgroundTask(name: "resolve all 1-1s", executer: backgroundTaskExecuter) {
             await withTaskGroup(of: Void.self) { group in
                 var iterator = userIDs.makeIterator()
 
@@ -81,7 +81,7 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
 
                 // Start the first batch of up to `concurrentLimit`.
                 let concurrentLimit = 4
-                for _ in 0..<min(concurrentLimit, userIDs.count) {
+                for _ in 0 ..< min(concurrentLimit, userIDs.count) {
                     addNextTaskIfAvailable()
                 }
 

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
@@ -752,8 +752,9 @@ final class IncrementalSyncV2Tests: XCTestCase {
         let token = try await sut.perform()
         await token.suspend()
 
-        try XCTAssertCount(pushChannel.close_Invocations, count: 1)
-        try XCTAssertCount(pushChannelState.markAsClosed_Invocations, count: 1)
+        // The push channel closes twice - once after the push channel completes and again on token.suspend()
+        try XCTAssertCount(pushChannel.close_Invocations, count: 2)
+        try XCTAssertCount(pushChannelState.markAsClosed_Invocations, count: 2)
 
     }
 

--- a/WireDomain/Tests/WireDomainTests/Synchronization/OneOnOneResolverTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/OneOnOneResolverTests.swift
@@ -54,7 +54,8 @@ final class OneOnOneResolverTests: XCTestCase {
             userLocalStore: userLocalStore,
             conversationLocalStore: conversationLocalStore,
             pullMLSOneOnOneSync: pullMLSOneOnOneSync,
-            mlsProvider: MLSProvider(service: mlsService, isMLSEnabled: true)
+            mlsProvider: MLSProvider(service: mlsService, isMLSEnabled: true),
+            backgroundTaskExecuter: PassthroughTaskExecuter()
         )
     }
 

--- a/wire-ios-data-model/Source/Core Crypto/SafeCoreCrypto.swift
+++ b/wire-ios-data-model/Source/Core Crypto/SafeCoreCrypto.swift
@@ -41,11 +41,15 @@ public final class SafeCoreCrypto {
     public func transaction<Result>(
         block: @escaping (any CoreCryptoContextProtocol) async throws -> Result
     ) async throws -> Result {
-        try await withBackgroundTask(
-            name: "core crypto transaction",
-            executer: backgroundTaskExecuter
-        ) { [coreCrypto] in
+        if BackgroundTaskContext.isBackgroundTask {
             try await coreCrypto.transaction(block)
+        } else {
+            try await withBackgroundTask(
+                name: "core crypto transaction",
+                executer: backgroundTaskExecuter
+            ) { [coreCrypto] in
+                try await coreCrypto.transaction(block)
+            }
         }
     }
 

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -162,10 +162,18 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
         WireLogger.sync.debug(
             "suspending sync \(backgroundActivity != nil ? "in a background task" : "")"
         )
-        ongoingSyncTask?.cancel()
-        ongoingSyncTask = nil
-        await incrementalSyncToken?.suspend()
-        incrementalSyncToken = nil
+
+        if let ongoingSyncTask {
+            ongoingSyncTask.cancel()
+            await ongoingSyncTask.value
+            self.ongoingSyncTask = nil
+        }
+
+        if let incrementalSyncToken {
+            await incrementalSyncToken.suspend()
+            self.incrementalSyncToken = nil
+        }
+
         syncStateSubject.send(.suspended)
 
         if let backgroundActivity {

--- a/wire-ios-system/Source/BackgroundTasks.swift
+++ b/wire-ios-system/Source/BackgroundTasks.swift
@@ -17,7 +17,10 @@
 //
 
 public protocol BackgroundTaskExecuter: Sendable {
-    func execute<T: Sendable>(name: String?, operation: sending @escaping () async throws -> T) async throws -> T
+    func execute<T: Sendable>(
+        name: String?,
+        operation: @escaping @isolated(any) () async throws -> T
+    ) async throws -> T
 }
 
 public enum BackgroundTaskContext {
@@ -27,7 +30,7 @@ public enum BackgroundTaskContext {
 public func withBackgroundTask<T: Sendable>(
     name: String? = nil,
     executer: any BackgroundTaskExecuter,
-    operation: sending @escaping @isolated(any) () async throws -> T
+    operation: @escaping @isolated(any) () async throws -> T
 ) async throws -> T {
     try await BackgroundTaskContext.$isBackgroundTask.withValue(true) {
         try await executer.execute(name: name, operation: operation)
@@ -41,7 +44,7 @@ public struct PassthroughTaskExecuter: BackgroundTaskExecuter {
 
     public func execute<T: Sendable>(
         name: String?,
-        operation: sending @escaping () async throws -> T
+        operation: @escaping @isolated(any) () async throws -> T
     ) async throws -> T {
         try await operation()
     }

--- a/wire-ios-system/Source/BackgroundTasks.swift
+++ b/wire-ios-system/Source/BackgroundTasks.swift
@@ -28,7 +28,7 @@ public func withBackgroundTask<T: Sendable>(
     try await executer.execute(name: name, operation: operation)
 }
 
-/// A `BackgroundTaskExecuter` that simply executes the operation without any background task management.
+/// A ``BackgroundTaskExecuter`` that simply executes the operation without any background task management.
 public struct PassthroughTaskExecuter: BackgroundTaskExecuter {
 
     public init() {}
@@ -40,4 +40,14 @@ public struct PassthroughTaskExecuter: BackgroundTaskExecuter {
         try await operation()
     }
 
+}
+
+public enum BackgroundTaskError: Error {
+
+    /// The background task was instantiated in while the app is int the background. This may not be allowed by a given
+    /// ``BackgroundTaskExecuter``.
+    case taskInstantiatedInBackground
+
+    /// The system returned `UIBackgroundTaskIdentifier.invalid` when beginning a background task.
+    case invalidTaskIdentifier
 }

--- a/wire-ios-system/Source/BackgroundTasks.swift
+++ b/wire-ios-system/Source/BackgroundTasks.swift
@@ -41,13 +41,3 @@ public struct PassthroughTaskExecuter: BackgroundTaskExecuter {
     }
 
 }
-
-public enum BackgroundTaskError: Error {
-
-    /// The background task was instantiated in while the app is int the background. This may not be allowed by a given
-    /// ``BackgroundTaskExecuter``.
-    case taskInstantiatedInBackground
-
-    /// The system returned `UIBackgroundTaskIdentifier.invalid` when beginning a background task.
-    case invalidTaskIdentifier
-}

--- a/wire-ios-system/Source/BackgroundTasks.swift
+++ b/wire-ios-system/Source/BackgroundTasks.swift
@@ -20,12 +20,18 @@ public protocol BackgroundTaskExecuter: Sendable {
     func execute<T: Sendable>(name: String?, operation: sending @escaping () async throws -> T) async throws -> T
 }
 
+public enum BackgroundTaskContext {
+    @TaskLocal public static var isBackgroundTask = false
+}
+
 public func withBackgroundTask<T: Sendable>(
     name: String? = nil,
     executer: any BackgroundTaskExecuter,
     operation: sending @escaping @isolated(any) () async throws -> T
 ) async throws -> T {
-    try await executer.execute(name: name, operation: operation)
+    try await BackgroundTaskContext.$isBackgroundTask.withValue(true) {
+        try await executer.execute(name: name, operation: operation)
+    }
 }
 
 /// A ``BackgroundTaskExecuter`` that simply executes the operation without any background task management.

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -47,6 +47,7 @@ public enum DeveloperFlag: String, CaseIterable {
     // TODO: [WPB-25941] Remove drive permissions flag when feature is complete
     case enableDrivePermissions
     case unSafeLogsForPublic
+    case useBackgroundActivityFactoryInAppBackgroundTaskExecuter
 
     public var description: String {
         switch self {
@@ -121,6 +122,8 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .unSafeLogsForPublic:
             "Turn on to write all logs (including debug and non-public) to disk in release builds"
+        case .useBackgroundActivityFactoryInAppBackgroundTaskExecuter:
+            "Turn on to use BackgroundActivityFactory in AppBackgroundTaskExecuter"
         }
     }
 

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -47,7 +47,7 @@ public enum DeveloperFlag: String, CaseIterable {
     // TODO: [WPB-25941] Remove drive permissions flag when feature is complete
     case enableDrivePermissions
     case unSafeLogsForPublic
-    case useBackgroundActivityFactoryInAppBackgroundTaskExecuter
+    case useBackgroundTaskAPIInAppBackgroundTaskExecuter
 
     public var description: String {
         switch self {
@@ -122,8 +122,9 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .unSafeLogsForPublic:
             "Turn on to write all logs (including debug and non-public) to disk in release builds"
-        case .useBackgroundActivityFactoryInAppBackgroundTaskExecuter:
-            "Turn on to use BackgroundActivityFactory in AppBackgroundTaskExecuter"
+
+        case .useBackgroundTaskAPIInAppBackgroundTaskExecuter:
+            "Turn on to use Apple's UIApplication task API directly in AppBackgroundTaskExecuter"
         }
     }
 

--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -206,6 +206,15 @@ public class MockBackgroundTaskApplication: BackgroundTaskApplication, @unchecke
 
     public init() {}
 
+    // MARK: - applicationState
+
+    public var applicationState: UIApplication.State {
+        get { return underlyingApplicationState }
+        set(value) { underlyingApplicationState = value }
+    }
+
+    public var underlyingApplicationState: UIApplication.State!
+
 
     // MARK: - beginBackgroundTask
 

--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -206,15 +206,6 @@ public class MockBackgroundTaskApplication: BackgroundTaskApplication, @unchecke
 
     public init() {}
 
-    // MARK: - applicationState
-
-    public var applicationState: UIApplication.State {
-        get { return underlyingApplicationState }
-        set(value) { underlyingApplicationState = value }
-    }
-
-    public var underlyingApplicationState: UIApplication.State!
-
 
     // MARK: - beginBackgroundTask
 

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -23,7 +23,7 @@ import WireTesting
 
 @testable import Wire
 
-@Suite
+@Suite(.serialized)
 struct AppBackgroundTaskExecuterTests {
 
     let application: MockBackgroundTaskApplication
@@ -38,6 +38,7 @@ struct AppBackgroundTaskExecuterTests {
         application.endBackgroundTask_MockMethod = { _ in }
 
         self.sut = AppBackgroundTaskExecuter(application: application, isInBackground: false)
+        DeveloperFlag.useBackgroundTaskAPIInAppBackgroundTaskExecuter.enable(true, storage: .temporary())
     }
 
     @Test

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -159,6 +159,26 @@ struct AppBackgroundTaskExecuterTests {
     }
 
     @Test
+    @MainActor
+    func `throws CancellationError when the expiration handler fires before the task starts`() async throws {
+        // given
+        let didRunOperation = OSAllocatedUnfairLock(initialState: false)
+        application.beginBackgroundTaskWithNameExpirationHandler_MockMethod = { _, handler in
+            handler?()
+            return UIBackgroundTaskIdentifier(rawValue: 30)
+        }
+
+        // then
+        await #expect(throws: CancellationError.self) {
+            // when
+            try await sut.execute(name: "task") {
+                didRunOperation.withLock { $0 = true }
+            }
+        }
+        #expect(didRunOperation.withLock { $0 } == false)
+    }
+
+    @Test
     func `external cancellation cancels the operation and ends the background task`() async throws {
         // given
         let didCancel = OSAllocatedUnfairLock(initialState: false)

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -35,6 +35,8 @@ struct AppBackgroundTaskExecuterTests {
             UIBackgroundTaskIdentifier(rawValue: 99)
         }
         application.endBackgroundTask_MockMethod = { _ in }
+        application.applicationState = .active
+
         self.sut = AppBackgroundTaskExecuter(application: application)
     }
 

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -29,15 +29,15 @@ struct AppBackgroundTaskExecuterTests {
     let application: MockBackgroundTaskApplication
     let sut: AppBackgroundTaskExecuter
 
+    @MainActor
     init() {
         self.application = MockBackgroundTaskApplication()
         application.beginBackgroundTaskWithNameExpirationHandler_MockMethod = { _, _ in
             UIBackgroundTaskIdentifier(rawValue: 99)
         }
         application.endBackgroundTask_MockMethod = { _ in }
-        application.applicationState = .active
 
-        self.sut = AppBackgroundTaskExecuter(application: application)
+        self.sut = AppBackgroundTaskExecuter(application: application, isInBackground: false)
     }
 
     @Test
@@ -125,9 +125,10 @@ struct AppBackgroundTaskExecuterTests {
     }
 
     @Test
+    @MainActor
     func `throws CancellationError when the app is in the background`() async throws {
         // given
-        application.applicationState = .background
+        let sut = AppBackgroundTaskExecuter(application: application, isInBackground: true)
         let didRunOperation = OSAllocatedUnfairLock(initialState: false)
 
         // then
@@ -139,18 +140,6 @@ struct AppBackgroundTaskExecuterTests {
         }
         #expect(didRunOperation.withLock { $0 } == false)
         #expect(application.beginBackgroundTaskWithNameExpirationHandler_Invocations.isEmpty)
-    }
-
-    @Test
-    func `does not throw when the app is inactive`() async throws {
-        // given
-        application.applicationState = .inactive
-
-        // when
-        let result = try await sut.execute(name: "task") { "result" }
-
-        // then
-        #expect(result == "result")
     }
 
     @Test

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -176,6 +176,7 @@ struct AppBackgroundTaskExecuterTests {
             }
         }
         #expect(didRunOperation.withLock { $0 } == false)
+        #expect(application.endBackgroundTask_Invocations == [UIBackgroundTaskIdentifier(rawValue: 30)])
     }
 
     @Test

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -125,6 +125,51 @@ struct AppBackgroundTaskExecuterTests {
     }
 
     @Test
+    func `throws CancellationError when the app is in the background`() async throws {
+        // given
+        application.applicationState = .background
+        let didRunOperation = OSAllocatedUnfairLock(initialState: false)
+
+        // then
+        await #expect(throws: CancellationError.self) {
+            // when
+            try await sut.execute(name: "task") {
+                didRunOperation.withLock { $0 = true }
+            }
+        }
+        #expect(didRunOperation.withLock { $0 } == false)
+        #expect(application.beginBackgroundTaskWithNameExpirationHandler_Invocations.isEmpty)
+    }
+
+    @Test
+    func `does not throw when the app is inactive`() async throws {
+        // given
+        application.applicationState = .inactive
+
+        // when
+        let result = try await sut.execute(name: "task") { "result" }
+
+        // then
+        #expect(result == "result")
+    }
+
+    @Test
+    func `throws CancellationError when beginBackgroundTask returns invalid`() async throws {
+        // given
+        application.beginBackgroundTaskWithNameExpirationHandler_MockMethod = { _, _ in .invalid }
+        let didRunOperation = OSAllocatedUnfairLock(initialState: false)
+
+        // then
+        await #expect(throws: CancellationError.self) {
+            // when
+            try await sut.execute(name: "task") {
+                didRunOperation.withLock { $0 = true }
+            }
+        }
+        #expect(didRunOperation.withLock { $0 } == false)
+    }
+
+    @Test
     func `external cancellation cancels the operation and ends the background task`() async throws {
         // given
         let didCancel = OSAllocatedUnfairLock(initialState: false)

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -43,7 +43,7 @@ extension UIApplication: BackgroundTaskApplication {}
 /// - warning: This executer should only be used from the main app.
 public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
-    private final class Operation<T>: Sendable {
+    private final class OperationState<T>: Sendable {
         let _taskID = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
         let _task = OSAllocatedUnfairLock(initialState: Optional<Task<T, any Error>>.none)
 
@@ -75,17 +75,17 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
             throw CancellationError()
         }
 
-        let backgroundOperation = Operation<T>()
-        backgroundOperation.taskID = application.beginBackgroundTask(withName: name) {
+        let operationState = OperationState<T>()
+        operationState.taskID = application.beginBackgroundTask(withName: name) {
             WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
 
-            backgroundOperation.task?.cancel()
+            operationState.task?.cancel()
 
             // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
-            endBackgroundTask(backgroundOperation)
+            endBackgroundTask(operationState)
         }
 
-        if backgroundOperation.taskID == .invalid {
+        if operationState.taskID == .invalid {
             WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
             throw CancellationError()
         }
@@ -97,9 +97,9 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
             WireLogger.backgroundActivity.debug("did end background task: \(name)")
             return result
         }
-        backgroundOperation.task = task
+        operationState.task = task
 
-        defer { endBackgroundTask(backgroundOperation) }
+        defer { endBackgroundTask(operationState) }
         return try await withTaskCancellationHandler {
             try await task.value
         } onCancel: {
@@ -107,10 +107,10 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         }
     }
 
-    private nonisolated func endBackgroundTask<T>(_ operation: Operation<T>) {
-        guard operation.taskID != .invalid else { return }
+    private nonisolated func endBackgroundTask<T>(_ operationState: OperationState<T>) {
+        guard operationState.taskID != .invalid else { return }
 
-        application.endBackgroundTask(operation.taskID)
-        operation.taskID = .invalid
+        application.endBackgroundTask(operationState.taskID)
+        operationState.taskID = .invalid
     }
 }

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -89,10 +89,10 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         name: String?,
         operation: sending @escaping @isolated(any) () async throws -> T
     ) async throws -> T {
-        if DeveloperFlag.useBackgroundActivityFactoryInAppBackgroundTaskExecuter.isOn {
-            try await executeUsingBackgroundActivityFactory(name: name, operation: operation)
-        } else {
+        if DeveloperFlag.useBackgroundTaskAPIInAppBackgroundTaskExecuter.isOn {
             try await executeUsingBackgroundTaskAPI(name: name, operation: operation)
+        } else {
+            try await executeUsingBackgroundActivityFactory(name: name, operation: operation)
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -87,7 +87,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
     public func execute<T: Sendable>(
         name: String?,
-        operation: sending @escaping @isolated(any) () async throws -> T
+        operation: @escaping @isolated(any) () async throws -> T
     ) async throws -> T {
         if DeveloperFlag.useBackgroundTaskAPIInAppBackgroundTaskExecuter.isOn {
             try await executeUsingBackgroundTaskAPI(name: name, operation: operation)
@@ -100,7 +100,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
     private func executeUsingBackgroundTaskAPI<T: Sendable>(
         name: String?,
-        operation: sending @escaping @isolated(any) () async throws -> T
+        operation: @escaping @isolated(any) () async throws -> T
     ) async throws -> T {
         let name = name ?? "unnamed"
 
@@ -153,7 +153,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
     private func executeUsingBackgroundActivityFactory<T: Sendable>(
         name: String?,
-        operation: sending @escaping @isolated(any) () async throws -> T
+        operation: @escaping @isolated(any) () async throws -> T
     ) async throws -> T {
         let name = name ?? "unnamed"
 

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -32,8 +32,6 @@ public protocol BackgroundTaskApplication: AnyObject, Sendable {
     ) -> UIBackgroundTaskIdentifier
 
     nonisolated func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier)
-
-    var applicationState: UIApplication.State { get }
 }
 
 extension UIApplication: BackgroundTaskApplication {}
@@ -59,9 +57,17 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
     }
 
     private let application: any BackgroundTaskApplication
+    private let applicationState: ApplicationState
 
-    public init(application: any BackgroundTaskApplication) {
+    @MainActor
+    public init(application: any BackgroundTaskApplication, isInBackground: Bool) {
         self.application = application
+        self.applicationState = ApplicationState(isInBackground: isInBackground)
+    }
+
+    @MainActor
+    public func startObservingLifecycleNotifications() {
+        applicationState.startObservingLifecycleNotifications()
     }
 
     public func execute<T: Sendable>(
@@ -70,7 +76,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
     ) async throws -> T {
         let name = name ?? "unnamed"
 
-        guard application.applicationState != .background else {
+        guard applicationState.isInBackground != true else {
             WireLogger.backgroundActivity.debug("background task \(name) cannot begin in the background")
             throw CancellationError()
         }
@@ -82,7 +88,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
             operationState.task?.cancel()
 
             // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
-            endBackgroundTask(operationState)
+            self.endBackgroundTask(operationState)
         }
 
         if operationState.taskID == .invalid {
@@ -107,10 +113,54 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         }
     }
 
+    // MARK: - Private
+
     private nonisolated func endBackgroundTask<T>(_ operationState: OperationState<T>) {
         guard operationState.taskID != .invalid else { return }
 
         application.endBackgroundTask(operationState.taskID)
         operationState.taskID = .invalid
+    }
+}
+
+@MainActor
+private final class ApplicationState: AnyObject {
+
+    nonisolated private let _isInBackground: OSAllocatedUnfairLock<Bool>
+
+    init(isInBackground: Bool) {
+        _isInBackground = OSAllocatedUnfairLock(initialState: isInBackground)
+    }
+
+    func startObservingLifecycleNotifications() {
+        let center = NotificationCenter.default
+        center.addObserver(
+            self,
+            selector: #selector(didEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(willEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+    }
+
+    nonisolated var isInBackground: Bool {
+        _isInBackground.withLock { $0 }
+    }
+
+    // MARK: - Notification Handling
+
+    @objc
+    private func didEnterBackground() {
+        _isInBackground.withLock { $0 = true }
+    }
+
+    @objc
+    private func willEnterForeground() {
+        _isInBackground.withLock { $0 = false }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -97,14 +97,10 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
             // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
             endBackgroundTask(operationState)
         }
+        defer { endBackgroundTask(operationState) }
 
-        if operationState.taskID == .invalid {
-            WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
-            throw CancellationError()
-        }
-
-        if operationState.isExpired {
-            WireLogger.backgroundActivity.debug("background task \(name) expired before starting")
+        if operationState.taskID == .invalid || operationState.isExpired {
+            WireLogger.backgroundActivity.warn("begin background task \(name) failed or expired before starting")
             throw CancellationError()
         }
 
@@ -117,7 +113,6 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         }
         operationState.task = task
 
-        defer { endBackgroundTask(operationState) }
         return try await withTaskCancellationHandler {
             try await task.value
         } onCancel: {

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -71,8 +71,8 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         let name = name ?? "unnamed"
 
         guard application.applicationState != .background else {
-            WireLogger.backgroundActivity.debug("background task \(name) cannot be started in the background")
-            throw BackgroundTaskError.taskInstantiatedInBackground
+            WireLogger.backgroundActivity.debug("background task \(name) cannot begin in the background")
+            throw CancellationError()
         }
 
         let backgroundOperation = Operation<T>()
@@ -87,7 +87,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
         if backgroundOperation.taskID == .invalid {
             WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
-            throw BackgroundTaskError.invalidTaskIdentifier
+            throw CancellationError()
         }
 
         // Don't start the task until we have a valid background task ID.

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -32,6 +32,8 @@ public protocol BackgroundTaskApplication: AnyObject, Sendable {
     ) -> UIBackgroundTaskIdentifier
 
     nonisolated func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier)
+
+    var applicationState: UIApplication.State { get }
 }
 
 extension UIApplication: BackgroundTaskApplication {}
@@ -41,12 +43,18 @@ extension UIApplication: BackgroundTaskApplication {}
 /// - warning: This executer should only be used from the main app.
 public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
-    private final class TaskID: Sendable {
-        let state = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
+    private final class Operation<T>: Sendable {
+        let _taskID = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
+        let _task = OSAllocatedUnfairLock(initialState: Optional<Task<T, any Error>>.none)
 
-        var value: UIBackgroundTaskIdentifier {
-            get { state.withLock { $0 } }
-            set { state.withLock { $0 = newValue } }
+        var taskID: UIBackgroundTaskIdentifier {
+            get { _taskID.withLock { $0 } }
+            set { _taskID.withLock { $0 = newValue } }
+        }
+
+        var task: Task<T, any Error>? {
+            get { _task.withLock { $0 } }
+            set { _task.withLock { $0 = newValue } }
         }
     }
 
@@ -62,27 +70,36 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
     ) async throws -> T {
         let name = name ?? "unnamed"
 
+        guard application.applicationState != .background else {
+            WireLogger.backgroundActivity.debug("background task \(name) cannot be started in the background")
+            throw BackgroundTaskError.taskInstantiatedInBackground
+        }
+
+        let backgroundOperation = Operation<T>()
+        backgroundOperation.taskID = application.beginBackgroundTask(withName: name) {
+            WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
+
+            backgroundOperation.task?.cancel()
+
+            // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
+            endBackgroundTask(backgroundOperation)
+        }
+
+        if backgroundOperation.taskID == .invalid {
+            WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
+            throw BackgroundTaskError.invalidTaskIdentifier
+        }
+
+        // Don't start the task until we have a valid background task ID.
         let task = Task {
             WireLogger.backgroundActivity.debug("will start background task: \(name)")
             let result = try await operation()
             WireLogger.backgroundActivity.debug("did end background task: \(name)")
             return result
         }
+        backgroundOperation.task = task
 
-        let taskID = TaskID()
-        taskID.value = application.beginBackgroundTask(withName: name) {
-            WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
-
-            task.cancel()
-
-            // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
-            endBackgroundTask(taskID)
-        }
-        if taskID.value == .invalid {
-            WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
-        }
-
-        defer { endBackgroundTask(taskID) }
+        defer { endBackgroundTask(backgroundOperation) }
         return try await withTaskCancellationHandler {
             try await task.value
         } onCancel: {
@@ -90,10 +107,10 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         }
     }
 
-    private nonisolated func endBackgroundTask(_ identifier: TaskID) {
-        guard identifier.value != .invalid else { return }
+    private nonisolated func endBackgroundTask<T>(_ operation: Operation<T>) {
+        guard operation.taskID != .invalid else { return }
 
-        application.endBackgroundTask(identifier.value)
-        identifier.value = .invalid
+        application.endBackgroundTask(operation.taskID)
+        operation.taskID = .invalid
     }
 }

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -44,6 +44,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
     private final class OperationState<T>: Sendable {
         let _taskID = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
         let _task = OSAllocatedUnfairLock(initialState: Task<T, any Error>?.none)
+        let _isExpired = OSAllocatedUnfairLock(initialState: false)
 
         var taskID: UIBackgroundTaskIdentifier {
             get { _taskID.withLock { $0 } }
@@ -53,6 +54,11 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         var task: Task<T, any Error>? {
             get { _task.withLock { $0 } }
             set { _task.withLock { $0 = newValue } }
+        }
+
+        var isExpired: Bool {
+            get { _isExpired.withLock { $0 } }
+            set { _isExpired.withLock { $0 = newValue } }
         }
     }
 
@@ -83,8 +89,9 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
         let operationState = OperationState<T>()
         operationState.taskID = application.beginBackgroundTask(withName: name) {
-            WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
+            operationState.isExpired = true
 
+            WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
             operationState.task?.cancel()
 
             // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
@@ -93,6 +100,11 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
         if operationState.taskID == .invalid {
             WireLogger.backgroundActivity.error("begin background task returned .invalid ID for task: \(name)")
+            throw CancellationError()
+        }
+
+        if operationState.isExpired {
+            WireLogger.backgroundActivity.debug("background task \(name) expired before starting")
             throw CancellationError()
         }
 

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -21,6 +21,7 @@ import UIKit
 
 import WireLogging
 import WireSystem
+@preconcurrency import WireTransport
 
 // sourcery: AutoMockable
 /// The subset of `UIApplication`'s background task APIs that `AppBackgroundTaskExecuter` depends on.
@@ -64,11 +65,17 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
     private let application: any BackgroundTaskApplication
     private let applicationState: ApplicationState
+    private let backgroundActivityFactory: BackgroundActivityFactory
 
     @MainActor
-    public init(application: any BackgroundTaskApplication, isInBackground: Bool) {
+    public init(
+        application: any BackgroundTaskApplication,
+        isInBackground: Bool,
+        backgroundActivityFactory: BackgroundActivityFactory = BackgroundActivityFactory.shared
+    ) {
         self.application = application
         self.applicationState = ApplicationState(isInBackground: isInBackground)
+        self.backgroundActivityFactory = backgroundActivityFactory
     }
 
     @MainActor
@@ -76,7 +83,22 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         applicationState.startObservingLifecycleNotifications()
     }
 
+    // MARK: - Private
+
     public func execute<T: Sendable>(
+        name: String?,
+        operation: sending @escaping @isolated(any) () async throws -> T
+    ) async throws -> T {
+        if DeveloperFlag.useBackgroundActivityFactoryInAppBackgroundTaskExecuter.isOn {
+            try await executeUsingBackgroundActivityFactory(name: name, operation: operation)
+        } else {
+            try await executeUsingBackgroundTaskAPI(name: name, operation: operation)
+        }
+    }
+
+    // MARK: BackgroundTaskAPI implementation
+
+    private func executeUsingBackgroundTaskAPI<T: Sendable>(
         name: String?,
         operation: sending @escaping @isolated(any) () async throws -> T
     ) async throws -> T {
@@ -120,13 +142,47 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         }
     }
 
-    // MARK: - Private
-
     private nonisolated func endBackgroundTask(_ operationState: OperationState<some Any>) {
         guard operationState.taskID != .invalid else { return }
 
         application.endBackgroundTask(operationState.taskID)
         operationState.taskID = .invalid
+    }
+
+    // MARK: BackgroundActivityFactory implementation
+
+    private func executeUsingBackgroundActivityFactory<T: Sendable>(
+        name: String?,
+        operation: sending @escaping @isolated(any) () async throws -> T
+    ) async throws -> T {
+        let name = name ?? "unnamed"
+
+        guard let activity = backgroundActivityFactory.startBackgroundActivity(name: name) else {
+            WireLogger.backgroundActivity.debug("background task \(name) cannot begin (BackgroundActivityFactory)")
+            throw CancellationError()
+        }
+
+        let task = Task {
+            WireLogger.backgroundActivity.debug("will start background task: \(name) (BackgroundActivityFactory)")
+            let result = try await operation()
+            WireLogger.backgroundActivity.debug("did end background task: \(name) (BackgroundActivityFactory)")
+            return result
+        }
+
+        activity.expirationHandler = {
+            WireLogger.backgroundActivity.warn(
+                "background task \(name) expiring soon (BackgroundActivityFactory). Cancelling..."
+            )
+            task.cancel()
+        }
+
+        defer { backgroundActivityFactory.endBackgroundActivity(activity) }
+
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -78,7 +78,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
     public func execute<T: Sendable>(
         name: String?,
-        operation: sending @escaping () async throws -> T
+        operation: sending @escaping @isolated(any) () async throws -> T
     ) async throws -> T {
         let name = name ?? "unnamed"
 

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -43,7 +43,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
     private final class OperationState<T>: Sendable {
         let _taskID = OSAllocatedUnfairLock(initialState: UIBackgroundTaskIdentifier.invalid)
-        let _task = OSAllocatedUnfairLock(initialState: Optional<Task<T, any Error>>.none)
+        let _task = OSAllocatedUnfairLock(initialState: Task<T, any Error>?.none)
 
         var taskID: UIBackgroundTaskIdentifier {
             get { _taskID.withLock { $0 } }
@@ -88,7 +88,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
             operationState.task?.cancel()
 
             // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
-            self.endBackgroundTask(operationState)
+            endBackgroundTask(operationState)
         }
 
         if operationState.taskID == .invalid {
@@ -115,7 +115,7 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
     // MARK: - Private
 
-    private nonisolated func endBackgroundTask<T>(_ operationState: OperationState<T>) {
+    private nonisolated func endBackgroundTask(_ operationState: OperationState<some Any>) {
         guard operationState.taskID != .invalid else { return }
 
         application.endBackgroundTask(operationState.taskID)
@@ -126,10 +126,10 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 @MainActor
 private final class ApplicationState: AnyObject {
 
-    nonisolated private let _isInBackground: OSAllocatedUnfairLock<Bool>
+    private nonisolated let _isInBackground: OSAllocatedUnfairLock<Bool>
 
     init(isInBackground: Bool) {
-        _isInBackground = OSAllocatedUnfairLock(initialState: isInBackground)
+        self._isInBackground = OSAllocatedUnfairLock(initialState: isInBackground)
     }
 
     func startObservingLifecycleNotifications() {

--- a/wire-ios/Wire-iOS/Sources/AppDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/AppDelegate.swift
@@ -398,9 +398,14 @@ private extension AppDelegate {
         queueInitializationOperations(launchOptions: launchOptions)
     }
 
+    @MainActor
     private func createAppRootRouter() {
         let defaultEnvironment = fetchDefaultEnvironment()
-        let appTaskExecuter = AppBackgroundTaskExecuter(application: UIApplication.shared)
+        let appTaskExecuter = AppBackgroundTaskExecuter(
+            application: UIApplication.shared,
+            isInBackground: UIApplication.shared.applicationState == .background
+        )
+        appTaskExecuter.startObservingLifecycleNotifications()
 
         let sessionManager: SessionManager
         do {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23511" title="WPB-23511" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23511</a>  [iOS] NSE is often getting stuck and expiring
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**I will retarget this to `develop` once one of my cherry pick is merged but this is not possible until `develop` - hence it is a WIP**

This PR continues https://github.com/wireapp/wire-ios/pull/4935 which was reverted due to some unwanted side affects due to our code not being able to handle cancellation - specifically we might end up sending a message with a `ZMFailedToCreateEncryptedMessagePayloadString`. 

To see what has changed only review from b10e79ffb5e829fe53464750c430447c727af304.

Specifically it:
- Updates `SafeCoreCrypto` so that a new background task is not started if the operation is already part of a background task. `TaskLocal` variables  (🤩 crazy swift feature) were chosen to avoid having to pass params everywhere.
- Wraps the resolving of all 1:1 in a `withBackgroundActivity` to avoid underlying granular calls `withBackgroundActivity` calls which might otherwise be cancelled because they would begin when the app is in the background already.
- Limits the number of concurrent 1:1 resolutions and adds cancellation checks before starting new ones
- Updates `SyncAgent.suspend()` to await cancellation to complete.

These changes were discussed with @johnxnguyen to avoid the most likely troublesome scenarios. I think the eventual goal would be that we only use `withBackgroundActivity` from fairly high level code as using it at a lower level can be problematic (e.g. see the reasoning in https://github.com/wireapp/wire-ios/pull/4935)

However I fear the above changes are not enough. Therefore I've added an experimental feature flag to use `BackgroundActivityFactory` within `withBackgroundActivity`. This object is more battle tested and I think fairly forgiving of some of our code.

I would like to merge this quite quickly to edge builds so we can try things out. 


### Testing

Observe logs.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
