### PR TITLE
fix: improve Create Group VoiceOver flow - WPB-14700

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/Cells/ConversationCreateNameCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/Cells/ConversationCreateNameCell.swift
@@ -48,6 +48,7 @@ final class ConversationCreateNameCell: UICollectionViewCell {
         setupStackView()
         setupGroupNameLabel()
         setupTextField()
+        setupAccessibility()
         setupConstraints()
         setupNotifications()
     }
@@ -70,6 +71,14 @@ final class ConversationCreateNameCell: UICollectionViewCell {
         textField.layer.borderColor = SemanticColors.SearchBar.borderInputView.cgColor
         textField.font = .font(for: .body1)
         stackView.addArrangedSubview(textField)
+    }
+
+    private func setupAccessibility() {
+        isAccessibilityElement = false
+        contentView.isAccessibilityElement = false
+        groupNameLabel.isAccessibilityElement = true
+        textField.accessibilityLabel = groupNameLabel.text
+        accessibilityElements = [groupNameLabel, textField]
     }
 
     private func setupConstraints() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -56,6 +56,7 @@ final class ConversationCreationController: UIViewController {
 
     private var preSelectedParticipants: UserSet?
     private var values: ConversationCreationValues
+    private var nextButtonWasEnabled = false
 
     weak var delegate: ConversationCreationControllerDelegate?
 
@@ -213,6 +214,14 @@ final class ConversationCreationController: UIViewController {
         setupNavigationBar()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .screenChanged, argument: CreateGroupName.title)
+        }
+    }
+
     // MARK: - Methods
 
     override var prefersStatusBarHidden: Bool {
@@ -271,8 +280,8 @@ final class ConversationCreationController: UIViewController {
 
         nextButtonItem.accessibilityIdentifier = Locators.CreateGroupPage.newGroupNextButton.rawValue
         nextButtonItem.tintColor = UIColor.accent()
-        nextButtonItem.isEnabled = isGroupNameValid()
         navigationItem.rightBarButtonItem = nextButtonItem
+        setNextButtonEnabled(isGroupNameValid(), announceChange: false)
     }
 
     func proceedWith(value: WireTextField.Value) {
@@ -323,6 +332,16 @@ final class ConversationCreationController: UIViewController {
         appsSection.configure(with: values)
         encryptionProtocolSection.configure(with: values)
         sharedDriveSection.configure(with: values)
+    }
+
+    private func setNextButtonEnabled(_ isEnabled: Bool, announceChange: Bool) {
+        navigationItem.rightBarButtonItem?.isEnabled = isEnabled
+
+        if announceChange, isEnabled, !nextButtonWasEnabled, UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .layoutChanged, argument: navigationItem.rightBarButtonItem)
+        }
+
+        nextButtonWasEnabled = isEnabled
     }
 }
 
@@ -539,8 +558,8 @@ extension ConversationCreationController: WireTextFieldDelegate {
     func textField(_ textField: WireTextField, valueChanged value: WireTextField.Value) {
         errorSection.clearError()
         switch value {
-        case .error: navigationItem.rightBarButtonItem?.isEnabled = false
-        case let .valid(text): navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
+        case .error: setNextButtonEnabled(false, announceChange: true)
+        case let .valid(text): setNextButtonEnabled(!text.isEmpty, announceChange: true)
         }
 
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -337,7 +337,7 @@ final class ConversationCreationController: UIViewController {
     private func setNextButtonEnabled(_ isEnabled: Bool, announceChange: Bool) {
         navigationItem.rightBarButtonItem?.isEnabled = isEnabled
 
-        if announceChange, isEnabled, !nextButtonWasEnabled, UIAccessibility.isVoiceOverRunning {
+        if announceChange, isEnabled, !nextButtonWasEnabled {
             UIAccessibility.post(notification: .layoutChanged, argument: navigationItem.rightBarButtonItem)
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/WireTextField.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/WireTextField.swift
@@ -120,8 +120,10 @@ class WireTextField: ContextMenuControllableUITextField {
         clearButton.tintColor = SemanticColors.Icon.foregroundDefaultBlack
 
         let clearAction = UIAction { [weak self] _ in
-            self?.text = ""
-            self?.sendActions(for: .editingChanged)
+            guard let self else { return }
+            text = ""
+            sendActions(for: .editingChanged)
+            textFieldValueChanged(text)
         }
         clearButton.addAction(clearAction, for: .touchUpInside)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14700" title="WPB-14700" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14700</a>  [iOS] Text content is not read aloud #70
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

- Announce the Create Group screen title when VoiceOver opens the view.
- Make the group name label part of the accessibility order before the text field.
- Move VoiceOver focus to the real Next button when it first becomes enabled.
- Ensure tapping the text field clear button revalidates the field so Next is disabled again.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
