### PR TITLE
fix: share extension progress not visible when sharing links - WPB-24816

### DIFF
--- a/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ShareExtensionViewController.swift
+++ b/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ShareExtensionViewController.swift
@@ -339,7 +339,7 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
             case .startingSending:
                 WireLogger.shareExtension.info("progress event: start sending")
                 DispatchQueue.main.asyncAfter(deadline: .now() + progressDisplayDelay) {
-                    guard postContent.sentAllSendables, self.progressViewController == nil else { return }
+                    guard !postContent.sentAllSendables, self.progressViewController == nil else { return }
                     self.presentSendingProgress(mode: .sending)
                 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24816" title="WPB-24816" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24816</a>  [iOS] [Share ext] Sharing website from Safari doesn't include link
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Follow up for #4934 , I noticed that when sending a link the progress indicator is not shown.

There are two progress events that present the progress view, `preparing` and `sending`. In the case of `preparing`, the progress view is presented only if not all messages are sent and the progress view hasn't yet been presented. In the case of `sending`, there is a guard that **all messages are sent** and the progress view hasn't yet been presented. This doesn't make sense and I believe it's an error: we want to guard not all messages are sent.

The fix is to align the guards as in the case of `preparing`.

### Testing
1. Open safari, go to a webpage
2. Share the webpage, select Wire in the share sheet
3. Send the link

Verify that the progress indicator is shown.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
