### PR TITLE
fix: asset not being always deselected - WPB-26581

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -658,6 +658,19 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
         }
     }
 
+    func selectItem(withLocalIdentifier localIdentifier: String) {
+        guard let assetLibrary else { return }
+
+        for index in 0 ..< assetLibrary.count {
+            guard let asset = try? assetLibrary.asset(atIndex: index) else { continue }
+            if asset.localIdentifier == localIdentifier {
+                let indexPath = IndexPath(item: Int(index), section: Int(CameraKeyboardSection.photos.rawValue))
+                collectionView.selectItem(at: indexPath, animated: true, scrollPosition: [])
+                return
+            }
+        }
+    }
+
     func collectionView(
         _ collectionView: UICollectionView,
         didEndDisplaying cell: UICollectionViewCell,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -658,7 +658,7 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
     func deselectItem(withLocalIdentifier localIdentifier: String) {
         guard let assetLibrary else { return }
 
-        for index in 0..<assetLibrary.count {
+        for index in 0 ..< assetLibrary.count {
             guard let asset = try? assetLibrary.asset(atIndex: index) else { continue }
             if asset.localIdentifier == localIdentifier {
                 let indexPath = IndexPath(item: Int(index), section: Int(CameraKeyboardSection.photos.rawValue))

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -645,16 +645,26 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
         delegate?.cameraKeyboardViewController(self, didDeselectImage: asset)
     }
 
-    func deselectItem(withLocalIdentifier localIdentifier: String) {
-        let indexPath = collectionView
-            .indexPathsForSelectedItems?
-            .first(where: {
-                let assetCell = collectionView.cellForItem(at: $0) as? AssetCell
-                return assetCell?.representedAssetIdentifier == localIdentifier
-            })
+    var selectedAssetIdentifiers: [String] {
+        guard let assetLibrary,
+              let selectedIndexPaths = collectionView.indexPathsForSelectedItems else {
+            return []
+        }
+        return selectedIndexPaths
+            .filter { CameraKeyboardSection(rawValue: UInt($0.section)) == .photos }
+            .compactMap { try? assetLibrary.asset(atIndex: UInt($0.item)).localIdentifier }
+    }
 
-        if let indexPath {
-            collectionView.deselectItem(at: indexPath, animated: true)
+    func deselectItem(withLocalIdentifier localIdentifier: String) {
+        guard let assetLibrary else { return }
+
+        for index in 0..<assetLibrary.count {
+            guard let asset = try? assetLibrary.asset(atIndex: index) else { continue }
+            if asset.localIdentifier == localIdentifier {
+                let indexPath = IndexPath(item: Int(index), section: Int(CameraKeyboardSection.photos.rawValue))
+                collectionView.deselectItem(at: indexPath, animated: true)
+                return
+            }
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -155,10 +155,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
     }
 
     func cameraKeyboardViewControllerWantsToOpenCameraRoll(_ controller: CameraKeyboardViewController) {
-        let collectionView = cameraKeyboardViewController?.collectionView
-        let preSelectedAssetIdentifiers = collectionView?.indexPathsForSelectedItems?
-            .compactMap { collectionView?.cellForItem(at: $0) as? AssetCell }
-            .compactMap(\.representedAssetIdentifier)
+        let preSelectedAssetIdentifiers = controller.selectedAssetIdentifiers
 
         hideCameraKeyboardViewController { [self] in
             shouldRefocusKeyboardAfterImagePickerDismiss = true
@@ -166,7 +163,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
                 sourceType: .photoLibrary,
                 mediaTypes: [UTType.movie.identifier, UTType.image.identifier],
                 allowsEditing: false,
-                preSelectedAssetIdentifiers: preSelectedAssetIdentifiers ?? [],
+                preSelectedAssetIdentifiers: preSelectedAssetIdentifiers,
                 pointToView: photoButton.imageView!
             )
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -1308,9 +1308,19 @@ extension ConversationInputBarViewController: UIGestureRecognizerDelegate {
         Task.detached { [weak self, observeDraftsUseCase, attachmentsCarouselViewModel] in
             let observed = await observeDraftsUseCase.invoke()
             for await drafts in observed {
+                let previousIdentifiers = Set(await attachmentsCarouselViewModel.draftsLocalIdentifiers)
                 await attachmentsCarouselViewModel.update(with: drafts)
                 await self?.syncCarouselVisible(drafts: drafts)
                 await self?.setAttachments(drafts: drafts)
+
+                let newIdentifiers = Set(drafts.compactMap(\.localIdentifier))
+                for identifier in previousIdentifiers.symmetricDifference(newIdentifiers) {
+                    if previousIdentifiers.contains(identifier) {
+                        await self?.cameraKeyboardViewController?.deselectItem(withLocalIdentifier: identifier)
+                    } else {
+                        await self?.cameraKeyboardViewController?.selectItem(withLocalIdentifier: identifier)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26581" title="WPB-26581" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26581</a>  [iOS] Multiple media selection: pre-select assets in native gallery
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes an issue where an asset from the custom gallery picker is sometimes not being automatically deselected.
Solution is to handle selection/deselection manually in the `observeDrafts` method to make sure the selection state is properly reflected at the exact time a draft is being updated.

### Testing

- In the custom gallery picker at the bottom of the conv, select multiple assets
- open the native gallery picker, and try to deselect some assets
- back to the custom gallery picker, observe that assets selection state is properly reflected.
- repeat the operation multiple times to ensure behavior is consistent

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
