### PR TITLE
fix: crash on implicit unwrapped optional - WPB-26725

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
@@ -123,7 +123,7 @@ extension AppLockModule.Interactor: AppLockInteractorPresenterInterface {
 
     private func handleAuthenticationResult(_ result: AppLockModule.AuthenticationResult) {
         DispatchQueue.main.async(group: dispatchGroup) { [weak self] in
-            guard let self else { return }
+            guard let self, let presenter else { return }
 
             switch result {
             case .granted:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26725" title="WPB-26725" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26725</a>  [iOS] App crashing when tapping on notification from group for inactive account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

- AppLockModule.Interactor.handleAuthenticationResult dispatches its result to the main queue guarding only [weak self], while its presenter property is a weak, implicitly-unwrapped optional (AppLockPresenterInteractorInterface!) that isn't guarded.
- The app-lock module can be torn down and rebuilt mid-flight: AppRootRouter.showAppLock rebuilds a fresh AppLockModule.View/Presenter/Interactor every time the app state re-enters .locked (e.g. when the Face ID/Touch ID/passcode system prompt briefly resigns the app). The old Interactor is kept alive by the pending LocalAuthentication callback closure, but its Presenter (owned only by the now-discarded View) gets deallocated, zeroing the weak presenter reference.
- When the stale callback later fires with .denied, .needCustomPasscode, or .unavailable, the code force-unwraps the nil presenter → EXC_BREAKPOINT / "Unexpectedly found nil while implicitly unwrapping an Optional value" crash (confirmed via crash.log, matches Thread 0 crash + Thread 14's LAContext completion path).

Fix: guard let self, let presenter else { return } in the dispatched closure — mirrors an existing pattern already used elsewhere in the codebase (ImagePickerManager.swift, AudioTrackPlayer.swift, ConversationListViewController+NavigationBar.swift). Stale/orphaned callbacks now no-op instead of crashing.

File changed: Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift (1 line)

### Testing

account A and B are logged in, A is the active account
app is int he background
B receives a notifcation from a group
B tapps on the notification -> app crashes

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
