### PR TITLE
fix: expose selected notification option to VoiceOver - WPB-14702

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Notifications.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Notifications.swift
@@ -60,14 +60,26 @@ enum NotificationResult: CaseIterable {
     }
 
     func action(for conversation: ZMConversation, handler: @escaping (NotificationResult) -> Void) -> UIAlertAction {
-        let checkmarkText = if let mutedMessageTypes, conversation.mutedMessageTypes == mutedMessageTypes {
+        let isSelected = mutedMessageTypes.map { conversation.mutedMessageTypes == $0 } ?? false
+        let checkmarkText = if isSelected {
             " ✓"
         } else {
             ""
         }
 
-        let title = title + checkmarkText
-        return .init(title: title, style: style, handler: { _ in handler(self) })
+        let actionTitle = title
+        let visibleTitle = actionTitle + checkmarkText
+        let action = UIAlertAction(title: visibleTitle, style: style, handler: { _ in handler(self) })
+        if mutedMessageTypes != nil {
+            let accessibilityValue = if isSelected {
+                L10n.Localizable.ButtonMessageCell.State.selected
+            } else {
+                L10n.Localizable.ButtonMessageCell.State.unselected
+            }
+            action.accessibilityLabel = "\(actionTitle), \(accessibilityValue)"
+            action.accessibilityValue = accessibilityValue
+        }
+        return action
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14702" title="WPB-14702" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14702</a>  [iOS] Value notifications are not programmatically deterifiable #78
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

- Add selected/unselected accessibility state to notification action-sheet options.
- Include the state in the action accessibility label so VoiceOver announces the active option.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
