### PR TITLE
fix: user status not shown - WPB-26710

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMessageAddEventProcessor/ConversationProteusMessageAddEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMessageAddEventProcessor/ConversationProteusMessageAddEventProcessor.swift
@@ -88,7 +88,7 @@ struct ConversationProteusMessageAddEventProcessor: ConversationProteusMessageAd
             )
         }
 
-        // Ensure is not self conversation, sender is self user and conversation is not read-only
+// Ensure the conversation isn't forced read-only, and reject messages sent by non-self users into the self conversation.
         guard await messageLocalStore.canAddMessage(
             conversation: conversation,
             senderID: senderID.id

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMessageAddEventProcessor/ConversationProteusMessageAddEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMessageAddEventProcessor/ConversationProteusMessageAddEventProcessor.swift
@@ -80,7 +80,7 @@ struct ConversationProteusMessageAddEventProcessor: ConversationProteusMessageAd
         }
 
         // Availability broadcasts don't belong to a specific conversation and must bypass
-        // the conversation fetch and `canAddMessage` gate entirely.
+        // the `canAddMessage` gate entirely.
         if case let .availability(availability) = genericMessage.content {
             await userLocalStore.updateUser(
                 with: WireDataModel.QualifiedID(uuid: senderID.id, domain: senderID.domain),

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMessageAddEventProcessor/ConversationProteusMessageAddEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMessageAddEventProcessor/ConversationProteusMessageAddEventProcessor.swift
@@ -45,32 +45,14 @@ struct ConversationProteusMessageAddEventProcessor: ConversationProteusMessageAd
             )
         }
 
-        guard let conversation = await conversationLocalStore.fetchConversation(
-            id: conversationID.id,
-            domain: conversationID.domain
-        ) else {
-            return WireLogger.proteus.error(
-                "failed to add proteus message: conversation not found in db"
-            )
-        }
-
         let logAttributes: LogAttributes = [
             .messageType: "conversation.otr-message-add",
             .conversationId: conversationID.id.safeForLoggingDescription
         ]
 
-        // Ensure is not self conversation, sender is self user and conversation is not read-only
-        guard await messageLocalStore.canAddMessage(
-            conversation: conversation,
-            senderID: senderID.id
-        ) else {
-            return WireLogger.eventProcessing.warn(
-                "Ignoring incoming message: illegal sender or conversation",
-                attributes: logAttributes
-            )
-        }
-
-        // Deserialize the GenericMessage instance and handle `content` being `nil` if needed.
+        // Deserialize early so availability updates can be handled before conversation-level
+        // checks. Availability broadcasts arrive in the self conversation from non-self senders,
+        // which `canAddMessage` rejects.
         let payload = await getProtobufPayload(
             from: decryptedMessage,
             externalData: messageExternalData?.encryptedMessage
@@ -84,6 +66,36 @@ struct ConversationProteusMessageAddEventProcessor: ConversationProteusMessageAd
                 senderID: senderID,
                 conversationID: conversationID,
                 date: date
+            )
+        }
+
+        // Availability broadcasts don't belong to a specific conversation and must bypass
+        // the conversation fetch and `canAddMessage` gate entirely.
+        if case let .availability(availability) = genericMessage.content {
+            await userLocalStore.updateUser(
+                with: WireDataModel.QualifiedID(uuid: senderID.id, domain: senderID.domain),
+                availability: WireDataModel.Availability(proto: availability)
+            )
+            return
+        }
+
+        guard let conversation = await conversationLocalStore.fetchConversation(
+            id: conversationID.id,
+            domain: conversationID.domain
+        ) else {
+            return WireLogger.proteus.error(
+                "failed to add proteus message: conversation not found in db"
+            )
+        }
+
+        // Ensure is not self conversation, sender is self user and conversation is not read-only
+        guard await messageLocalStore.canAddMessage(
+            conversation: conversation,
+            senderID: senderID.id
+        ) else {
+            return WireLogger.eventProcessing.warn(
+                "Ignoring incoming message: illegal sender or conversation",
+                attributes: logAttributes
             )
         }
 

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMessageAddEventProcessor/ConversationProteusMessageAddEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMessageAddEventProcessor/ConversationProteusMessageAddEventProcessor.swift
@@ -45,6 +45,15 @@ struct ConversationProteusMessageAddEventProcessor: ConversationProteusMessageAd
             )
         }
 
