### PR TITLE
chore: add GOV_RELEASE variable - WPB-26202

### DIFF
--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -4,8 +4,9 @@
 # It is triggered whenever a pull request is merged into any `release/*` branch.
 #
 # Target branch selection:
-# - If the source branch is the LTS release branch (vars.LTS_RELEASE, e.g. release/cycle-4.16),
-#   targets `develop` directly, skipping any future release branches.
+# - If the source branch is the LTS release branch (vars.LTS_RELEASE, e.g. release/cycle-4.16)
+#   or the tracked GOV release branch (vars.GOV_RELEASE), targets `develop` directly, skipping
+#   any future release branches.
 # - Gets all release branches and sorts them
 # - Finds the position of the source branch in the sorted list
 # - Selects the next branch in the sorted list, or `develop` if no next branch exists
@@ -60,6 +61,7 @@ jobs:
         id: target-branch
         env:
           LTS_RELEASE: ${{ vars.LTS_RELEASE }}
+          GOV_RELEASE: ${{ vars.GOV_RELEASE }}
         run: |
           scripts/determine-cherry-pick-target.py "${{ github.event.pull_request.base.ref }}"
 

--- a/.github/workflows/ios_release_status.yml
+++ b/.github/workflows/ios_release_status.yml
@@ -36,7 +36,7 @@ jobs:
       # When set, an extra LTS section is appended to the report.
       LTS_RELEASE: ${{ vars.LTS_RELEASE }}
       # Optional: full branch name of an additionally tracked release (e.g. release/cycle-4.20).
-      # When set, an extra GOV section is appended to the report.
+      # When set, and the Jira version isn't yet released, an extra GOV section is appended to the report.
       GOV_RELEASE: ${{ vars.GOV_RELEASE }}
     steps:
       # Needed so the local ./.github/actions/notify-wire composite action is available.

--- a/.github/workflows/ios_release_status.yml
+++ b/.github/workflows/ios_release_status.yml
@@ -35,6 +35,9 @@ jobs:
       # Optional: full branch name of the current LTS C-build release (e.g. release/cycle-4.18).
       # When set, an extra LTS section is appended to the report.
       LTS_RELEASE: ${{ vars.LTS_RELEASE }}
+      # Optional: full branch name of an additionally tracked release (e.g. release/cycle-4.20).
+      # When set, an extra GOV section is appended to the report.
+      GOV_RELEASE: ${{ vars.GOV_RELEASE }}
     steps:
       # Needed so the local ./.github/actions/notify-wire composite action is available.
       # Only .github is required, and no LFS objects.
@@ -253,6 +256,28 @@ jobs:
               }
             }
 
+            // ── GOV Builds (optional, only if vars.GOV_RELEASE is set
+            //                and the Jira version isn't yet released) ────────
+            let gov = null;
+            if (process.env.GOV_RELEASE) {
+              const govBranch  = process.env.GOV_RELEASE;
+              const govVersion = await readVersionFromRef(govBranch);
+              const govName    = `iOS v${govVersion}`;
+              const govQ       = jqlEscape(govName);
+              const govJira    = await findJiraVersion(govVersion);
+              if (govJira?.released) {
+                core.info(`GOV ${govName} is already released in Jira — skipping section`);
+              } else {
+                const govTotalJql = `project = ${project} AND fixVersion = "${govQ}"`;
+                const govTotal    = await countIssues(govTotalJql);
+                const govOpenJql  = `project = ${project} AND fixVersion = "${govQ}" AND statusCategory != Done`;
+                const govOpen     = await countIssues(govOpenJql);
+                const govOpenItems = govOpen > 0 ? (await listIssues(govOpenJql, ['summary', 'status', 'assignee'])).issues : [];
+                const daysToGov  = govJira ? daysBetween(govJira.releaseDate) : null;
+                gov = { govBranch, govName, govJira, govTotal, govOpen, govOpenItems, daysToGov };
+              }
+            }
+
             // ── Render Slack-flavoured Markdown ───────────────────────────────
             // Each live release is rendered as its own self-contained message so
             // they can be posted to Wire separately (one message per release).
@@ -326,19 +351,39 @@ jobs:
               }
             }
 
