### PR TITLE
fix: update accessibility labels - WPB-27223

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemView.swift
@@ -383,7 +383,7 @@ struct FilesItemView: View {
     ) -> some View {
         if viewModel.menuActions.contains(itemAction) {
             menuItem(itemAction)
-                .accessibilityLabel(itemAction.accessibilityLabel)
+                .accessibilityLabel(viewModel.accessibilitylabel(for: itemAction))
                 .accessibilityIdentifier("fileMenu.\(itemAction)")
         }
     }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
@@ -196,7 +196,7 @@ final class FilesItemViewModel: ObservableObject {
         case .deletePermanently:
             Locators.WireDrive.RecycleBinPage.deletePermanently.rawValue
         default:
-            "\(self)"
+            "\(action)"
         }
     }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
@@ -51,19 +51,6 @@ final class FilesItemViewModel: ObservableObject {
         case deletePermanently
         case makeAvailableOffline
         case removeAvailableOffline
-
-        var accessibilityLabel: String {
-            switch self {
-            case .makeAvailableOffline:
-                Accessibility.Files.ViewerAccess.makeAvailableOffline
-            case .shareLink:
-                Accessibility.Files.ViewerAccess.shareLink
-            case .deletePermanently:
-                Locators.WireDrive.RecycleBinPage.deletePermanently.rawValue
-            default:
-                "\(self)"
-            }
-        }
     }
 
     let onItemAction: (ItemAction, FilesViewItem) async -> Void
