### PR TITLE
chore: prevent background tasks resuming when the app is foregrounded - WPB-23511

### DIFF
--- a/wire-ios-data-model/Source/Core Crypto/SafeCoreCrypto.swift
+++ b/wire-ios-data-model/Source/Core Crypto/SafeCoreCrypto.swift
@@ -41,15 +41,11 @@ public final class SafeCoreCrypto {
     public func transaction<Result>(
         block: @escaping (any CoreCryptoContextProtocol) async throws -> Result
     ) async throws -> Result {
-        if BackgroundTaskContext.isBackgroundTask {
+        try await withBackgroundTask(
+            name: "core crypto transaction",
+            executer: backgroundTaskExecuter
+        ) { [coreCrypto] in
             try await coreCrypto.transaction(block)
-        } else {
-            try await withBackgroundTask(
-                name: "core crypto transaction",
-                executer: backgroundTaskExecuter
-            ) { [coreCrypto] in
-                try await coreCrypto.transaction(block)
-            }
         }
     }
 

--- a/wire-ios-system/Source/BackgroundTasks.swift
+++ b/wire-ios-system/Source/BackgroundTasks.swift
@@ -32,8 +32,13 @@ public func withBackgroundTask<T: Sendable>(
     executer: any BackgroundTaskExecuter,
     operation: @escaping @isolated(any) () async throws -> T
 ) async throws -> T {
-    try await BackgroundTaskContext.$isBackgroundTask.withValue(true) {
-        try await executer.execute(name: name, operation: operation)
+    // If we are already in a background task, just execute the operation directly
+    if BackgroundTaskContext.isBackgroundTask {
+        try await operation()
+    } else {
+        try await BackgroundTaskContext.$isBackgroundTask.withValue(true) {
+            try await executer.execute(name: name, operation: operation)
+        }
     }
 }
 

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -47,7 +47,7 @@ public enum DeveloperFlag: String, CaseIterable {
     // TODO: [WPB-25941] Remove drive permissions flag when feature is complete
     case enableDrivePermissions
     case unSafeLogsForPublic
-    case useBackgroundTaskAPIInAppBackgroundTaskExecuter
+    case useBackgroundActivityFactoryInAppBackgroundTaskExecuter
 
     public var description: String {
         switch self {
@@ -123,8 +123,8 @@ public enum DeveloperFlag: String, CaseIterable {
         case .unSafeLogsForPublic:
             "Turn on to write all logs (including debug and non-public) to disk in release builds"
 
-        case .useBackgroundTaskAPIInAppBackgroundTaskExecuter:
-            "Turn on to use Apple's UIApplication task API directly in AppBackgroundTaskExecuter"
+        case .useBackgroundActivityFactoryInAppBackgroundTaskExecuter:
+            "Turn on to use BackgroundActivityFactory in AppBackgroundTaskExecuter"
         }
     }
 

--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -207,6 +207,15 @@ public class MockBackgroundTaskApplication: BackgroundTaskApplication, @unchecke
 
     public init() {}
 
+    // MARK: - backgroundTimeRemaining
+
+    public var backgroundTimeRemaining: TimeInterval {
+        get { return underlyingBackgroundTimeRemaining }
+        set(value) { underlyingBackgroundTimeRemaining = value }
+    }
+
+    public var underlyingBackgroundTimeRemaining: TimeInterval!
+
 
     // MARK: - beginBackgroundTask
 

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -39,7 +39,6 @@ struct AppBackgroundTaskExecuterTests {
         application.endBackgroundTask_MockMethod = { _ in }
 
         self.sut = AppBackgroundTaskExecuter(application: application, isInBackground: false)
-        DeveloperFlag.useBackgroundTaskAPIInAppBackgroundTaskExecuter.enable(true, storage: .temporary())
     }
 
     @Test

--- a/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppBackgroundTaskExecuterTests.swift
@@ -32,6 +32,7 @@ struct AppBackgroundTaskExecuterTests {
     @MainActor
     init() {
         self.application = MockBackgroundTaskApplication()
+        application.underlyingBackgroundTimeRemaining = 30
         application.beginBackgroundTaskWithNameExpirationHandler_MockMethod = { _, _ in
             UIBackgroundTaskIdentifier(rawValue: 99)
         }
@@ -110,6 +111,10 @@ struct AppBackgroundTaskExecuterTests {
     @Test
     func `firing the expiration handler cancels the operation`() async throws {
         // given
+        application.beginBackgroundTaskWithNameExpirationHandler_MockMethod = { _, _ in
+            UIBackgroundTaskIdentifier(rawValue: 42)
+        }
+
         let task = Task {
             try await sut.execute(name: "task") {
                 try await Task.sleep(for: .seconds(10))
@@ -123,12 +128,14 @@ struct AppBackgroundTaskExecuterTests {
         await #expect(throws: CancellationError.self) {
             _ = try await task.value
         }
+        #expect(application.endBackgroundTask_Invocations == [UIBackgroundTaskIdentifier(rawValue: 42)])
     }
 
     @Test
     @MainActor
-    func `throws CancellationError when the app is in the background`() async throws {
+    func `throws CancellationError when the app is in the background with insufficient time`() async throws {
         // given
+        application.underlyingBackgroundTimeRemaining = 3
         let sut = AppBackgroundTaskExecuter(application: application, isInBackground: true)
         let didRunOperation = OSAllocatedUnfairLock(initialState: false)
 
@@ -141,6 +148,21 @@ struct AppBackgroundTaskExecuterTests {
         }
         #expect(didRunOperation.withLock { $0 } == false)
         #expect(application.beginBackgroundTaskWithNameExpirationHandler_Invocations.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `executes the operation when the app is in the background with sufficient time`() async throws {
+        // given
+        application.underlyingBackgroundTimeRemaining = 10
+        let sut = AppBackgroundTaskExecuter(application: application, isInBackground: true)
+
+        // when
+        let result = try await sut.execute(name: "task") { "done" }
+
+        // then
+        #expect(result == "done")
+        #expect(!application.beginBackgroundTaskWithNameExpirationHandler_Invocations.isEmpty)
     }
 
     @Test

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -129,9 +129,19 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         // Don't start the task until we have a valid background task ID.
         let task = Task {
             WireLogger.backgroundActivity.debug("will start background task: \(name)")
-            let result = try await operation()
-            WireLogger.backgroundActivity.debug("did end background task: \(name)")
-            return result
+            do {
+                let result = try await operation()
+                WireLogger.backgroundActivity.debug("did end background task: \(name)")
+                return result
+            } catch {
+                if error is CancellationError {
+                    WireLogger.backgroundActivity.debug("did cancel background task: \(name)")
+                } else {
+                    let errorDescription = (error as NSError).safeForLoggingDescription
+                    WireLogger.backgroundActivity.warn("did fail background task: \(name), error: \(errorDescription)")
+                }
+                throw error
+            }
         }
         operationState.task = task
 

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -91,10 +91,10 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
         name: String?,
         operation: @escaping @isolated(any) () async throws -> T
     ) async throws -> T {
-        if DeveloperFlag.useBackgroundTaskAPIInAppBackgroundTaskExecuter.isOn {
-            try await executeUsingBackgroundTaskAPI(name: name, operation: operation)
-        } else {
+        if DeveloperFlag.useBackgroundActivityFactoryInAppBackgroundTaskExecuter.isOn {
             try await executeUsingBackgroundActivityFactory(name: name, operation: operation)
+        } else {
+            try await executeUsingBackgroundTaskAPI(name: name, operation: operation)
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -27,6 +27,8 @@ import WireSystem
 /// The subset of `UIApplication`'s background task APIs that `AppBackgroundTaskExecuter` depends on.
 public protocol BackgroundTaskApplication: AnyObject, Sendable {
 
+    nonisolated var backgroundTimeRemaining: TimeInterval { get }
+
     nonisolated func beginBackgroundTask(
         withName taskName: String?,
         expirationHandler handler: (@MainActor @Sendable () -> Void)?
@@ -104,8 +106,8 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
     ) async throws -> T {
         let name = name ?? "unnamed"
 
-        guard applicationState.isInBackground != true else {
-            WireLogger.backgroundActivity.debug("background task \(name) cannot begin in the background")
+        if applicationState.isInBackground && application.backgroundTimeRemaining < 5 {
+            WireLogger.backgroundActivity.debug("background task \(name) cannot begin. Not enough time")
             throw CancellationError()
         }
 

--- a/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppBackgroundTaskExecuter.swift
@@ -117,9 +117,6 @@ public struct AppBackgroundTaskExecuter: BackgroundTaskExecuter {
 
             WireLogger.backgroundActivity.warn("background task \(name) expiring soon. Cancelling...")
             operationState.task?.cancel()
-
-            // Eagerly end the background task to avoid the app being killed in case that cancellation takes too long.
-            endBackgroundTask(operationState)
         }
         defer { endBackgroundTask(operationState) }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23511" title="WPB-23511" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23511</a>  [iOS] NSE is often getting stuck and expiring
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

@johnxnguyen  and I looked further into issues causing the frozen NSE. Among the issues we found was that some background tasks that should have been cancelled may still be active when the process resumes.

Most recently the `AppBackgroundTaskExecuter` makes use of the `BackgroundActivityFactory` underneath. In the case of expiry this object calls [UIApplication.endbackgroundtask(_:)](https://developer.apple.com/documentation/uikit/uiapplication/endbackgroundtask(_:)) internally directly after telling all it's users to expire via *synchronous* expiry blocks.

As we are dealing with async operations this means that we are only calling `Task.cancel()` in the expiry blocks - **we are not awaiting the cancellation to complete before `UIApplication.endbackgroundtask(_:)` is called**. 

This PR close: https://wearezeta.atlassian.net/browse/WPB-27281

This is undesirable because:

1. Generally the task APIs call the expiry block around 5 seconds before we run out of time giving us around 5 seconds for clean-up. Because we call `UIApplication.endbackgroundtask(_:)` immediately we have almost no time to complete cleanup before the process sleeps leading to a higher chance of NSE being blocked.
2. These tasks are not done and will continue when the process awakes.

To address these issues this PR returns to using the  the begin task API directly within `AppBackgroundTaskExecuter` with some changes:

- We now await the task to complete or cancel before calling `UIApplication.endbackgroundtask(_:)`.
- Previously we were blocking any tasks from starting when the app was in the background which lead to issues as I code is not good at dealing with cancellation. Now instead we allow the task to begin if there is at least 5 seconds remaining. I would rather the background API just prevented us from creating the tasks if there is not much time left but this is not the case so using a 5 second magic number.

Additionally this PR:

- Improves logging to ensure we always see when the task completes / fails.
- Move the `BackgroundTaskContext.isBackgroundTask` logic into BackgroundTask code instead of SafeCoreCrypto. As a reminder this code prevents calling the begin/end background task API when already inside a background task as this adds unnecessary overhead.

### Testing

Checking logs for NSE expiries in beta.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---
