### PR TITLE
chore: new test to unarchive conversations - WPB-26644

### DIFF
--- a/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
@@ -101,6 +101,11 @@ class ConversationDetailsPage: PageModel {
         return try ConversationsPage()
     }
 
+    func unarchiveOptionsConversationDetails() throws -> ConversationsPage {
+        archiveOptionConversationDetailsButton.tap()
+        return try ConversationsPage()
+    }
+
     func clearContentOptionsConversationDetails() throws -> Self {
         clearContentOptionConversationDetailsButton.tap()
         return self

--- a/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
@@ -102,8 +102,7 @@ class ConversationDetailsPage: PageModel {
     }
 
     func unarchiveOptionsConversationDetails() throws -> ConversationsPage {
-        archiveOptionConversationDetailsButton.tap()
-        return try ConversationsPage()
+        try archiveOptionsConversationDetails()
     }
 
     func clearContentOptionsConversationDetails() throws -> Self {

--- a/wire-ios/WireUITests/TeamManageTests.swift
+++ b/wire-ios/WireUITests/TeamManageTests.swift
@@ -192,7 +192,7 @@ final class TeamManageTests: WireUITestCase {
             .openConversation()
             .goBackToConversationPage()
             .openArchived()
-        
+
         // [WPB-3772]: BUG: just opening an archived conversation must not unarchive it.
         XCTAssertTrue(
             stillArchivedPage.conversationExists(withName: groupName),

--- a/wire-ios/WireUITests/TeamManageTests.swift
+++ b/wire-ios/WireUITests/TeamManageTests.swift
@@ -165,9 +165,8 @@ final class TeamManageTests: WireUITestCase {
         )
     }
 
-    /// [WPB-3772] Bug: Opening an archived conversation unarchives it
     @MainActor
-    func testArchivedConversationUnarchivesWhenOpened_TC_8872() async throws {
+    func testArchiveOpenAndUnarchiveConversation_TC_8872_8873() async throws {
         let groupName = UserGenerator.generateRandomConversationName()
 
         let (teamOwner, _, _, _) = try await UserHelper.default.registerTeam(
@@ -175,29 +174,7 @@ final class TeamManageTests: WireUITestCase {
             conversation: .group(groupName)
         )
 
-        let archivedConversationPage = try app.loginUser(email: teamOwner.email, password: teamOwner.password)
-            .acceptPopup()
-            .openConversation()
-            .openConversationDetails()
-            .moreOptionsConversationDetails()
-            .archiveOptionsConversationDetails()
-            .openArchived()
-            .openConversation()
-            .goBackToConversationPage()
-            .openArchived()
-
-        XCTAssertTrue(archivedConversationPage.conversationExists(withName: groupName))
-    }
-
-    @MainActor
-    func testUnarchiveConversation_TC_8873() async throws {
-        let groupName = UserGenerator.generateRandomConversationName()
-
-        let (teamOwner, _, _, _) = try await UserHelper.default.registerTeam(
-            withMemberCount: 1,
-            conversation: .group(groupName)
-        )
-
+        // Archive the group via conversation details.
         let archivedConversationPage = try app.loginUser(email: teamOwner.email, password: teamOwner.password)
             .acceptPopup()
             .openConversation()
@@ -208,10 +185,21 @@ final class TeamManageTests: WireUITestCase {
 
         XCTAssertTrue(
             archivedConversationPage.conversationExists(withName: groupName),
-            "Group \(groupName) should be in the archived list after archiving"
+            "Group \(groupName) not showing in archived"
         )
 
-        let conversationsPage = try archivedConversationPage
+        let stillArchivedPage = try archivedConversationPage
+            .openConversation()
+            .goBackToConversationPage()
+            .openArchived()
+        
+        // [WPB-3772]: BUG: just opening an archived conversation must not unarchive it.
+        XCTAssertTrue(
+            stillArchivedPage.conversationExists(withName: groupName),
+            "Group \(groupName) gets unarchived after only opening it"
+        )
+
+        let conversationsPage = try stillArchivedPage
             .openConversation()
             .openConversationDetails()
             .moreOptionsConversationDetails()

--- a/wire-ios/WireUITests/TeamManageTests.swift
+++ b/wire-ios/WireUITests/TeamManageTests.swift
@@ -170,17 +170,14 @@ final class TeamManageTests: WireUITestCase {
     func testArchivedConversationUnarchivesWhenOpened_TC_8872() async throws {
         let groupName = UserGenerator.generateRandomConversationName()
 
-        let (_, teamOwner) = try await UserHelper.default.registerUserAsTeamOwner()
-
-        let teamNames = try await UserHelper.default.registerTeamWith2Members(teamOwner: teamOwner)
+        let (teamOwner, _, _, _) = try await UserHelper.default.registerTeam(
+            withMemberCount: 1,
+            conversation: .group(groupName)
+        )
 
         let archivedConversationPage = try app.loginUser(email: teamOwner.email, password: teamOwner.password)
             .acceptPopup()
-            .tapPlusButtonToCreateGroup()
-            .tapNewGroupButton()
-            .enterGroupName(groupName)
-            .tapMemberCells(withLabelPrefixes: teamNames)
-            .doneSelectingMembers()
+            .openConversation()
             .openConversationDetails()
             .moreOptionsConversationDetails()
             .archiveOptionsConversationDetails()
@@ -190,6 +187,45 @@ final class TeamManageTests: WireUITestCase {
             .openArchived()
 
         XCTAssertTrue(archivedConversationPage.conversationExists(withName: groupName))
+    }
+
+    @MainActor
+    func testUnarchiveConversation_TC_8873() async throws {
+        let groupName = UserGenerator.generateRandomConversationName()
+
+        let (teamOwner, _, _, _) = try await UserHelper.default.registerTeam(
+            withMemberCount: 1,
+            conversation: .group(groupName)
+        )
+
+        let archivedConversationPage = try app.loginUser(email: teamOwner.email, password: teamOwner.password)
+            .acceptPopup()
+            .openConversation()
+            .openConversationDetails()
+            .moreOptionsConversationDetails()
+            .archiveOptionsConversationDetails()
+            .openArchived()
+
+        XCTAssertTrue(
+            archivedConversationPage.conversationExists(withName: groupName),
+            "Group \(groupName) should be in the archived list after archiving"
+        )
+
+        let conversationsPage = try archivedConversationPage
+            .openConversation()
+            .openConversationDetails()
+            .moreOptionsConversationDetails()
+            .unarchiveOptionsConversationDetails()
+
+        XCTAssertTrue(
+            conversationsPage.conversationCell(named: groupName).waitForExistence(timeout: 5),
+            "Group \(groupName) should be back in the recent conversation list after unarchiving"
+        )
+
+        XCTAssertFalse(
+            try conversationsPage.openArchived().conversationExists(withName: groupName),
+            "Group \(groupName) should no longer be in the archived list after unarchiving"
+        )
     }
 
     /// [critical]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26644" title="WPB-26644" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26644</a>  [iOS] Automate - Unarchive conversation 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

UITest - Unarchive conversation + merge archive and unarchive tests to single test function

### Testing


https://github.com/user-attachments/assets/93c3b3cf-e1a6-4c60-a8e8-7be2a3ef65ec



---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
