### PR TITLE
fix:  nightly failures - WPB-27029

### DIFF
--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -162,7 +162,7 @@ public enum Locators {
         case sharedDriveButton
         case ephemeralTimeSelectionButton
         case message
-        case linkPreviewCell = "LinkPreviewCell"
+        case linkPreviewCell
         case imageCell
         case videoCell
         case videoPlayButton

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
@@ -36,7 +36,9 @@ enum ConversationSystemMessageCellDescription {
               let sender = message.senderUser,
               let conversation = message.conversationLike
         else {
-            assertionFailure("Invalid system message")
+            WireLogger.conversation.warn(
+                "Skipping invalid system message: missing systemMessageData, sender, or conversation"
+            )
             return []
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 import WireDataModel
+import WireLocators
 import WireSyncEngine
 
 final class ConversationLinkPreviewArticleCell: UIView, ConversationMessageCell, ContextMenuDelegate {
@@ -130,7 +131,7 @@ final class ConversationLinkPreviewArticleCellDescription: ConversationMessageCe
     let shouldAlignMessageContentForBubbles: Bool = true
 
     var accessibilityIdentifier: String? {
-        configuration.isObfuscated ? "ObfuscatedLinkPreviewCell" : "LinkPreviewCell"
+        configuration.isObfuscated ? "ObfuscatedLinkPreviewCell" : Locators.ActiveConversationPage.linkPreviewCell.rawValue
     }
 
     let accessibilityLabel: String?

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
@@ -131,7 +131,8 @@ final class ConversationLinkPreviewArticleCellDescription: ConversationMessageCe
     let shouldAlignMessageContentForBubbles: Bool = true
 
     var accessibilityIdentifier: String? {
-        configuration.isObfuscated ? "ObfuscatedLinkPreviewCell" : Locators.ActiveConversationPage.linkPreviewCell.rawValue
+        configuration.isObfuscated ? "ObfuscatedLinkPreviewCell" : Locators.ActiveConversationPage.linkPreviewCell
+            .rawValue
     }
 
     let accessibilityLabel: String?

--- a/wire-ios/WireUITests/ConversationTests.swift
+++ b/wire-ios/WireUITests/ConversationTests.swift
@@ -52,19 +52,15 @@ final class ConversationTests: WireUITestCase {
 
     @MainActor
     func testLeaveGroup_TC_8861() async throws {
-        let stagingTeam = try await UserHelper.default.registerTeam(withMemberCount: 2)
-        let userA = try XCTUnwrap(stagingTeam.teamOwner)
-        let userB = try XCTUnwrap(stagingTeam.teamMembers.last)
-
-        let conversationsPage = try await loginToBackend(user: userA)
-
-        // WHEN
-        let activeConversationPage = try conversationsPage
-            .tapPlusButtonToCreateGroup()
-            .tapNewGroupButton()
-            .enterGroupName("test")
-            .tapMemberCells(withLabelPrefixes: [userB.name])
-            .doneSelectingMembers()
+        // GIVEN
+        let (_, members, _, _) = try await UserHelper.default.registerTeam(
+            withMemberCount: 2,
+            conversation: .group("Test")
+        )
+        let activeConversationPage = try app.loginUser(email: members[0].email, password: members[0].password)
+            .acceptPopup()
+            .openConversation()
+            // WHEN
             .sendMessage("test")
             .openConversationDetails()
             .moreOptionsConversationDetails()
@@ -81,19 +77,15 @@ final class ConversationTests: WireUITestCase {
 
     @MainActor
     func testLeaveAndClearGroup_TC_10525() async throws {
-        let stagingTeam = try await UserHelper.default.registerTeam(withMemberCount: 2)
-        let userA = try XCTUnwrap(stagingTeam.teamOwner)
-        let userB = try XCTUnwrap(stagingTeam.teamMembers.last)
-
-        let conversationsPage = try await loginToBackend(user: userA)
-
-        // WHEN
-        let activeConversationPage = try conversationsPage
-            .tapPlusButtonToCreateGroup()
-            .tapNewGroupButton()
-            .enterGroupName("test")
-            .tapMemberCells(withLabelPrefixes: [userB.name])
-            .doneSelectingMembers()
+        // GIVEN
+        let (_, members, _, _) = try await UserHelper.default.registerTeam(
+            withMemberCount: 2,
+            conversation: .group("Test")
+        )
+        let activeConversationPage = try app.loginUser(email: members[0].email, password: members[0].password)
+            .acceptPopup()
+            .openConversation()
+            // WHEN
             .sendMessage("test")
             .openConversationDetails()
             .moreOptionsConversationDetails()

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -534,6 +534,7 @@ class ActiveConversationPage: PageModel {
     ) -> ActiveConversationPage {
         XCTAssertTrue(
             linkPreviewCell.waitForExistence(timeout: 10),
+            "Link preview cell did not appear",
             file: file,
             line: line
         )

--- a/wire-ios/WireUITests/SettingsTests.swift
+++ b/wire-ios/WireUITests/SettingsTests.swift
@@ -100,43 +100,33 @@ final class SettingsTests: WireUITestCase {
 
     @MainActor
     func testCreateLinkPreviewsOption_TC_8951() async throws {
-        let stagingTeam = try await UserHelper.default.registerTeam(withMemberCount: 2)
-        let userA = try XCTUnwrap(stagingTeam.teamMembers.first)
-        let userB = try XCTUnwrap(stagingTeam.teamMembers.last)
+        let (stagingTeam, _, _, _) = try await UserHelper.default.registerTeam(
+            withMemberCount: 2,
+            conversation: .group("Test")
+        )
 
-        // Login & create conversation
-        _ = try await loginToBackend(user: userA)
-            .tapPlusButtonToCreateGroup()
-            .tapNewGroupButton()
-            .enterGroupName("Test")
-            .tapMemberCells(withLabelPrefixes: [userB.name])
-            .doneSelectingMembers()
-            .goBackToConversationPage()
-
-        // Disable link previews
-        _ = try ConversationsPage()
+        // Login & Disable link previews
+        let conversationPage = try app.loginUser(email: stagingTeam.email, password: stagingTeam.password)
+            .acceptPopup()
             .openSettings()
             .openOptionsMenu()
             .disableCreateLinkPreviews()
             .backToSettings()
             .switchToConversationsTab()
-
-        // Open conversation and send first link
-        _ = try ConversationsPage()
+        
+            // Open conversation and send first link
             .openConversation()
             .sendMessage("First link: https://github.com/wireapp/wire-ios")
             .goBackToConversationPage()
-
-        // Enable link previews
-        _ = try ConversationsPage()
+        
+            // Enable link previews
             .openSettings()
             .openOptionsMenu()
             .enableCreateLinkPreviews()
             .backToSettings()
             .switchToConversationsTab()
-
-        // Open conversation and send first link
-        let conversationPage = try ConversationsPage()
+        
+            // Open conversation and send first link
             .openConversation()
             .sendMessage("Second link: https://github.com/wireapp/wire-android")
 

--- a/wire-ios/WireUITests/SettingsTests.swift
+++ b/wire-ios/WireUITests/SettingsTests.swift
@@ -113,19 +113,16 @@ final class SettingsTests: WireUITestCase {
             .disableCreateLinkPreviews()
             .backToSettings()
             .switchToConversationsTab()
-        
             // Open conversation and send first link
             .openConversation()
             .sendMessage("First link: https://github.com/wireapp/wire-ios")
             .goBackToConversationPage()
-        
             // Enable link previews
             .openSettings()
             .openOptionsMenu()
             .enableCreateLinkPreviews()
             .backToSettings()
             .switchToConversationsTab()
-        
             // Open conversation and send first link
             .openConversation()
             .sendMessage("Second link: https://github.com/wireapp/wire-android")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27029" title="WPB-27029" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27029</a>  [iOS] Fix - nightly UITests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Nightly failures: 
❌ WireUITests > ConversationTests > testLeaveAndClearGroupTC10525(): ConversationTests.swift:106: XCTAssertEqual failed: ("1") is not equal to ("0")
❌ WireUITests > ConversationTests > testLeaveGroupTC8861(): ConversationTests.swift:79: XCTAssertTrue failed - the system message is missing
❌ WireUITests > SettingsTests > testCreateLinkPreviewsOptionTC8951(): SettingsTests.swift:145: XCTAssertTrue failed

### Changes

Related to ConversationTests: UI test crashes: testLeaveAndClearGroup_TC_10525, testLeaveGroup_TC_8861

Problem

Tests now create team/group via API instead of step-by-step UI flow. On leave-and-clear, app crashed in ConversationSystemMessageCellDescription.cells(...).

Root cause: a system message reached the cell builder before its object graph was fully synced — systemMessageData, senderUser, or conversationLike was temporarily nil. The guard called assertionFailure("Invalid system message"), which traps in debug builds (UI tests run debug) → crash. Step-by-step UI flow never hit this because system messages arrive complete.

Change

Downgraded assertionFailure → WireLogger.conversation.warn(...) in the guard's else.

```
-            assertionFailure("Invalid system message")
+            WireLogger.conversation.warn(
+                "Skipping invalid system message: missing systemMessageData, sender, or conversation"
+            )
             return []
```

Why safe — no production behavior change

- assertionFailure is compiled out of release builds; production already returned [] here silently.
- Both paths still return []. Only difference: debug builds warn instead of trapping.
- The condition is now known-reachable with valid data (API-created convos / sync race), so a hard assert was wrong. Warning keeps the signal in logs.

Trade-off

Loses the loud debug trap for genuinely-malformed system messages. Accepted: return value unchanged, condition is legitimate, warning preserves observability.

### Testing

Local run looks good.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
