### PR TITLE
fix: sync not cancelled when going to background - WPB-26979

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -400,12 +400,22 @@ public struct IncrementalSync: IncrementalSyncProtocol {
 
         do {
             for item in envelopesWithObjectIDs {
+                // Important: this batch of events may be large so completing
+                // the event processing may take time. If the sync is suspended
+                // during this loop we may not reach a cancellation check before
+                // the app is suspended. Therefore, check for cancellation before
+                // EACH event is processed.
+                try Task.checkCancellation()
 
                 guard !earService.isLocked || item.envelope.isBackgroundAccessible else {
                     throw Failure.databaseLocked
                 }
 
                 for event in item.envelope.events {
+                    // In practice there's only one event per envelope, but add
+                    // a check here anyway just in case.
+                    try Task.checkCancellation()
+
                     do {
                         logger.debug(
                             "processing pending event: \(event.name)",

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSyncV2.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSyncV2.swift
@@ -220,7 +220,18 @@ public struct IncrementalSyncV2: LiveSyncProtocol {
             )
 
             for envelope in envelopes {
+                // Important: this batch of events may be large so completing
+                // the event processing may take time. If the sync is suspended
+                // during this loop we may not reach a cancellation check before
+                // the app is suspended. Therefore, check for cancellation before
+                // EACH event is processed.
+                try Task.checkCancellation()
+
                 for event in envelope.events {
+                    // In practice there's only one event per envelope, but add
+                    // a check here anyway just in case.
+                    try Task.checkCancellation()
+
                     do {
                         logger.debug(
                             "processing pending event: \(event.name)",

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
@@ -427,7 +427,7 @@ final class IncrementalSyncTests: XCTestCase {
         // Given: A large batch of stored events
         let largeEventCount = 100
         var largeEventBatch: [(UpdateEventEnvelope, NSManagedObjectID)] = []
-        for i in 0..<largeEventCount {
+        for i in 0 ..< largeEventCount {
             let event = Scaffolding.createEvent(
                 message: "message \(i)",
                 timeIntervalSinceNow: TimeInterval(-i)

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
@@ -423,6 +423,87 @@ final class IncrementalSyncTests: XCTestCase {
         XCTAssertEqual(updateEventsStore.resetLastEventID_Invocations.count, 1)
     }
 
+    func test_perform_CancelledDuringLargeBatch_CancellationCheckIsReached() async throws {
+        // Given: A large batch of stored events
+        let largeEventCount = 100
+        var largeEventBatch: [(UpdateEventEnvelope, NSManagedObjectID)] = []
+        for i in 0..<largeEventCount {
+            let event = Scaffolding.createEvent(
+                message: "message \(i)",
+                timeIntervalSinceNow: TimeInterval(-i)
+            )
+            largeEventBatch.append((event, NSManagedObjectID()))
+        }
+
+        updateEventsStore.fetchStoredEventEnvelopesLimitPrivateKeysBackgroundAccessibleOnly_MockMethod = { _, _, _ in
+            let result = largeEventBatch
+            largeEventBatch = []
+            return result
+        }
+
+        updateEventsStore.deleteNextPendingEventsWith_MockMethod = { _ in }
+        updateEventsStore.calculateLastUnreadMessages_MockMethod = {}
+        databaseSaver.save_MockMethod = {}
+        updateEventsSync.pullPublicKeys_MockMethod = { _ in AsyncStream { [] } }
+
+        // Setup push channel
+        let pushChannel = MockPushChannelProtocol()
+        pushChannel.open_MockValue = AsyncThrowingStream { _ in }
+        pushChannel.close_MockMethod = {}
+        pushChannelAPI.createPushChannelClientID_MockMethod = { _ in pushChannel }
+
+        // Cancel the task after processing a few events to simulate
+        // cancellation during the batch processing
+        var processedEventCount = 0
+        let cancelAfterCount = 10
+        let expectation = expectation(description: "task cancelled")
+        var taskToCancel: Task<Void, any Error>?
+
+        processor.processEvent_MockMethod = { _ in
+            processedEventCount += 1
+            if processedEventCount == cancelAfterCount {
+                taskToCancel?.cancel()
+                expectation.fulfill()
+            }
+        }
+
+        // When: Start sync and cancel during processing
+        taskToCancel = Task {
+            _ = try await self.sut.perform()
+        }
+
+        // Wait for cancellation to occur
+        await fulfillment(of: [expectation], timeout: 5)
+
+        // Then: Should throw CancellationError
+        do {
+            _ = try await taskToCancel!.value
+            XCTFail("Expected CancellationError to be thrown")
+        } catch is CancellationError {
+            // Expected - cancellation check was reached
+            XCTAssertTrue(true, "Cancellation check was successfully reached during batch processing")
+        } catch {
+            XCTFail("Expected CancellationError but got: \(error)")
+        }
+
+        // Verify that:
+        // 1. Some events were processed (at least up to the cancellation point)
+        XCTAssertGreaterThanOrEqual(processedEventCount, cancelAfterCount)
+
+        // 2. Not all events were processed (cancellation stopped processing)
+        XCTAssertLessThan(processedEventCount, largeEventCount)
+
+        // 3. Push channel was closed
+        XCTAssertEqual(pushChannel.close_Invocations.count, 1)
+
+        // 4. Partial batch was committed (only the events processed before cancellation)
+        XCTAssertEqual(updateEventsStore.deleteNextPendingEventsWith_Invocations.count, 1)
+        XCTAssertLessThan(
+            updateEventsStore.deleteNextPendingEventsWith_Invocations[0].count,
+            largeEventCount
+        )
+    }
+
     // MARK: - EAR Database Lock Tests
 
     func test_perform_databaseUnlocked_succeeds() async throws {

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
@@ -930,7 +930,7 @@ final class IncrementalSyncV2Tests: XCTestCase {
         // Given: A large batch of stored events
         let largeEventCount = 100
         var largeEventBatch: [(UpdateEventEnvelope, NSManagedObjectID)] = []
-        for i in 0..<largeEventCount {
+        for i in 0 ..< largeEventCount {
             let event = Scaffolding.createEvent(
                 message: "message \(i)",
                 timeIntervalSinceNow: TimeInterval(-i)

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
@@ -926,6 +926,80 @@ final class IncrementalSyncV2Tests: XCTestCase {
         XCTAssertEqual(journal[.brokenMLSGroupIDs].first, Scaffolding.mlsGroupID)
     }
 
+    func testPerform_CancelledDuringLargeBatch_CancellationCheckIsReached() async throws {
+        // Given: A large batch of stored events
+        let largeEventCount = 100
+        var largeEventBatch: [(UpdateEventEnvelope, NSManagedObjectID)] = []
+        for i in 0..<largeEventCount {
+            let event = Scaffolding.createEvent(
+                message: "message \(i)",
+                timeIntervalSinceNow: TimeInterval(-i)
+            )
+            largeEventBatch.append((event, NSManagedObjectID()))
+        }
+
+        setPendingEvents(envelopes: largeEventBatch)
+
+        updateEventsStore.deleteNextPendingEventsWith_MockMethod = { _ in }
+        updateEventsStore.calculateLastUnreadMessages_MockMethod = {}
+        databaseSaver.save_MockMethod = {}
+
+        // Setup push channel
+        let pushChannel = MockPushChannelV2Protocol()
+        pushChannel.open_MockValue = AsyncThrowingStream { _ in }
+        pushChannel.close_MockMethod = {}
+        pushChannelAPI.createPushChannelClientIDMarker_MockMethod = { _, _ in pushChannel }
+        pushChannelState.markAsOpen_MockMethod = {}
+        pushChannelState.markAsClosed_MockMethod = {}
+
+        // Cancel the task after processing a few events to simulate
+        // cancellation during the batch processing
+        var processedEventCount = 0
+        let cancelAfterCount = 10
+        let expectation = expectation(description: "task cancelled")
+        var taskToCancel: Task<Void, any Error>?
+
+        processor.processEvent_MockMethod = { _ in
+            processedEventCount += 1
+            if processedEventCount == cancelAfterCount {
+                taskToCancel?.cancel()
+                expectation.fulfill()
+            }
+        }
+
+        // When: Start sync and cancel during processing
+        taskToCancel = Task {
+            _ = try await self.sut.perform()
+        }
+
+        // Wait for cancellation to occur
+        await fulfillment(of: [expectation], timeout: 5)
+
+        // Then: Should throw CancellationError
+        do {
+            _ = try await taskToCancel!.value
+            XCTFail("Expected CancellationError to be thrown")
+        } catch is CancellationError {
+            // Expected - cancellation check was reached
+            XCTAssertTrue(true, "Cancellation check was successfully reached during batch processing")
+        } catch {
+            XCTFail("Expected CancellationError but got: \(error)")
+        }
+
+        // Verify that:
+        // 1. Some events were processed (at least up to the cancellation point)
+        XCTAssertGreaterThanOrEqual(processedEventCount, cancelAfterCount)
+
+        // 2. Not all events were processed (cancellation stopped processing)
+        XCTAssertLessThan(processedEventCount, largeEventCount)
+
+        // 3. Push channel was closed
+        XCTAssertEqual(pushChannel.close_Invocations.count, 1)
+
+        // 4. Push channel state was marked as closed
+        XCTAssertEqual(pushChannelState.markAsClosed_Invocations.count, 1)
+    }
+
     private func setPendingEvents(envelopes: [(UpdateEventEnvelope, NSManagedObjectID)]) {
         var storedEnvelopes = envelopes
         updateEventsStore.fetchStoredEventEnvelopesLimitPrivateKeysBackgroundAccessibleOnly_MockMethod = { _, _, _ in


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26979" title="WPB-26979" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26979</a>  [iOS] Synchronization appears interrupted but synchronization bar remains active.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**TL;DR**: incremental sync doesn't check task cancellation frequently enough and may not suspend properly before app execution is suspended. When app comes to FG again, the sync suspends and leaves the app in a broken state.

- If the app accumulates many pending events (stored locally in the DB) then these will all need to be processed during the incremental sync when the app comes to the foreground
- If the event processing starts and then the app is put in the background, then the incremental sync will be suspended (task cancelled).
- However, the next cancellation check is only at the start of the next batch (or later on after event processing), so the incremental sync continues to process events
- The app is in the background will suspend execution. If this happens before the cancellation check then the incremental sync is not torn down and simply frozen.
- When the app comes to the foreground again, the frozen incremental sync continues execution, finishing the event processing and then hitting a cancellation check, finally tearing down the sync
- No new incremental sync is started and the app is left in an idle state: the sync bar is showing because app is not live, but there is no sync. It looks like an infinite sync but no events are being received since there is no websocket open.
- Only when the app is put in BG and FG again does a new sync start and the issue is resolved.

The solution is simple:
- Check task cancellation before processing **EACH** event so that the incremental sync can tear down immediately.
- A nice to have would be to restart syncs in the foreground is needed, but this is not in scope of the current PR.

### Testing

1. Accumulate many events (e.g 500) while in the background.
2. Open the app and immediately put it in the background.
3. Wait for at least 2 minutes.
4. Open the app and let it sync.

Assert that the sync completes in normal time and the app becomes live.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
