### PR TITLE
fix: SharingSessionTests - WPB-26723

### DIFF
--- a/wire-ios-share-engine/WireShareEngineTests/SharingSessionTests.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/SharingSessionTests.swift
@@ -45,6 +45,8 @@ final class SharingSessionTests: BaseSharingSessionTests {
         activeConnection = createConversation(type: .connection, archived: false)
         archivedConversation = createConversation(type: .group, archived: true)
         archivedConnection = createConversation(type: .connection, archived: true)
+        moc.saveOrRollback()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 1))
     }
 
     override func tearDown() {
@@ -66,7 +68,5 @@ final class SharingSessionTests: BaseSharingSessionTests {
         let conversations = sharingSession.writebleArchivedConversations.map { $0 as! ZMConversation }
         XCTAssertEqual(conversations, [archivedConversation])
     }
-
-    // MARK: - Init
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26723" title="WPB-26723" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26723</a>  [iOS] Fix SharingSessionTests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes `SharingSessionTests` which are currently broken on `develop` causing merges to fail. Saving the context is necessary due to behaviour changes in `ZMConversationListDirectory`

### Testing

Run automated tests

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.