### PR TITLE
fix: add accessibility headings to login flow - WPB-14677

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
@@ -112,6 +112,7 @@ package struct DetermineAuthMethodView: View {
         Text(Strings.Identity.Input.body)
             .multilineTextAlignment(.center)
             .font(for: .body1)
+            .accessibilityHeading(.h1)
             .lineLimit(nil)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.trailing)

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
@@ -180,6 +180,7 @@ package struct LoginViaEmailView: View {
             Text(Strings.CreateAccountOrTeam.title)
                 .multilineTextAlignment(.center)
                 .font(for: .body1)
+                .accessibilityHeading(.h1)
                 .lineLimit(nil)
                 .fixedSize(horizontal: false, vertical: true)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14677" title="WPB-14677" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14677</a>  [iOS] Headings not developed #1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

- Mark the primary prompt on the determine-auth-method screen as a level-one accessibility heading.
- Mark the primary prompt on the email login screen as a level-one accessibility heading.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
