### PR TITLE
fix: add profile color option accessibility role - WPB-14761

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPicker.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPicker.swift
@@ -35,17 +35,21 @@ struct AccentColorPicker: View {
 
     @ViewBuilder private var accentColorList: some View {
         List(AccentColor.allCases, id: \.self) { color in
-            cell(for: color)
-                .listRowBackground(Color(SemanticColors.View.backgroundUserCell))
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    selectedColor = color
-                    onColorSelect?(color)
-                }
+            Button {
+                selectedColor = color
+                onColorSelect?(color)
+            } label: {
+                cell(for: color)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .listRowBackground(ColorTheme.Backgrounds.surface.color)
+            .accessibilityLabel(color.name)
+            .accessibilityAddTraits(selectedColor == color ? .isSelected : [])
         }
         .listStyle(.plain)
         .modifier(ListBackgroundStyleModifier())
-        .background(Color(SemanticColors.View.backgroundDefault))
+        .background(ColorTheme.Backgrounds.background.color)
     }
 
     @ViewBuilder
@@ -64,7 +68,7 @@ struct AccentColorPicker: View {
             // Checkmark view
             if selectedColor == color {
                 Image(systemName: "checkmark")
-                    .foregroundColor(Color(SemanticColors.Icon.foregroundDefaultBlack))
+                    .foregroundStyle(ColorTheme.Backgrounds.onSurface.color)
             }
         }
     }

--- a/wire-ios/WireUITests/Pages/AccountSettingsPage.swift
+++ b/wire-ios/WireUITests/Pages/AccountSettingsPage.swift
@@ -145,12 +145,13 @@ class AccountSettingsPage: PageModel {
 
     func selectProfileColor(_ color: ProfileColor) throws -> AccountSettingsPage {
         colorCell.waitAndTap()
-        let colorOption = app.staticTexts[color.displayName].firstMatch
+        let colorOption = app.buttons[color.displayName].firstMatch
         XCTAssertTrue(
             colorOption.waitForExistence(timeout: 5),
             "\(color.displayName) color option did not appear"
         )
         colorOption.tap()
+        XCTAssertTrue(colorOption.isSelected, "\(color.displayName) color option was not selected")
         XCTAssertTrue(backToPreviousPage.waitAndTap(), "Failed to navigate back from the color picker")
         return try AccountSettingsPage()
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14761" title="WPB-14761" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14761</a>  [iOS] Profile colors options without roll #122
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In Settings -> Account -> Profile color, VoiceOver announced the color names but did not identify them as actionable controls.

- Expose the currently selected option with the selected accessibility trait
- Update the UI test page object to query the options as buttons and verify selection
- Replace deprecated SemanticColors usages in the touched view with ColorTheme

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [X] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
