### PR TITLE
fix: incorrect welcome system messages - WPB-26988

### DIFF
--- a/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testChannel.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testChannel.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e89c853e66c41b4d3b5aac76bb83c5a60a090e786076439192687a792aa07b0
-size 91512
+oid sha256:178c9a16c04a4dfa4fba07b0d68e5abd599d609bb31e72774bf494b549f13c96
+size 92227

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testGroup_guestsAllowed.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testGroup_guestsAllowed.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:398e59f478578170b9739a1fdda522c1fed6ed8804dbae71b372e2e3df29e553
-size 115919
+oid sha256:97911e2eee5f1458f185097ab84a84c799a741c1d5ac27e92d86081d9f4b1b2e
+size 116773

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testGroup_guestsAllowed_withDriveEnabled.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testGroup_guestsAllowed_withDriveEnabled.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7caba771c4cfba8120881b46c719ce70755ec270f1f9b54af1e7123da4e62465
-size 167170
+oid sha256:e1492053a888a6253aaf76bf3ba59a726e80081eebd30a6cc2873561757663e7
+size 171806

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testGroup_wireDriveEnabled.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testGroup_wireDriveEnabled.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:31f7e067d94eb91d13393a6d7852ec64044aff3988258e5ba1d635ca018a4ff2
-size 135458
+oid sha256:823c397e6b06d1fdd0c16a6dff035bed1f836fc7844a73460c47c6e18ecaa850
+size 140157

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testNamedGroup_otherCreator.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testNamedGroup_otherCreator.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:638b64aeaa6823f587088eebc770ba4168a8ba77eaf23e317e4a0e70f01783f2
-size 92207
+oid sha256:ec8651eb2cf6ffaa966a8eec7a27b42575d5c468a63bdff349465544fd823bb8
+size 93146

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testNamedGroup_selfCreator_noOtherParticipants.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testNamedGroup_selfCreator_noOtherParticipants.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a5f23abbf8ec15248ee0b6582ac692448005b8adb58fae75b9ba6f9d1c4a679
-size 83080
+oid sha256:753f98e7b9e9bc8f2a5a76ebdefb02ae30878250d242b064c618b4ba47af244b
+size 83999

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testNamedGroup_selfCreator_withParticipants.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testNamedGroup_selfCreator_withParticipants.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:466078aee3382afa641a659e3458c5f94fb02c5964cef9bc0f1d9619840d5228
-size 92256
+oid sha256:5ff6cf2d4521a406066335c8d302b7ba11e684e3ca88cf24f775a334675ec006
+size 93195

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testNamedGroup_selfCreator_withParticipants_darkMode.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/GroupConversationHeaderViewSnapshotTests/testNamedGroup_selfCreator_withParticipants_darkMode.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29ec4cf1550911e8b727a404721fd3f186655010e6854347116513433aed791e
-size 91546
+oid sha256:660e42a589c21c7a7bc1d2b1602fec7379afea7a1795549a8dfe0c2a0c4bc4cd
+size 92495

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/GuestAccountWarningView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/GuestAccountWarningView.swift
@@ -25,7 +25,7 @@ final class GuestAccountWarningView: UIView {
         case group(driveEnabled: Bool)
         case channel(driveEnabled: Bool)
     }
-    
+
     private let variant: Variant
     private let stackView = UIStackView(axis: .vertical)
 
@@ -95,7 +95,7 @@ final class GuestAccountWarningView: UIView {
         default: // Drive enabled message
             L10n.Localizable.Conversation.ConnectionView.Welcome.Message.wireCells
         }
-        
+
         messageLabel.isAccessibilityElement = true
 
         stackView.addArrangedSubview(messageLabel)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/GuestAccountWarningView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/GuestAccountWarningView.swift
