### PR TITLE
fix: update profile picture accessibility label - WPB-14703

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsAppearanceCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsAppearanceCellDescriptor.swift
@@ -25,6 +25,7 @@ class SettingsAppearanceCellDescriptor: SettingsGroupCellDescriptorType, Setting
     static let cellType: SettingsTableCellProtocol.Type = SettingsAppearanceCell.self
 
     private var text: String
+    private let accessibilityLabel: String?
     private let presentationStyle: PresentationStyle
 
     weak var viewController: UIViewController?
@@ -46,6 +47,7 @@ class SettingsAppearanceCellDescriptor: SettingsGroupCellDescriptorType, Setting
 
     init(
         text: String,
+        accessibilityLabel: String? = nil,
         identifier: String? = .none,
         previewGenerator: PreviewGeneratorType? = .none,
         presentationStyle: PresentationStyle,
@@ -53,6 +55,7 @@ class SettingsAppearanceCellDescriptor: SettingsGroupCellDescriptorType, Setting
         settingsCoordinator: AnySettingsCoordinator
     ) {
         self.text = text
+        self.accessibilityLabel = accessibilityLabel
         self.identifier = identifier
         self.previewGenerator = previewGenerator
         self.presentationStyle = presentationStyle
@@ -65,6 +68,7 @@ class SettingsAppearanceCellDescriptor: SettingsGroupCellDescriptorType, Setting
     func featureCell(_ cell: SettingsCellType) {
         if let tableCell = cell as? SettingsAppearanceCell {
             tableCell.configure(with: .appearance(title: text))
+            tableCell.accessibilityLabel = accessibilityLabel ?? text
             tableCell.accessibilityIdentifier = identifier
 
             if let previewGenerator {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -326,6 +326,7 @@ extension SettingsCellDescriptorFactory {
         }
         return SettingsAppearanceCellDescriptor(
             text: L10n.Localizable.Self.Settings.AccountPictureGroup.picture.capitalized,
+            accessibilityLabel: L10n.Localizable.Self.Settings.AccountPictureGroup.Alert.title,
             identifier: Locators.AccountSettingsPage.pictureCell.rawValue,
             previewGenerator: previewGenerator,
             presentationStyle: .alert,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsAppearanceCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsAppearanceCell.swift
@@ -81,7 +81,7 @@ final class SettingsAppearanceCell: SettingsTableCell, CellConfigurationConfigur
                 iconImageView.image = image
                 iconImageView.backgroundColor = UIColor.clear
                 subtitleLabel.text = nil
-                accessibilityValue = "image"
+                accessibilityValue = nil
                 titleLabelToIconInset.isActive = true
                 accessibilityTraits = [.button]
             case let .color(color):


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14703" title="WPB-14703" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14703</a>  [iOS] Control element has no accessible name #63
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Updates the profile picture row to use the localized “Change your profile picture” accessibility label. Removes the redundant “image” value from the VoiceOver announcement.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
