### PR TITLE
fix: show loader when processing video from the native gallery picker - WPB-27398

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -372,9 +372,7 @@ class CameraKeyboardViewController: UIViewController {
                         completeBlock(data, info?["PHImageFileUTIKey"] as? String)
                     } else {
                         options.isSynchronous = true
-                        DispatchQueue.main.async {
-                            self.activityIndicator.start()
-                        }
+                        self.showActivityIndicator(true)
 
                         self.imageManagerType.defaultInstance.requestImage(
                             for: asset,
@@ -382,9 +380,7 @@ class CameraKeyboardViewController: UIViewController {
                             contentMode: .aspectFit,
                             options: options,
                             resultHandler: { image, info in
-                                DispatchQueue.main.async {
-                                    self.activityIndicator.stop()
-                                }
+                                self.showActivityIndicator(false)
 
                                 if let image {
                                     let data = image.jpegData(compressionQuality: 0.9)
@@ -408,15 +404,11 @@ class CameraKeyboardViewController: UIViewController {
 
                 guard let data else {
                     options.isNetworkAccessAllowed = true
-                    DispatchQueue.main.async {
-                        self.activityIndicator.start()
-                    }
+                    self.showActivityIndicator(true)
 
                     self.imageManagerType.defaultInstance
                         .requestImageData(for: asset, options: options) { data, uti, _, _ in
-                            DispatchQueue.main.async {
-                                self.activityIndicator.stop()
-                            }
+                            self.showActivityIndicator(false)
                             guard let data else {
                                 WireLogger.ui.error("Failure: cannot fetch image")
                                 return
@@ -434,28 +426,22 @@ class CameraKeyboardViewController: UIViewController {
     }
 
     private func forwardSelectedVideoAsset(_ asset: PHAsset) {
-        activityIndicator.start()
+        showActivityIndicator(true)
         let fileLengthLimit: UInt64 = userSession.maxUploadFileSize
         let localIdentifier = asset.localIdentifier
 
         asset.getVideoURL { url in
-            DispatchQueue.main.async {
-                self.activityIndicator.stop()
-            }
+            self.showActivityIndicator(false)
 
             guard let url else { return }
 
-            DispatchQueue.main.async {
-                self.activityIndicator.start()
-            }
+            self.showActivityIndicator(true)
 
             AVURLAsset.convertVideoToUploadFormat(
                 at: url,
                 fileLengthLimit: Int64(fileLengthLimit)
             ) { resultURL, asset, error in
-                DispatchQueue.main.async {
-                    self.activityIndicator.stop()
-                }
+                self.showActivityIndicator(false)
 
                 guard error == nil,
                       let resultURL,
@@ -472,6 +458,12 @@ class CameraKeyboardViewController: UIViewController {
             }
         }
 
+    }
+
+    func showActivityIndicator(_ show: Bool) {
+        DispatchQueue.main.async {
+            show ? self.activityIndicator.start() : self.activityIndicator.stop()
+        }
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePickerDriveConversation.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePickerDriveConversation.swift
@@ -73,11 +73,13 @@ extension ConversationInputBarViewController: PHPickerViewControllerDelegate {
     }
 
     private func processWireDriveVideo(provider: NSItemProvider, localIdentifier: String?) {
+        cameraKeyboardViewController?.showActivityIndicator(true)
         let filename = String.filename(for: userSession.selfUser)
         let fileLengthLimit = Int64(userSession.maxUploadFileSize)
 
         provider.loadFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { url, error in
             guard let url, error == nil else {
+                self.cameraKeyboardViewController?.showActivityIndicator(false)
                 return WireLogger.wireDrive.error("Could not load video: \(String(describing: error))")
             }
 
@@ -88,10 +90,12 @@ extension ConversationInputBarViewController: PHPickerViewControllerDelegate {
             do {
                 try FileManager.default.removeTmpIfNeededAndCopy(fileURL: url, tmpURL: videoTempURL)
             } catch {
+                self.cameraKeyboardViewController?.showActivityIndicator(false)
                 return WireLogger.wireDrive.error("Cannot copy video from \(url) to \(videoTempURL): \(error)")
             }
 
             AVURLAsset.convertVideoToUploadFormat(at: videoTempURL, fileLengthLimit: fileLengthLimit) { url, _, error in
+                self.cameraKeyboardViewController?.showActivityIndicator(false)
                 guard error == nil, let url else { return }
                 self.uploadVideoFile(.init(url: url, localIdentifier: localIdentifier))
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27398" title="WPB-27398" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27398</a>  [iOS] Show loader when video is being processed from native gallery picker
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fixes a missing loading indicator when a video selected from the native gallery picker is being processed for a Shared Drive conversation.

- Extracted a `showActivityIndicator(_:)` helper on `CameraKeyboardViewController` that wraps the existing `activityIndicator.start()`/`stop()` calls in `DispatchQueue.main.async`, replacing the repeated inline dispatch blocks.
- `ConversationInputBarViewController+ImagePickerDriveConversation` now calls `cameraKeyboardViewController?.showActivityIndicator(true)` when a video is picked via the native `PHPickerViewController` for a Wire Drive conversation, and stops it once the video finishes loading, copying, or converting (including on early-return error paths).

### Testing

- Pick a video from the native gallery picker in a Shared Drive conversation and confirm a loading indicator appears while the video is processed and disappears once the upload starts.
- Trigger the error paths (failed load, failed copy, failed conversion) and confirm the loading indicator is dismissed in each case.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.