@@ -197,6 +184,19 @@ final class FilesItemViewModel: ObservableObject {
             isDrivePermissionsFlagEnabled && item.isReadOnly && isBrowsing
         default:
             false
+        }
+    }
+
+    func accessibilitylabel(for action: ItemAction) -> String {
+        switch action {
+        case .makeAvailableOffline where showReadOnlyIcon:
+            Accessibility.Files.ViewerAccess.makeAvailableOffline
+        case .shareLink where showReadOnlyIcon:
+            Accessibility.Files.ViewerAccess.shareLink
+        case .deletePermanently:
+            Locators.WireDrive.RecycleBinPage.deletePermanently.rawValue
+        default:
+            "\(self)"
         }
     }
 

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -339,8 +339,12 @@ internal enum L10n {
         internal static let description = L10n.tr("Accessibility", "conversation.bulletListButton.description", fallback: "Use bullet list")
       }
       internal enum CameraButton {
+        /// Take or select a photo
+        internal static let description = L10n.tr("Accessibility", "conversation.cameraButton.description", fallback: "Take or select a photo")
+      }
+      internal enum CameraButtonDisabled {
         /// Take or select a photo, disabled in viewer access
-        internal static let description = L10n.tr("Accessibility", "conversation.cameraButton.description", fallback: "Take or select a photo, disabled in viewer access")
+        internal static let description = L10n.tr("Accessibility", "conversation.cameraButtonDisabled.description", fallback: "Take or select a photo, disabled in viewer access")
       }
       internal enum CodeButton {
         /// Use code format
@@ -429,8 +433,12 @@ internal enum L10n {
         internal static let description = L10n.tr("Accessibility", "conversation.sendButton.description", fallback: "Send this message")
       }
       internal enum SketchButton {
+        /// Open sketch to draw or write
+        internal static let description = L10n.tr("Accessibility", "conversation.sketchButton.description", fallback: "Open sketch to draw or write")
+      }
+      internal enum SketchButtonDisabled {
         /// Open sketch to draw or write, disabled in viewer access
-        internal static let description = L10n.tr("Accessibility", "conversation.sketchButton.description", fallback: "Open sketch to draw or write, disabled in viewer access")
+        internal static let description = L10n.tr("Accessibility", "conversation.sketchButtonDisabled.description", fallback: "Open sketch to draw or write, disabled in viewer access")
       }
       internal enum TimerButton {
         /// Set a timer for self-deleting messages
@@ -481,16 +489,24 @@ internal enum L10n {
         internal static let hint = L10n.tr("Accessibility", "conversation.titleViewForOneToOne.hint", fallback: "Double tap to open profile")
       }
       internal enum UploadFileButton {
+        /// Share a file
+        internal static let description = L10n.tr("Accessibility", "conversation.uploadFileButton.description", fallback: "Share a file")
+      }
+      internal enum UploadFileButtonDisabled {
         /// Share a file, disabled in viewer access
-        internal static let description = L10n.tr("Accessibility", "conversation.uploadFileButton.description", fallback: "Share a file, disabled in viewer access")
+        internal static let description = L10n.tr("Accessibility", "conversation.uploadFileButtonDisabled.description", fallback: "Share a file, disabled in viewer access")
       }
       internal enum VerifiedIcon {
         /// Verified
         internal static let description = L10n.tr("Accessibility", "conversation.verifiedIcon.description", fallback: "Verified")
       }
       internal enum VideoButton {
+        /// Record a video
+        internal static let description = L10n.tr("Accessibility", "conversation.videoButton.description", fallback: "Record a video")
+      }
+      internal enum VideoButtonDisabled {
         /// Record a video, disabled in viewer access
-        internal static let description = L10n.tr("Accessibility", "conversation.videoButton.description", fallback: "Record a video, disabled in viewer access")
+        internal static let description = L10n.tr("Accessibility", "conversation.videoButtonDisabled.description", fallback: "Record a video, disabled in viewer access")
       }
     }
     internal enum ConversationAnnouncement {

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Accessibility.strings
@@ -38,14 +38,14 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
-"conversation.uploadFileButton.description" = "Share a file, disabled in viewer access";
+"conversation.uploadFileButton.description" = "Share a file";
 "conversation.locationButton.description" = "Share your location";
-"conversation.videoButton.description" = "Record a video, disabled in viewer access";
+"conversation.videoButton.description" = "Record a video";
 "conversation.moreButton.description" = "Open more messaging options";
 "conversation.emphemeralButton.description" = "Set a timer for self-deleting messages";
 "conversation.timerForSelfDeletingMessagesSeconds.value" = "%@ seconds";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/ar.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ar.lproj/Accessibility.strings
@@ -38,12 +38,12 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
-"conversation.uploadFileButton.description" = "Share a file, disabled in viewer access";
+"conversation.uploadFileButton.description" = "Share a file";
 "conversation.locationButton.description" = "Share your location";
 "conversation.videoButton.description" = "تسجيل الفيديو";
 "conversation.moreButton.description" = "Open more messaging options";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/da.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/da.lproj/Accessibility.strings
@@ -38,12 +38,12 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
-"conversation.uploadFileButton.description" = "Share a file, disabled in viewer access";
+"conversation.uploadFileButton.description" = "Share a file";
 "conversation.locationButton.description" = "Share your location";
 "conversation.videoButton.description" = "Optag en video";
 "conversation.moreButton.description" = "Open more messaging options";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Accessibility.strings
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ Tag";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ Woche";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ Wochen";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Überschrift benutzen";
 "conversation.boldButton.description" = "Fettdruck benutzen";

--- a/wire-ios/Wire-iOS/Resources/Localization/es.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/es.lproj/Accessibility.strings
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ día";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ semana";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ semanas";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Usar un encabezado";
 "conversation.boldButton.description" = "Usar texto en negrita";

--- a/wire-ios/Wire-iOS/Resources/Localization/et.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/et.lproj/Accessibility.strings
@@ -38,12 +38,12 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
-"conversation.uploadFileButton.description" = "Share a file, disabled in viewer access";
+"conversation.uploadFileButton.description" = "Share a file";
 "conversation.locationButton.description" = "Share your location";
 "conversation.videoButton.description" = "Salvesta video";
 "conversation.moreButton.description" = "Open more messaging options";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/fi.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/fi.lproj/Accessibility.strings
@@ -38,12 +38,12 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
-"conversation.uploadFileButton.description" = "Share a file, disabled in viewer access";
+"conversation.uploadFileButton.description" = "Share a file";
 "conversation.locationButton.description" = "Share your location";
 "conversation.videoButton.description" = "Kuvaa video";
 "conversation.moreButton.description" = "Open more messaging options";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Accessibility.strings
@@ -39,11 +39,11 @@
 "conversation.timerButton.description" = "Définir une minuterie pour les messages auto-supprimés";
 "conversation.mentionButton.description" = "Mentionner quelqu'un";
 "conversation.cameraButton.description" = "Prendre ou choisir une photo";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
-"conversation.uploadFileButton.description" = "Share a file, disabled in viewer access";
+"conversation.uploadFileButton.description" = "Share a file";
 "conversation.locationButton.description" = "Share your location";
 "conversation.videoButton.description" = "Enregistrer une vidéo";
 "conversation.moreButton.description" = "Open more messaging options";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/it.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/it.lproj/Accessibility.strings
@@ -38,8 +38,8 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Scegli una GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/ja.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ja.lproj/Accessibility.strings
@@ -38,8 +38,8 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "自動削除メッセージのタイマーを設定します";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "pingを送信";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/lt.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/lt.lproj/Accessibility.strings
@@ -38,12 +38,12 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
-"conversation.uploadFileButton.description" = "Share a file, disabled in viewer access";
+"conversation.uploadFileButton.description" = "Share a file";
 "conversation.locationButton.description" = "Share your location";
 "conversation.videoButton.description" = "Įrašyti vaizdą";
 "conversation.moreButton.description" = "Open more messaging options";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/nl.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/nl.lproj/Accessibility.strings
@@ -38,12 +38,12 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
-"conversation.uploadFileButton.description" = "Share a file, disabled in viewer access";
+"conversation.uploadFileButton.description" = "Share a file";
 "conversation.locationButton.description" = "Share your location";
 "conversation.videoButton.description" = "Neem een video op";
 "conversation.moreButton.description" = "Open more messaging options";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/pl.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/pl.lproj/Accessibility.strings
@@ -38,12 +38,12 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
-"conversation.uploadFileButton.description" = "Share a file, disabled in viewer access";
+"conversation.uploadFileButton.description" = "Share a file";
 "conversation.locationButton.description" = "Share your location";
 "conversation.videoButton.description" = "Nagraj film";
 "conversation.moreButton.description" = "Open more messaging options";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/pt-BR.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/pt-BR.lproj/Accessibility.strings
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ dia";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ semana";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ semanas";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Usar um título";
 "conversation.boldButton.description" = "Usar texto em negrito";

--- a/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Accessibility.strings
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ дн.";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ нед.";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ нед.";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Использовать заголовок";
 "conversation.boldButton.description" = "Использовать полужирный текст";

--- a/wire-ios/Wire-iOS/Resources/Localization/sl.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/sl.lproj/Accessibility.strings
@@ -38,12 +38,12 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
-"conversation.uploadFileButton.description" = "Share a file, disabled in viewer access";
+"conversation.uploadFileButton.description" = "Share a file";
 "conversation.locationButton.description" = "Share your location";
 "conversation.videoButton.description" = "Snemaj video";
 "conversation.moreButton.description" = "Open more messaging options";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Resources/Localization/tr.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/tr.lproj/Accessibility.strings
@@ -39,7 +39,7 @@
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Birinden bahset";
 "conversation.cameraButton.description" = "Fotoğraf çekin veya seçin";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "GIF seç";
 "conversation.audioButton.description" = "Sesli mesaj kaydet";
 "conversation.pingButton.description" = "Ping gönder";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ gün";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ hafta";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ hafta";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Başlık kullan";
 "conversation.boldButton.description" = "Kalın yazı kullan";

--- a/wire-ios/Wire-iOS/Resources/Localization/uk.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/uk.lproj/Accessibility.strings
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ день";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ тиждень";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ тижнів";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Застосувати заголовок";
 "conversation.boldButton.description" = "Застосувати жирний текст";

--- a/wire-ios/Wire-iOS/Resources/Localization/zh-Hans.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/zh-Hans.lproj/Accessibility.strings
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ 天";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ 周";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ 周";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "使用标题";
 "conversation.boldButton.description" = "使用粗体文本";

--- a/wire-ios/Wire-iOS/Resources/Localization/zh-Hant.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/zh-Hant.lproj/Accessibility.strings
@@ -38,12 +38,12 @@
 "conversation.hideFormattingButton.description" = "Hide formatting options";
 "conversation.timerButton.description" = "Set a timer for self-deleting messages";
 "conversation.mentionButton.description" = "Mention someone";
-"conversation.cameraButton.description" = "Take or select a photo, disabled in viewer access";
-"conversation.sketchButton.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.cameraButton.description" = "Take or select a photo";
+"conversation.sketchButton.description" = "Open sketch to draw or write";
 "conversation.gifButton.description" = "Select a GIF";
 "conversation.audioButton.description" = "Record an audio message";
 "conversation.pingButton.description" = "Send a ping";
-"conversation.uploadFileButton.description" = "Share a file, disabled in viewer access";
+"conversation.uploadFileButton.description" = "Share a file";
 "conversation.locationButton.description" = "Share your location";
 "conversation.videoButton.description" = "錄製影片";
 "conversation.moreButton.description" = "Open more messaging options";
@@ -54,6 +54,10 @@
 "conversation.timerForSelfDeletingMessagesDay.value" = "%@ day";
 "conversation.timerForSelfDeletingMessagesWeek.value" = "%@ week";
 "conversation.timerForSelfDeletingMessagesWeeks.value" = "%@ weeks";
+"conversation.cameraButtonDisabled.description" = "Take or select a photo, disabled in viewer access";
+"conversation.sketchButtonDisabled.description" = "Open sketch to draw or write, disabled in viewer access";
+"conversation.uploadFileButtonDisabled.description" = "Share a file, disabled in viewer access";
+"conversation.videoButtonDisabled.description" = "Record a video, disabled in viewer access";
 
 "conversation.headerButton.description" = "Use a heading";
 "conversation.boldButton.description" = "Use bolded text";

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -173,11 +173,14 @@ final class ConversationInputBarViewController: UIViewController,
 
     let videoButton: IconButton = .init()
 
+    private var showDriveViewerBanner: Bool {
+        conversation.isWireDriveEnabled && userSession.selfUser
+            .isGuest(in: conversation) && DeveloperFlag.enableDrivePermissions.isOn
+    }
+
     // MARK: subviews
 
     lazy var inputBar: InputBar = {
-        let showDriveViewerBanner = conversation.isWireDriveEnabled && userSession.selfUser
-            .isGuest(in: conversation) && DeveloperFlag.enableDrivePermissions.isOn
         let inputBar = InputBar(
             buttons: inputBarButtons,
             isWireDriveEnabled: conversation.isWireDriveEnabled,
@@ -1243,15 +1246,19 @@ extension ConversationInputBarViewController: UIGestureRecognizerDelegate {
     private func setupAccessibility() {
         typealias Conversation = L10n.Accessibility.Conversation
 
-        photoButton.accessibilityLabel = Conversation.CameraButton.description
+        photoButton.accessibilityLabel = showDriveViewerBanner ? Conversation.CameraButtonDisabled
+            .description : Conversation.CameraButton.description
         mentionButton.accessibilityLabel = Conversation.MentionButton.description
-        sketchButton.accessibilityLabel = Conversation.SketchButton.description
+        sketchButton.accessibilityLabel = showDriveViewerBanner ? Conversation.SketchButtonDisabled
+            .description : Conversation.SketchButton.description
         gifButton.accessibilityLabel = Conversation.GifButton.description
         audioButton.accessibilityLabel = Conversation.AudioButton.description
         pingButton.accessibilityLabel = Conversation.PingButton.description
-        uploadFileButton.accessibilityLabel = Conversation.UploadFileButton.description
+        uploadFileButton.accessibilityLabel = showDriveViewerBanner ? Conversation.UploadFileButtonDisabled
+            .description : Conversation.UploadFileButton.description
         locationButton.accessibilityLabel = Conversation.LocationButton.description
-        videoButton.accessibilityLabel = Conversation.VideoButton.description
+        videoButton.accessibilityLabel = showDriveViewerBanner ? Conversation.VideoButtonDisabled
+            .description : Conversation.VideoButton.description
         hourglassButton.accessibilityLabel = Conversation.TimerButton.description
         sendButton.accessibilityLabel = Conversation.SendButton.description
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27223" title="WPB-27223" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27223</a>  [iOS] Update accessibility strings for action not available
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This is a follow-up from #5031 where accessibility strings were not correctly set depending on the access mode (viewer/editor).
This PR corrects that by reintroducing the original accessibility strings and using the new **"..disabled in viewer access"** ones solely in viewer mode.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
