### PR TITLE
fix: wire notification action during pr-daily-summary workflow - WPB-26619

### DIFF
--- a/.github/workflows/pr-review-summary.yml
+++ b/.github/workflows/pr-review-summary.yml
@@ -16,6 +16,14 @@ jobs:
         env:
             SLACK_WEBHOOK_URL: ${{ secrets.WIRE_IOS_CODE_REVIEW }}
         steps:
+            # Needed so the local ./.github/actions/notify-wire composite action is available.
+            # Only .github is required, and no LFS objects.
+            -   name: Checkout
+                uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+                with:
+                    sparse-checkout: .github
+                    lfs: 'false'
+
             -   name: Build summary message
                 id: build-summary
                 uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26619" title="WPB-26619" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26619</a>  [iOS] Testflight another build in review error stops dsym from being uploaded
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Following PR  (#4930), the way we send a notification to Wire was refactored and broke on the PR daily summary because the action was not checked out.

See: https://github.com/wireapp/wire-ios/actions/runs/28930050528

This PR fixes this.

### Testing

Merge and check this morning summary.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
