### PR TITLE
fix: Skipping SSOTests due to Okta being removed - WPB-27003

### DIFF
--- a/wire-ios/WireUITests/SSOTests.swift
+++ b/wire-ios/WireUITests/SSOTests.swift
@@ -45,6 +45,10 @@ final class SSOTests: WireUITestCase {
     /// [critical]
     @MainActor
     func testSSOLoginWithSSOCodeAndNoResetPassword_TC_8966_TC_10850() async throws {
+        // Skipped: Okta license removed, so the SSO IdP backing this test is no longer available.
+        // Re-enable once a replacement SSO provider is configured.
+        throw XCTSkip("Okta license removed - SSO IdP unavailable")
+
         // GIVEN
         let ssoUser = try await createSSOUser()
         let ssoCode = try ssoHelper.getSSOCode()
@@ -70,6 +74,10 @@ final class SSOTests: WireUITestCase {
     /// [critical]
     @MainActor
     func testReloginSSO_TC_8970() async throws {
+        // Skipped: Okta license removed, so the SSO IdP backing this test is no longer available.
+        // Re-enable once a replacement SSO provider is configured.
+        throw XCTSkip("Okta license removed - SSO IdP unavailable")
+
         // GIVEN
         let ssoUser = try await createSSOUser()
         let ssoCode = try ssoHelper.getSSOCode()
@@ -103,6 +111,9 @@ final class SSOTests: WireUITestCase {
 
     @MainActor
     func testSCIMManagedUserCannotChangeAccountFields_TC_10851() async throws {
+        // Skipped: Okta license removed, so the SSO IdP backing this test is no longer available.
+        // Re-enable once a replacement SSO provider is configured.
+        throw XCTSkip("Okta license removed - SSO IdP unavailable")
 
         // GIVEN
         let teamOwner = try await registerTeamOwnerWithSSOEnabled()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27003" title="WPB-27003" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27003</a>  [iOS] Fix - Skip SSOTests due to Okta removed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Need to skip SSOTests as Okta is removed now.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
