### PR TITLE
fix: set accessibility label on delete permanently action - WPB-27267

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
@@ -18,8 +18,8 @@
 
 import Combine
 import Foundation
-import WireMessagingDomain
 import WireLocators
+import WireMessagingDomain
 
 private typealias Strings = L10n.Localizable.Conversation.WireCells
 private typealias Accessibility = L10n.Accessibility.Conversation.WireCells

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
@@ -19,6 +19,7 @@
 import Combine
 import Foundation
 import WireMessagingDomain
+import WireLocators
 
 private typealias Strings = L10n.Localizable.Conversation.WireCells
 private typealias Accessibility = L10n.Accessibility.Conversation.WireCells
@@ -57,6 +58,8 @@ final class FilesItemViewModel: ObservableObject {
                 Accessibility.Files.ViewerAccess.makeAvailableOffline
             case .shareLink:
                 Accessibility.Files.ViewerAccess.shareLink
+            case .deletePermanently:
+                Locators.WireDrive.RecycleBinPage.deletePermanently.rawValue
             default:
                 "\(self)"
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27267" title="WPB-27267" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27267</a>  [iOS] Manage Release 4.25
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fixes a failing Shared Drive UI test by adding a missing accessibility label for the "Delete permanently" file action.

- `FilesItemViewModel.ItemAction.accessibilityLabel` now returns `Locators.WireDrive.RecycleBinPage.deletePermanently.rawValue` for the `.deletePermanently` case, instead of falling through to the default raw enum description.

### Testing

- Run the Shared Drive recycle bin UI tests and confirm the "Delete permanently" action test no longer fails on the accessibility label lookup.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.