+        guard let conversation = await conversationLocalStore.fetchConversation(
+            id: conversationID.id,
+            domain: conversationID.domain
+        ) else {
+            return WireLogger.proteus.error(
+                "failed to add proteus message: conversation not found in db"
+            )
+        }
+        
         let logAttributes: LogAttributes = [
             .messageType: "conversation.otr-message-add",
             .conversationId: conversationID.id.safeForLoggingDescription
@@ -57,6 +66,7 @@ struct ConversationProteusMessageAddEventProcessor: ConversationProteusMessageAd
             from: decryptedMessage,
             externalData: messageExternalData?.encryptedMessage
         )
+
         guard let payload, let genericMessage = GenericMessage(from: payload, validate: false) else {
             WireLogger.eventProcessing.warn(
                 "Can't read protobuf, abort processing",
@@ -79,16 +89,7 @@ struct ConversationProteusMessageAddEventProcessor: ConversationProteusMessageAd
             return
         }
 
-        guard let conversation = await conversationLocalStore.fetchConversation(
-            id: conversationID.id,
-            domain: conversationID.domain
-        ) else {
-            return WireLogger.proteus.error(
-                "failed to add proteus message: conversation not found in db"
-            )
-        }
-
-// Ensure the conversation isn't forced read-only, and reject messages sent by non-self users into the self conversation.
+        // Ensure the conversation isn't forced read-only, and reject messages sent by non-self users into the self conversation.
         guard await messageLocalStore.canAddMessage(
             conversation: conversation,
             senderID: senderID.id

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMessageAddEventProcessor/ConversationProteusMessageAddEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMessageAddEventProcessor/ConversationProteusMessageAddEventProcessor.swift
@@ -53,7 +53,7 @@ struct ConversationProteusMessageAddEventProcessor: ConversationProteusMessageAd
                 "failed to add proteus message: conversation not found in db"
             )
         }
-        
+
         let logAttributes: LogAttributes = [
             .messageType: "conversation.otr-message-add",
             .conversationId: conversationID.id.safeForLoggingDescription
@@ -89,7 +89,8 @@ struct ConversationProteusMessageAddEventProcessor: ConversationProteusMessageAd
             return
         }
 
-        // Ensure the conversation isn't forced read-only, and reject messages sent by non-self users into the self conversation.
+        // Ensure the conversation isn't forced read-only, and reject messages sent by non-self users into the self
+        // conversation.
         guard await messageLocalStore.canAddMessage(
             conversation: conversation,
             senderID: senderID.id

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProteusMessageAddEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProteusMessageAddEventProcessorTests.swift
@@ -190,6 +190,33 @@ final class ConversationProteusMessageAddEventProcessorTests: XCTestCase {
         }
     }
 
