### PR TITLE
chore: update some GitHub actions to latest version - WPB-27340

### DIFF
--- a/.github/actions/allure-reporting/action.yaml
+++ b/.github/actions/allure-reporting/action.yaml
@@ -25,7 +25,7 @@ runs:
         
     - name: Upload Allure Report Artifact
       if: ${{ env.ALLURE_REPORT_AVAILABLE == 'true' }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.allure_artifact_name }}
         path: allure-reports/

--- a/.github/actions/allure-reporting/action.yaml
+++ b/.github/actions/allure-reporting/action.yaml
@@ -13,9 +13,10 @@ runs:
   steps:
     - name: Setup Node.js
       if: always()
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 20
+        package-manager-cache: false
 
     - name: Generate Allure Report
       if: always()

--- a/.github/actions/cache-swift-packages/action.yaml
+++ b/.github/actions/cache-swift-packages/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Restore Swift Package Dependencies Cache
       id: cache-swift-packages
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.PACKAGES_DIR }}
         key: ${{ runner.os }}-swiftpm-project-${{ hashFiles('**/*.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
@@ -32,7 +32,7 @@ runs:
         steps.cache-swift-packages.outputs.cache-hit != 'true' &&
         startsWith(github.ref, 'refs/heads/') &&
         !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.PACKAGES_DIR }}
         key: ${{ runner.os }}-swiftpm-project-${{ hashFiles('**/*.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}

--- a/.github/actions/kalium-testservice/setup/action.yaml
+++ b/.github/actions/kalium-testservice/setup/action.yaml
@@ -40,7 +40,7 @@ runs:
 
     - name: Restore Kalium fat jar cache
       id: jar-cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ runner.temp }}/kalium/tools/testservice/build/libs/
         key: kalium-jar-${{ runner.os }}-${{ runner.arch }}-${{ steps.kalium-ref.outputs.ref }}
@@ -49,7 +49,7 @@ runs:
 
     - name: Cache Gradle dependencies
       if: ${{ steps.jar-cache.outputs.cache-hit != 'true' }}
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.gradle/caches
@@ -108,7 +108,7 @@ runs:
 
     - name: Save Kalium fat jar cache
       if: ${{ steps.jar-cache.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ runner.temp }}/kalium/tools/testservice/build/libs/
         key: kalium-jar-${{ runner.os }}-${{ runner.arch }}-${{ steps.kalium-ref.outputs.ref }}

--- a/.github/actions/notify-wire/action.yaml
+++ b/.github/actions/notify-wire/action.yaml
@@ -37,7 +37,7 @@ runs:
     - name: Notify (custom message)
       if: ${{ inputs.notify == 'custom' }}
       continue-on-error: true
-      uses: 8398a7/action-slack@v3
+      uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
       with:
         status: custom
         custom_payload: |

--- a/.github/actions/setup-test-environment/action.yaml
+++ b/.github/actions/setup-test-environment/action.yaml
@@ -44,7 +44,7 @@ runs:
         path: fastlane/
 
     - name: Restore Carthage Cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: cache-carthage
       with:
         path: Carthage

--- a/.github/actions/upload-datadog-junit/action.yaml
+++ b/.github/actions/upload-datadog-junit/action.yaml
@@ -18,7 +18,7 @@ runs:
         node-version: 18
 
     - name: Cache datadog-ci
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.npm
         key: npm-datadog-ci-${{ runner.os }}-node18

--- a/.github/actions/upload-datadog-junit/action.yaml
+++ b/.github/actions/upload-datadog-junit/action.yaml
@@ -13,9 +13,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 18
+        package-manager-cache: false
 
     - name: Cache datadog-ci
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -152,7 +152,7 @@ jobs:
         with:
           xcode-version: ${{ steps.xcode-version.outputs.XCODE_VERSION }}
       - name: Restore Carthage Cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cache-carthage
         with:
           path: Carthage

--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -189,7 +189,7 @@ jobs:
         continue-on-error: true
         run: ./scripts/check_duplicate_classes.sh .
       - name: Archiving Logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: build-logs (${{ github.run_id }} - ${{ github.run_attempt}})
@@ -200,7 +200,7 @@ jobs:
 
       - name: Archiving env variables
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: post-build-env-${{ inputs.fastlane_action }} (${{ github.run_id }} - ${{ github.run_attempt}})
           path: |

--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
             echo "::add-mask::${{ secrets.CLIENT_NAME_C1_C2_C3 }}"
             echo "::add-mask::${{ secrets.CLIENT_ID_C1_C2_C3 }}"
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: 'false'
           token: ${{ secrets.SUBMODULE_PAT }}

--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -141,7 +141,7 @@ jobs:
           submodules: recursive
       - name: Download changelog     
         id: download_changelog
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.changelog.outputs.changelog-name }}    
       - name: Retrieve Xcode version

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -71,7 +71,7 @@ jobs:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch }}
           lfs: 'true'
@@ -406,7 +406,7 @@ jobs:
           SANITIZED_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/_/g')
           echo "SANITIZED_BRANCH=$SANITIZED_BRANCH" >> $GITHUB_ENV
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch }}
           lfs: 'false'

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -107,7 +107,7 @@ jobs:
           path: fastlane/
 
       - name: Restore Carthage Cache
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cache-carthage
         with:
           path: Carthage

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Upload .xcresult files as artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: XCResults for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
           path: artifacts/**/*.xcresult