@@ -20,7 +20,13 @@ import UIKit
 import WireDesign
 
 final class GuestAccountWarningView: UIView {
-
+    enum Variant {
+        case oneOnOne
+        case group(driveEnabled: Bool)
+        case channel(driveEnabled: Bool)
+    }
+    
+    private let variant: Variant
     private let stackView = UIStackView(axis: .vertical)
 
     private let titleLabel = DynamicFontLabel(
@@ -44,7 +50,8 @@ final class GuestAccountWarningView: UIView {
 
     // MARK: - Setup
 
-    init() {
+    init(variant: Variant) {
+        self.variant = variant
         super.init(frame: .zero)
         setupViews()
         setupConstraints()
@@ -64,7 +71,12 @@ final class GuestAccountWarningView: UIView {
         stackView.alignment = .fill
         stackView.spacing = 16
 
-        let title = L10n.Localizable.Conversation.ConnectionView.Welcome.Title.wire
+        let title = switch variant {
+        case .oneOnOne, .group(driveEnabled: false), .channel(driveEnabled: false):
+            L10n.Localizable.Conversation.ConnectionView.Welcome.Title.wire
+        default: // Drive enabled title
+            L10n.Localizable.Conversation.ConnectionView.Welcome.Title.wireCells
+        }
 
         titleLabel.numberOfLines = 0
         titleLabel.text = title
@@ -73,7 +85,17 @@ final class GuestAccountWarningView: UIView {
         stackView.addArrangedSubview(titleLabel)
 
         messageLabel.numberOfLines = 0
-        messageLabel.text = L10n.Localizable.Conversation.ConnectionView.Welcome.Message.wireOneOnOne
+        messageLabel.text = switch variant {
+        case .oneOnOne:
+            L10n.Localizable.Conversation.ConnectionView.Welcome.Message.wireOneOnOne
+        case .group(driveEnabled: false):
+            L10n.Localizable.Conversation.ConnectionView.Welcome.Message.wireGroup
+        case .channel(driveEnabled: false):
+            L10n.Localizable.Conversation.ConnectionView.Welcome.Message.wireChannel
+        default: // Drive enabled message
+            L10n.Localizable.Conversation.ConnectionView.Welcome.Message.wireCells
+        }
+        
         messageLabel.isAccessibilityElement = true
 
         stackView.addArrangedSubview(messageLabel)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/OneOnOneConversationHeaderView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/OneOnOneConversationHeaderView.swift
@@ -37,7 +37,7 @@ final class OneOnOneConversationHeaderView: UIView, Copyable {
     private let labelContainer = UIStackView(axis: .vertical)
     private let userImageView = UserImageView()
     private let guestIndicator = LabelIndicator(context: .guest)
-    private let guestWarningView = GuestAccountWarningView()
+    private let guestWarningView = GuestAccountWarningView(variant: .oneOnOne)
     private let guestWarningContainer = UIView()
     private let userSession: UserSession
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/GroupConversationHeaderView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/GroupConversationHeaderView.swift
@@ -72,7 +72,9 @@ final class GroupConversationHeaderView: UIView {
     }
 
     private func populate(conversation: ZMConversation, selfUser: any UserType) {
-        let variant: GuestAccountWarningView.Variant = conversation.isChannel ? .channel(driveEnabled: conversation.isWireDriveEnabled) : .group(driveEnabled: conversation.isWireDriveEnabled)
+        let variant: GuestAccountWarningView.Variant = conversation
+            .isChannel ? .channel(driveEnabled: conversation.isWireDriveEnabled) :
+            .group(driveEnabled: conversation.isWireDriveEnabled)
         let bannerView = makeGuestWarningBanner(variant: variant)
         stackView.addArrangedSubview(bannerView)
         stackView.setCustomSpacing(16, after: bannerView)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/GroupConversationHeaderView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/GroupConversationHeaderView.swift
@@ -61,8 +61,8 @@ final class GroupConversationHeaderView: UIView {
         ])
     }
 
-    private func makeGuestWarningBanner() -> UIView {
-        let warningView = GuestAccountWarningView()
+    private func makeGuestWarningBanner(variant: GuestAccountWarningView.Variant) -> UIView {
+        let warningView = GuestAccountWarningView(variant: variant)
         warningView.translatesAutoresizingMaskIntoConstraints = false
         let container = UIView()
         container.backgroundColor = SemanticColors.View.backgroundGreen
@@ -72,7 +72,8 @@ final class GroupConversationHeaderView: UIView {
     }
 
     private func populate(conversation: ZMConversation, selfUser: any UserType) {
-        let bannerView = makeGuestWarningBanner()
+        let variant: GuestAccountWarningView.Variant = conversation.isChannel ? .channel(driveEnabled: conversation.isWireDriveEnabled) : .group(driveEnabled: conversation.isWireDriveEnabled)
+        let bannerView = makeGuestWarningBanner(variant: variant)
         stackView.addArrangedSubview(bannerView)
         stackView.setCustomSpacing(16, after: bannerView)
 


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->
WPB-26988
<!--jira-description-action-hidden-marker-end-->

### Issue

A regression was introduced in this [PR](https://github.com/wireapp/wire-ios/pull/4492) where the welcome system messages were not properly ported to the newly introduced green banner, displaying inaccurate information to the user — especially that Drive conversations were end-to-end encrypted.


`GuestAccountWarningView` was hardcoded to always show the one-on-one welcome title/message, regardless of conversation type. This meant group conversations, channels, and Wire Drive-enabled conversations all displayed the generic one-on-one copy in the green banner, which incorrectly implied Drive conversations were end-to-end encrypted.

This PR introduces a `GuestAccountWarningView.Variant` enum (`oneOnOne`, `group(driveEnabled:)`, `channel(driveEnabled:)`) so the correct title and message are selected based on the conversation's actual type and Drive-enabled state, restoring the behavior that was lost in #4492.

### Testing

- Updated snapshot reference images for `GroupConversationHeaderViewSnapshotTests` to reflect the corrected banner copy for channels and Drive-enabled groups.
- Manually verify the green welcome banner text on: a 1:1 connection request, a group conversation, a channel, and a Wire Drive-enabled group — confirm none of them claim Drive conversations are end-to-end encrypted.

---

### Checklist

- [x] Title contains a reference JIRA issue number.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.