+            // GOV Builds (optional)
+            let govLines = null;
+            if (gov) {
+              govLines = [dateTitle, ''];
+              govLines.push(`*⬛ GOV Builds - ${releaseLink(gov.govJira, gov.govName)} (\`${gov.govBranch}\`)*`);
+              govLines.push(`  • ${driverLabel(gov.govJira?.driver)}`);
+              if (gov.daysToGov != null) {
+                const label = gov.daysToGov >= 0 ? 'until release' : 'past release';
+                govLines.push(`  • ${Math.abs(gov.daysToGov)} day(s) ${label} (${gov.govJira.releaseDate})`);
+              } else {
+                govLines.push(`  • ⚠️ no release date on Jira version`);
+              }
+              govLines.push(`  • ${gov.govOpen} of ${gov.govTotal} tickets not done`);
+              if (gov.govOpen > 0) {
+                govLines.push(...renderGroupedByStatus(gov.govOpenItems));
+              }
+            }
+
             const edgeMsg = edgeLines.join('\n');
             const betaMsg = betaLines.join('\n');
             const prodMsg = prodLines.join('\n');
             const ltsMsg  = ltsLines ? ltsLines.join('\n') : '';
+            const govMsg  = govLines ? govLines.join('\n') : '';
 
-            // LTS is '' when no LTS_RELEASE is configured — its post step is skipped.
+            // LTS/GOV are '' when their vars aren't configured — their post steps are skipped.
             core.setOutput('edge', edgeMsg);
             core.setOutput('beta', betaMsg);
             core.setOutput('prod', prodMsg);
             core.setOutput('lts', ltsMsg);
+            core.setOutput('gov', govMsg);
 
             await core.summary
-              .addRaw([edgeMsg, betaMsg, prodMsg, ltsMsg].filter(Boolean).join('\n\n'))
+              .addRaw([edgeMsg, betaMsg, prodMsg, ltsMsg, govMsg].filter(Boolean).join('\n\n'))
               .write();
 
       - name: Post Edge to Wire
@@ -368,3 +413,10 @@ jobs:
         with:
           notify: custom
           text: ${{ steps.build.outputs.lts }}
+
+      - name: Post GOV to Wire
+        if: env.SLACK_WEBHOOK_URL != '' && steps.build.outputs.gov != ''
+        uses: ./.github/actions/notify-wire
+        with:
+          notify: custom
+          text: ${{ steps.build.outputs.gov }}

--- a/scripts/determine-cherry-pick-target.py
+++ b/scripts/determine-cherry-pick-target.py
@@ -3,8 +3,9 @@
 Determine the target branch for cherry-picking from a release branch.
 
 This script:
-1. If the input branch is the LTS release branch (LTS_RELEASE env var, e.g.
-   release/cycle-4.16), targets 'develop' directly, skipping future release branches
+1. If the input branch is one of the tracked release branches (LTS_RELEASE or
+   GOV_RELEASE env vars, e.g. release/cycle-4.16), targets 'develop' directly,
+   skipping future release branches
 2. Gets all release branches matching release/cycle-* pattern
 3. Sorts them by version number (major.minor)
 4. Finds the position of the input branch in the sorted list
@@ -60,12 +61,13 @@ def determine_target_branch(base_branch):
         print(f"Base branch {base_branch} doesn't match release/cycle-* pattern, using develop")
         return "develop"
 
-    # If the base branch is the LTS release branch, skip future release branches
-    # and cherry-pick straight to develop.
-    lts_release = os.environ.get("LTS_RELEASE", "").strip()
-    if lts_release and base_branch == lts_release:
-        print(f"Base branch {base_branch} is the LTS release branch, using develop")
-        return "develop"
+    # If the base branch is one of the tracked release branches (LTS or GOV),
+    # skip future release branches and cherry-pick straight to develop.
+    for env_var in ("LTS_RELEASE", "GOV_RELEASE"):
+        tracked_release = os.environ.get(env_var, "").strip()
+        if tracked_release and base_branch == tracked_release:
+            print(f"Base branch {base_branch} is the {env_var} release branch, using develop")
+            return "develop"
     
     # Get all release branches
     branches = get_release_branches()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26202" title="WPB-26202" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26202</a>  [iOS] Create Gov edition build pipleline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

As LTS_RELEASE, we need to keep track of GOV_RELEASE which is a long term support release.


* cherry-pick actions port fix directly to develop
* add a Gov release  to the daily release reports 

### Testing

N/A
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
