### PR TITLE
chore: update localization for adminless groups - WPB-25289

### DIFF
--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -991,14 +991,14 @@
 // Admin selection (promote new admin before leaving)
 "admin_selection.title" = "New admin";
 "admin_selection.promote" = "Promote";
-"admin_selection.info_banner" = "After you promoted a new admin, you will leave the group.";
+"admin_selection.info_banner" = "After you promote a new admin, you leave the group.";
 "admin_selection.promotion_error" = "Failed to promote user to admin.";
 
 // Last admin leave flow
 "last_admin_leave.title" = "Leave \"%@\"?";
 "last_admin_leave.promote_or_delete_message" = "You're the only admin.\nPromote another participant before leaving, or delete the group if it is no longer needed.";
 "last_admin_leave.promote_new_admin" = "Promote new admin";
-"last_admin_leave.no_eligible_candidates_message" = "You're the only admin.\nNone of the other participants can be promoted to admin. You can only delete the group.";
+"last_admin_leave.no_eligible_candidates_message" = "You're the only admin. The other participants can't be admins.\nAdd at least one team member and promote them as an admin before you leave. Alternatively, delete the group if it is no longer needed.";
 "last_admin_leave.delete_group" = "Delete group";
 
 // Conversation Degraded (security level lowered)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25289" title="WPB-25289" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25289</a>  [iOS] Implement admin selection flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


This PR updates copy for the admin-selection and last-admin-leave flows introduced for adminless groups.

### Changes

**Modified:**
- `Localizable.strings` — Reworded `admin_selection.info_banner` to active voice, and expanded `last_admin_leave.no_eligible_candidates_message` to explain how to add an eligible admin candidate.

### Testing

Trigger the leave-group flow as the only admin of a group with no eligible admin candidates and verify the updated copy reads correctly. Also trigger the admin promotion flow and verify the info banner text.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.