### PR TITLE
fix: persist sent link preview state - WPB-26664

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategy.swift
@@ -86,6 +86,7 @@ extension LinkPreviewUpdateRequestStrategy: ModifiedKeyObjectSyncTranscoder {
             await managedObjectContext.perform {
                 object.markAsSent()
                 completion()
+                self.managedObjectContext.enqueueDelayedSave()
             }
             managedObjectContext.leaveAllGroups(groups)
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
@@ -182,6 +182,7 @@ class LinkPreviewUpdateRequestStrategyTests: MessagingTestBase {
         syncMOC.performGroupedAndWait {
             XCTAssertEqual(message.linkPreviewState, .done)
             XCTAssertNil(message.expirationDate)
+            XCTAssertFalse(syncMOC.hasChanges)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26664" title="WPB-26664" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26664</a>  [iOS] [Share] "Connection timeout" when sharing from unmanaged app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Sharing a webpage through the Wire share extension with link previews enabled sends the message to the backend but leaves its link-preview state pending.

`LinkPreviewUpdateRequestStrategy` marks the message as sent in memory, but the managed object context is not saved afterward. The persisted message can therefore remain in the `.uploaded` link-preview state even though delivery succeeded.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [X] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
