### PR TITLE
fix: fix three-dots button's tap area - WPB-25676

### DIFF
--- a/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/Meeting/MeetingRow.swift
+++ b/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/Meeting/MeetingRow.swift
@@ -48,7 +48,7 @@ struct MeetingRow: View {
                 )
 
             VStack(alignment: .leading, spacing: 2) {
-                HStack(alignment: .firstTextBaseline) {
+                HStack(alignment: .top) {
                     Text(meeting.title)
                         .font(for: .body2)
                         .foregroundStyle(ColorTheme.Backgrounds.onSurface.color)
@@ -72,11 +72,9 @@ struct MeetingRow: View {
                         Image(systemName: "ellipsis")
                             .rotationEffect(.degrees(90))
                             .foregroundStyle(ColorTheme.Buttons.Secondary.onEnabled.color)
-                            // Grow the hit target to ~44x44pt without affecting layout:
-                            // the padding is hittable via contentShape and compensated
-                            // by the negative padding on the Menu below.
+                            // The padding is part of the tap target via contentShape.
                             .padding(.horizontal, 12)
-                            .padding(.vertical, 20)
+                            .padding(.vertical, 8)
                             .contentShape(Rectangle())
                     }
                 }
@@ -87,7 +85,6 @@ struct MeetingRow: View {
 
                 if !meeting.members.isEmpty {
                     MemberAvatarsView(members: meeting.members)
-                        .padding(.top, 2)
                 }
             }
         }

--- a/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/Meeting/MeetingRow.swift
+++ b/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/Meeting/MeetingRow.swift
@@ -72,11 +72,15 @@ struct MeetingRow: View {
                         Image(systemName: "ellipsis")
                             .rotationEffect(.degrees(90))
                             .foregroundStyle(ColorTheme.Buttons.Secondary.onEnabled.color)
-                            // The padding is part of the tap target via contentShape.
+                            // The design's padding is 12/8; the extra 12pt of vertical
+                            // padding grows the tap target to ~44pt and is cancelled
+                            // out by the negative padding below, so the layout keeps
+                            // the design's spacing.
                             .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
+                            .padding(.vertical, 20)
                             .contentShape(Rectangle())
                     }
+                    .padding(.vertical, -12)
                 }
 
                 Text(formatTimeRange(meeting))

--- a/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/Meeting/MeetingRow.swift
+++ b/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/Meeting/MeetingRow.swift
@@ -29,20 +29,23 @@ struct MeetingRow: View {
     let onEdit: () -> Void
     let onDelete: () -> Void
 
+    @ScaledMetric private var iconBoxSize: CGFloat = 31
+    @ScaledMetric private var iconFontSize: CGFloat = 15
+
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .fill(ColorTheme.Backgrounds.surface.color)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .strokeBorder(ColorTheme.Strokes.outline.color, lineWidth: 1)
-                    )
-                    .frame(width: 31, height: 31)
-
-                Image(systemName: "calendar")
-                    .font(.system(size: 15))
-            }
+            Image(systemName: "calendar")
+                .font(.system(size: iconFontSize, weight: .semibold))
+                .foregroundStyle(ColorTheme.Backgrounds.onSurface.color)
+                .frame(width: iconBoxSize, height: iconBoxSize)
+                .background(
+                    ColorTheme.Backgrounds.surface.color,
+                    in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(ColorTheme.Strokes.outline.color, lineWidth: 1)
+                )
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(alignment: .firstTextBaseline) {

--- a/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/Meeting/MeetingRow.swift
+++ b/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/Meeting/MeetingRow.swift
@@ -28,6 +28,7 @@ struct MeetingRow: View {
     let formatTimeRange: (Meeting) -> String
     let onEdit: () -> Void
     let onDelete: () -> Void
+
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
             ZStack {
@@ -68,6 +69,11 @@ struct MeetingRow: View {
                         Image(systemName: "ellipsis")
                             .rotationEffect(.degrees(90))
                             .foregroundStyle(ColorTheme.Buttons.Secondary.onEnabled.color)
+                            // Grow the hit target to ~44x44pt without affecting layout:
+                            // the padding is hittable via contentShape and compensated
+                            // by the negative padding on the Menu below.
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 20)
                             .contentShape(Rectangle())
                     }
                 }

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/PreferredAPIVersion/PreferredAPIVersionView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/PreferredAPIVersion/PreferredAPIVersionView.swift
@@ -28,7 +28,7 @@ struct PreferredAPIVersionView: View {
 
     var body: some View {
         List(viewModel.sections, rowContent: sectionView(for:))
-            .navigationTitle("Preferred API version")
+            .navigationTitle(Text(verbatim: "Preferred API version"))
             .navigationBarTitleDisplayMode(.inline)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25676" title="WPB-25676" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25676</a>  [iOS] Create / edit meetings - API
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The trailing menu button of a meeting row could hardly be tapped. This PR fixes the layout.

### Testing

Enabled the WireMeetings feature flag, create a meeting and test tapping the menu button for editing and deleting a meeting.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
