### PR TITLE
feat: 1:1 is not ending calls properly - WPB-26745

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -863,28 +863,11 @@ public extension WireCallCenterV3 {
             snapshot?.mlsConferenceStaleParticipantsRemover?.stopSubscribing()
             snapshot?.mlsConferenceStaleParticipantsRemover = nil
 
-            guard isGroupConversation(conversationId: conversationId) else { return }
-
             leaveSubconversation(
                 parentQualifiedID: mlsParentIDs.0,
                 parentGroupID: mlsParentIDs.1
             )
         }
-    }
-
-    private func isGroupConversation(conversationId: AVSIdentifier) -> Bool {
-        guard
-            let context = uiMOC,
-            let domain = conversationId.domain ?? localDomain,
-            let conversation = ZMConversation.fetch(
-                with: conversationId.identifier,
-                domain: domain,
-                in: context
-            )
-        else {
-            return false
-        }
-        return conversation.conversationType == .group
     }
 
     /// Rejects an incoming call in the conversation.

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -679,34 +679,6 @@ final class WireCallCenterV3Tests: MessagingTest {
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
     }
 
-    func testThatClosingAnMLSOneOnOneCallDoesNotLeaveTheSubconversation() throws {
-        // Given
-        let conversationID = try XCTUnwrap(oneOnOneConversationID)
-        oneOnOneConversation.messageProtocol = .mls
-        oneOnOneConversation.mlsGroupID = .random()
-
-        let mlsService = MockMLSServiceInterface()
-        syncMOC.performAndWait {
-            syncMOC.mlsService = mlsService
-        }
-
-        var didLeaveSubconversation = false
-        mlsService
-            .leaveSubconversationParentQualifiedIDParentGroupIDSubconversationType_MockMethod = { _, _, _ in
-                didLeaveSubconversation = true
-            }
-
-        // When
-        sut.closeCall(conversationId: conversationID)
-
-        // Then
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        XCTAssertFalse(
-            didLeaveSubconversation,
-            "leaveSubconversation should not be called for 1-1 MLS calls"
-        )
-    }
-
     func testThatItLeavesSubconversationIfNeededOnIncoming() throws {
         // Given
         groupConversation.messageProtocol = .mls


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26745" title="WPB-26745" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26745</a>  [iOS] iOS not ending 1:1 calls properly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When a user is in a 1:1 call with iOS, the calls does not seem to end properly. This can be seen, if the 1:1 call ends and the same user calls iOS again immediately after. 

### Solution

Revert https://github.com/wireapp/wire-ios/pull/4898

### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