@@ -247,7 +247,7 @@ jobs:
           xcrun swift test --package-path ./scripts
 
       - name: Upload Failed snapshots
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: Failed Snapshots and log for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
@@ -256,7 +256,7 @@ jobs:
             xcodebuild*.log
 
       - name: Upload Test Reports as Artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: Test reports for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})
@@ -335,7 +335,7 @@ jobs:
 
 
       - name: Archiving DerivedData Logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: Derived Data Xcode for ${{env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: Download tests results
         id: download-test-results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           name: Test reports for ${{ env.SANITIZED_BRANCH }} (${{ github.run_id }} - ${{ github.run_attempt}})

--- a/.github/workflows/_reusable_run_tests_parallel.yml
+++ b/.github/workflows/_reusable_run_tests_parallel.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch }}
           lfs: 'false'
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch }}
           lfs: ${{ matrix.needs_lfs }}
@@ -202,7 +202,7 @@ jobs:
           echo "SANITIZED_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/_/g')" >> "$GITHUB_ENV"
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch }}
           lfs: 'false'

--- a/.github/workflows/_reusable_run_tests_parallel.yml
+++ b/.github/workflows/_reusable_run_tests_parallel.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Download test results
         id: download-test-results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           pattern: "test-reports-*-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"

--- a/.github/workflows/_reusable_run_tests_parallel.yml
+++ b/.github/workflows/_reusable_run_tests_parallel.yml
@@ -137,14 +137,14 @@ jobs:
 
       - name: Upload .xcresult as artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "xcresult-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: artifacts/**/*.xcresult
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "test-reports-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: |
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload failed snapshots
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "snapshots-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: |
@@ -172,7 +172,7 @@ jobs:
 
       - name: Archive DerivedData logs
         if: failure() || cancelled()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "deriveddata-batch-${{ matrix.batch_index }}-${{ env.SANITIZED_BRANCH }}-(${{ github.run_id }}-${{ github.run_attempt }})"
           path: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -36,7 +36,7 @@ jobs:
       changelog-name: ${{ steps.expose-url.outputs.changelog-name }}
     steps:
       - name: 'Checkout Git repository with history for all branches and tags'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: 'false'
           fetch-depth: 0

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: 'Upload changelog'
         id: upload-file
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: CHANGELOG-${{ github.run_number }}-${{ steps.date.outputs.date }}.md
           path: ./CHANGELOG.md

--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: 'true'
           token: ${{ secrets.SUBMODULE_PAT }}

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -68,7 +68,7 @@ jobs:
           echo "RELEASE_BRANCH=release/cycle-${VERSION}" >> "$GITHUB_ENV"
 
       - name: Checkout develop
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: develop
           token: ${{ secrets.SUBMODULE_PAT }}

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -19,7 +19,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.SUBMODULE_PAT }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Crowdin action
         uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2.16.2

--- a/.github/workflows/ios_release_status.yml
+++ b/.github/workflows/ios_release_status.yml
@@ -42,7 +42,7 @@ jobs:
       # Needed so the local ./.github/actions/notify-wire composite action is available.
       # Only .github is required, and no LFS objects.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
           lfs: 'false'

--- a/.github/workflows/pr-review-summary.yml
+++ b/.github/workflows/pr-review-summary.yml
@@ -19,7 +19,7 @@ jobs:
             # Needed so the local ./.github/actions/notify-wire composite action is available.
             # Only .github is required, and no LFS objects.
             -   name: Checkout
-                uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
                 with:
                     sparse-checkout: .github
                     lfs: 'false'

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -66,7 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-wire-ios-${{ steps.read_version.outputs.project_version }}
           path: bom.json

--- a/.github/workflows/semantic_commit_lint.yml
+++ b/.github/workflows/semantic_commit_lint.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Checkout
         if: always()
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 

--- a/.github/workflows/swiftformat.yml
+++ b/.github/workflows/swiftformat.yml
@@ -25,7 +25,7 @@ jobs:
             swift:
               - '**/*.swift'
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ steps.changes.outputs.swift == 'true' }}
 
       - name: Install SwiftFormat 0.58.3

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -27,7 +27,7 @@ jobs:
             swift:
               - '**/*.swift'
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ steps.changes.outputs.swift == 'true' }}
 
       - name: GitHub Action for SwiftLint

--- a/.github/workflows/test_pr_changes.yml
+++ b/.github/workflows/test_pr_changes.yml
@@ -23,7 +23,7 @@ jobs:
       folders: ${{ steps.filter.outputs.changes }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ github.event_name == 'merge_group' }} # on PR, paths-filter can access list of changed files from event payload
         with:
           lfs: 'false' # as long as we use lfs only for snapshotTesting it should not be useful here


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27340" title="WPB-27340" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27340</a>  [iOS] Fix GitHub Actions node20 deprecation warnings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR updates a number of github actions to there most recent versions to fix a GitHub actions warning about using node 20 which is no longer supported.

Unfortunately I couldn't fix `8398a7/action-slack` which is already on it's latest version and is now archived. I will create an independent ticket to migrate off `8398a7/action-slack`

### Testing

I ran test & playground workflows to confirm things were working.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
