### PR TITLE
fix: bad `BackgroundActivityFactory` state when receiving calls  - WPB-23511

### DIFF
--- a/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
+++ b/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
@@ -39,6 +39,7 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
     public let callKitManager: CallKitManager
 
     private let pushTokenService: PushTokenServiceInterface
+    private let backgroundActivityFactory: BackgroundActivityFactory
     private let registry: PKPushRegistry
 
     public weak var delegate: VoIPPushManagerDelegate?
@@ -49,10 +50,12 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
 
     public init(
         application: ZMApplication,
-        pushTokenService: PushTokenServiceInterface
+        pushTokenService: PushTokenServiceInterface,
+        backgroundActivityFactory: BackgroundActivityFactory = .shared
     ) {
         Self.logger.debug("init VoIPPushManager")
         self.pushTokenService = pushTokenService
+        self.backgroundActivityFactory = backgroundActivityFactory
 
         self.registry = PKPushRegistry(queue: Self.pushRegistryQueue)
         self.callKitManager = CallKitManager(
@@ -124,6 +127,8 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
             completion()
             return
         }
+
+        backgroundActivityFactory.resume()
 
         let handle = CallHandle(
             accountID: accountID,

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -158,26 +158,30 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         let name = name ?? "unnamed"
 
         guard let activity = backgroundActivityFactory.startBackgroundActivity(name: name) else {
-            WireLogger.backgroundActivity.debug("background task \(name) cannot begin (BackgroundActivityFactory)")
+            WireLogger.backgroundActivity.debug("background task \(name) cannot begin")
             throw CancellationError()
         }
 
         let task = Task {
-            WireLogger.backgroundActivity.debug("will start background task: \(name) (BackgroundActivityFactory)")
+            WireLogger.backgroundActivity.debug("will start background task: \(name)")
 
             do {
                 let result = try await operation()
-                WireLogger.backgroundActivity.debug("did end background task: \(name) (BackgroundActivityFactory)")
+                WireLogger.backgroundActivity.debug("did end background task: \(name)")
                 return result
             } catch {
-                WireLogger.backgroundActivity.warn("did fail background task: \(name) (BackgroundActivityFactory)")
+                if error is CancellationError {
+                    WireLogger.backgroundActivity.debug("did cancel background task: \(name)")
+                } else {
+                    WireLogger.backgroundActivity.warn("did fail background task: \(name)")
+                }
                 throw error
             }
         }
 
         activity.expirationHandler = {
             WireLogger.backgroundActivity.warn(
-                "background task \(name) expiring soon (BackgroundActivityFactory). Cancelling..."
+                "background task \(name) expiring soon. Cancelling..."
             )
             task.cancel()
         }

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -164,9 +164,15 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
         let task = Task {
             WireLogger.backgroundActivity.debug("will start background task: \(name) (BackgroundActivityFactory)")
-            let result = try await operation()
-            WireLogger.backgroundActivity.debug("did end background task: \(name) (BackgroundActivityFactory)")
-            return result
+
+            do {
+                let result = try await operation()
+                WireLogger.backgroundActivity.debug("did end background task: \(name) (BackgroundActivityFactory)")
+                return result
+            } catch {
+                WireLogger.backgroundActivity.warn("did fail background task: \(name) (BackgroundActivityFactory)")
+                throw error
+            }
         }
 
         activity.expirationHandler = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23511" title="WPB-23511" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23511</a>  [iOS] NSE is often getting stuck and expiring
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When using the `BackgroundActivityFactory`, if an activity expires, the `BackgroundActivityFactory` no longer accepts new activities until it is reset by calling `resume()`. This is already being done when the app in response to a `applicationWillEnterForeground` notification, but was missing in cases of receiving a call kit call leading to `VoIPPushManagerDelegate` methods failing. In this PR we add an additional reset of `BackgroundActivityFactory` when the app wakes due to push kit to handle a call notification. It is safe to call `BackgroundActivityFactory.resume()` multiple times as only the first call has an effect.

This PR also adds a missing log for cases where a background activity errors.

### Testing

Check that calls from the background are working correctly.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
