### PR TITLE
fix: add accessible name to profile picture row - WPB-14703

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsAppearanceCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsAppearanceCell.swift
@@ -97,7 +97,7 @@ final class SettingsAppearanceCell: SettingsTableCell, CellConfigurationConfigur
                 iconImageView.image = .none
                 accessibilityValue = nil
                 titleLabelToIconInset.isActive = false
-                accessibilityTraits = []
+                accessibilityTraits = [.button]
             }
             layoutIfNeeded()
         }
@@ -115,6 +115,8 @@ final class SettingsAppearanceCell: SettingsTableCell, CellConfigurationConfigur
     func configure(with configuration: CellConfiguration) {
         guard case let .appearance(title) = configuration else { preconditionFailure() }
         titleLabel.text = title
+        accessibilityLabel = title
+        accessibilityTraits = [.button]
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14703" title="WPB-14703" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14703</a>  [iOS] Control element has no accessible name #63
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Adds an accessibility label to the account settings profile picture row and keeps it exposed as a button, so VoiceOver has a name for the tappable pen/profile-picture control.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