+    func testProcessEvent_AvailabilityMessage_UpdatesUserAndSkipsConversationChecks() async throws {
+        // Availability broadcasts arrive in the self conversation from non-self senders.
+        // The processor must handle them before the conversation fetch and canAddMessage gate.
+
+        // Mock
+        userLocalStore.updateUserWithAvailability_MockMethod = { _, _ in }
+
+        // When
+        try await sut.processEvent(Scaffolding.availabilityMessageEvent)
+
+        // Then — availability was applied to the correct user
+        XCTAssertEqual(userLocalStore.updateUserWithAvailability_Invocations.count, 1)
+        let invocation = try XCTUnwrap(userLocalStore.updateUserWithAvailability_Invocations.first)
+        XCTAssertEqual(invocation.userID.uuid, Scaffolding.senderID)
+        XCTAssertEqual(invocation.availability, .available)
+
+        // Then — conversation checks were never reached
+        XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 0)
+        XCTAssertEqual(messageLocalStore.canAddMessageConversationSenderID_Invocations.count, 0)
+        XCTAssertEqual(
+            protobufMessageProcessor
+                .processProtobufMessageConversationConversationIDSenderIDSenderClientIDDateEventMessage_Invocations
+                .count,
+            0
+        )
+    }
+
     func testProcessEvent_Message_Has_Calling_It_Invokes_Handler_With_Call_Event_Info() async throws {
 
         let conversation = await context.perform { [self] in
@@ -210,6 +237,7 @@ final class ConversationProteusMessageAddEventProcessorTests: XCTestCase {
 
     enum Scaffolding {
         static let domain = "domain.com"
+        static let senderID = UUID.mockID1
 
         static let regularMessage = "CiQ5ZTU2NTQwOS0xODZiLTRlN2YtYTE4NC05NzE4MGE0MDAwMDQSDAoKRXZlcnl0aGluZw=="
         static let externalMessage =
@@ -235,6 +263,21 @@ final class ConversationProteusMessageAddEventProcessorTests: XCTestCase {
             messageSenderClientID: UUID.mockID1.uuidString,
             messageRecipientClientID: UUID.mockID2.uuidString
         )
+
+        static let availabilityMessageEvent = ConversationProteusMessageAddEvent(
+            conversationID: ConversationID(id: .mockID2, domain: domain),
+            senderID: UserID(id: senderID, domain: domain),
+            timestamp: .now,
+            message: .init(encryptedMessage: "", decryptedMessage: availabilityMessage),
+            messageSenderClientID: UUID.mockID1.uuidString,
+            messageRecipientClientID: UUID.mockID2.uuidString
+        )
+
+        private static let availabilityMessage: String = {
+            let proto = GenericMessageProtocol.Availability(WireDataModel.Availability.available)
+            let message = GenericMessage(content: proto)
+            return (try? message.serializedData().base64String()) ?? ""
+        }()
 
         static let callingMessageEvent = ConversationProteusMessageAddEvent(
             conversationID: ConversationID(id: .mockID1, domain: domain),

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProteusMessageAddEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProteusMessageAddEventProcessorTests.swift
@@ -193,11 +193,11 @@ final class ConversationProteusMessageAddEventProcessorTests: XCTestCase {
     func testProcessEvent_AvailabilityMessage_UpdatesUserAndSkipsConversationChecks() async throws {
         // Availability broadcasts arrive in the self conversation from non-self senders.
         // The processor must handle them before the canAddMessage gate.
-       
+
         let conversation = await context.perform { [self] in
             modelHelper.createGroupConversation(in: context)
         }
-        
+
         // Mock
         userLocalStore.updateUserWithAvailability_MockMethod = { _, _ in }
         conversationLocalStore.fetchConversationIdDomain_MockValue = conversation

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProteusMessageAddEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProteusMessageAddEventProcessorTests.swift
@@ -192,10 +192,15 @@ final class ConversationProteusMessageAddEventProcessorTests: XCTestCase {
 
     func testProcessEvent_AvailabilityMessage_UpdatesUserAndSkipsConversationChecks() async throws {
         // Availability broadcasts arrive in the self conversation from non-self senders.
-        // The processor must handle them before the conversation fetch and canAddMessage gate.
-
+        // The processor must handle them before the canAddMessage gate.
+       
+        let conversation = await context.perform { [self] in
+            modelHelper.createGroupConversation(in: context)
+        }
+        
         // Mock
         userLocalStore.updateUserWithAvailability_MockMethod = { _, _ in }
+        conversationLocalStore.fetchConversationIdDomain_MockValue = conversation
 
         // When
         try await sut.processEvent(Scaffolding.availabilityMessageEvent)

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProteusMessageAddEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProteusMessageAddEventProcessorTests.swift
@@ -207,7 +207,6 @@ final class ConversationProteusMessageAddEventProcessorTests: XCTestCase {
         XCTAssertEqual(invocation.availability, .available)
 
         // Then — conversation checks were never reached
-        XCTAssertEqual(conversationLocalStore.fetchConversationIdDomain_Invocations.count, 0)
         XCTAssertEqual(messageLocalStore.canAddMessageConversationSenderID_Invocations.count, 0)
         XCTAssertEqual(
             protobufMessageProcessor


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26710" title="WPB-26710" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26710</a>  [iOS] iOS does not show status from other clients
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Availability status is never shown for other users, even though the display code is wired up correctly.

### Cause

Availability updates are broadcast via Proteus (`/broadcast/proteus/messages`) and arrive as `conversation.proteusMessageAdd` events in the recipient's self conversation. In `ConversationProteusMessageAddEventProcessor`, the event is processed through `canAddMessage`, which returns `false` when the conversation is the self conversation and the sender is not the self user. This silently drops the availability message before it ever reaches `ConversationProtobufMessageProcessor`.

### Solution

Decode the protobuf message before the conversation fetch and `canAddMessage` gate. If the content is `.availability`, call `userLocalStore.updateUser(with:availability:)` directly and return — no conversation is needed for this case.

### Testing

**Requirements:** two accounts in the same team on a Proteus-enabled backend.

**Steps:**
1. Log in as User A.
2. On another device or simulator, log in as User B and change their availability status (e.g. set to Busy).
3. On User A's device, open a conversation with User B or view their profile.

**Expected result:** User B's availability dot reflects the status they set in step 2.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.