### PR TITLE
fix: admin promotion flow not presenting from context menu - WPB-25289

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -48,6 +48,7 @@ final class ConversationListContentController: UICollectionViewController {
     private weak var scrollToMessageOnNextSelection: ZMConversationMessage?
     private let layoutCell = ConversationListCell()
     var startCallController: ConversationCallController?
+    private var contextMenuActionController: ConversationActionController?
     private let selectionFeedbackGenerator = UISelectionFeedbackGenerator()
     private var token: NSObjectProtocol?
 
@@ -271,6 +272,7 @@ final class ConversationListContentController: UICollectionViewController {
                         sourceView: collectionView.cellForItem(at: indexPath)!,
                         userSession: self.userSession
                     )
+                    self.contextMenuActionController = actionController
                     actionController.handleAction(action)
                 }
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25289" title="WPB-25289" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25289</a>  [iOS] Implement admin selection flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The admin promotion flow does not present when triggered from a conversation's context menu.

### Causes

`ConversationActionController.handleAction(_:)` was called on a locally-scoped `actionController` instance with no strong reference held elsewhere. Once the enclosing closure returned, the controller was deallocated before it could present its flow.

### Solution

Added a `contextMenuActionController` property on `ConversationListContentController` to retain the `ConversationActionController` for the duration of the action.

### Testing

Open a group conversation as the last admin, trigger "Leave conversation" (or another action that triggers admin promotion) from the conversation list's context menu, and verify the admin promotion flow presents correctly.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.