### PR TITLE
fix: expose About web links as links - WPB-14705

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -306,7 +306,8 @@ struct SettingsCellDescriptorFactory {
             presentationAction: {
                 WireURLs.shared.legal.browserControllerOrOpenExternally()
             },
-            previewGenerator: .none
+            previewGenerator: .none,
+            accessibilityTraits: .link
         )
 
         let shortVersion = Bundle.main.shortVersionString ?? "Unknown"
@@ -332,7 +333,8 @@ struct SettingsCellDescriptorFactory {
             presentationAction: {
                 WireURLs.shared.website.browserControllerOrOpenExternally()
             },
-            previewGenerator: .none
+            previewGenerator: .none,
+            accessibilityTraits: .link
         )
 
         let websiteSection = SettingsSectionDescriptor(cellDescriptors: [websiteButton])

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
@@ -34,6 +34,7 @@ class SettingsExternalScreenCellDescriptor: SettingsGroupCellDescriptorType, Set
     let settingsTopLevelMenuItem: SettingsTopLevelMenuItem?
 
     private let accessoryView: AccessoryView?
+    private let accessibilityTraits: UIAccessibilityTraits?
 
     weak var group: SettingsGroupCellDescriptorType?
     weak var viewController: UIViewController?
@@ -42,7 +43,11 @@ class SettingsExternalScreenCellDescriptor: SettingsGroupCellDescriptorType, Set
 
     let presentationAction: () -> (UIViewController?)
 
-    convenience init(title: String, presentationAction: @escaping () -> (UIViewController?)) {
+    convenience init(
+        title: String,
+        presentationAction: @escaping () -> (UIViewController?),
+        accessibilityTraits: UIAccessibilityTraits? = nil
+    ) {
         self.init(
             title: title,
             isDestructive: false,
@@ -52,7 +57,8 @@ class SettingsExternalScreenCellDescriptor: SettingsGroupCellDescriptorType, Set
             previewGenerator: nil,
             icon: .none,
             copiableText: nil,
-            settingsTopLevelMenuItem: nil
+            settingsTopLevelMenuItem: nil,
+            accessibilityTraits: accessibilityTraits
         )
     }
 
@@ -64,7 +70,8 @@ class SettingsExternalScreenCellDescriptor: SettingsGroupCellDescriptorType, Set
         previewGenerator: PreviewGeneratorType? = .none,
         icon: StyleKitIcon? = nil,
         accessoryView: AccessoryView? = .automatic,
-        copiableText: String? = nil
+        copiableText: String? = nil,
+        accessibilityTraits: UIAccessibilityTraits? = nil
     ) {
         self.init(
             title: title,
@@ -76,7 +83,8 @@ class SettingsExternalScreenCellDescriptor: SettingsGroupCellDescriptorType, Set
             icon: icon,
             accessoryView: accessoryView,
             copiableText: copiableText,
-            settingsTopLevelMenuItem: nil
+            settingsTopLevelMenuItem: nil,
+            accessibilityTraits: accessibilityTraits
         )
     }
 
@@ -90,7 +98,8 @@ class SettingsExternalScreenCellDescriptor: SettingsGroupCellDescriptorType, Set
         icon: StyleKitIcon? = nil,
         accessoryView: AccessoryView? = .automatic,
         copiableText: String?,
-        settingsTopLevelMenuItem: SettingsTopLevelMenuItem?
+        settingsTopLevelMenuItem: SettingsTopLevelMenuItem?,
+        accessibilityTraits: UIAccessibilityTraits? = nil
     ) {
         self.title = title
         self.destructive = isDestructive
@@ -102,6 +111,7 @@ class SettingsExternalScreenCellDescriptor: SettingsGroupCellDescriptorType, Set
         self.accessoryView = accessoryView
         self.copiableText = copiableText
         self.settingsTopLevelMenuItem = settingsTopLevelMenuItem
+        self.accessibilityTraits = accessibilityTraits
     }
 
     func select(_ value: SettingsPropertyValue, sender: UIView) {
@@ -158,6 +168,9 @@ class SettingsExternalScreenCellDescriptor: SettingsGroupCellDescriptorType, Set
                 groupCell.showExternalLinkAccessoryView()
             case .none:
                 groupCell.hideAccessoryView()
+            }
+            if let accessibilityTraits {
+                groupCell.accessibilityTraits = accessibilityTraits
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14705" title="WPB-14705" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14705</a>  [iOS] Link is interpreted as a button #123
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

- Expose “Legal” and “Wire Website” under Settings as links instead of buttons.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
