### PR TITLE
chore: test device limit reached and delete one to enter - WPB-24967

### DIFF
--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -399,6 +399,7 @@ public enum Locators {
         case manageDevices
         case removeDevice = "minus.circle.fill"
         case deleteDevice = "Delete"
+        case ok = "OK"
     }
 
     public enum TeamSetupStepsPage: AutoPrefixedEnum {

--- a/wire-ios/WireUITests/AccountManagementTests.swift
+++ b/wire-ios/WireUITests/AccountManagementTests.swift
@@ -130,4 +130,36 @@ final class AccountManagementTests: WireUITestCase {
             .deleteDevice(password: user.password)
             .verifyDeviceIsDeleted(named: deviceName)
     }
+
+    @MainActor
+    func testDeleteDeviceWhenClientLimitReached_TC_8973() async throws {
+        // GIVEN
+        let user = try await UserHelper.default.createPersonalUser()
+        let deviceNames = (1 ... 7).map { "device-limit-\($0)" }
+
+        for deviceName in deviceNames {
+            _ = try await testServicesClient.createInstance(
+                email: user.email,
+                password: user.password,
+                name: user.name,
+                verificationCode: nil,
+                deviceName: deviceName
+            )
+        }
+
+        // WHEN
+        _ = try WelcomePage()
+            .enterEmailOrSSO(user.email)
+            .enterPassword(user.password)
+            .acceptFirstTimeAlert()
+
+        let conversationsPage = try ManagedDevicesPage()
+            .removeFirstDeviceAndContinue(password: user.password)
+
+        // THEN
+        XCTAssertTrue(
+            conversationsPage.conversationsButton.exists,
+            "Conversations tab did not appear after removing a device"
+        )
+    }
 }

--- a/wire-ios/WireUITests/AccountManagementTests.swift
+++ b/wire-ios/WireUITests/AccountManagementTests.swift
@@ -141,7 +141,7 @@ final class AccountManagementTests: WireUITestCase {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for deviceName in deviceNames {
                 group.addTask {
-                    _ = try await self.testServicesClient.createInstance(
+                    _ = try await self.testServicesClient.getInstanceId(
                         email: user.email,
                         password: user.password,
                         name: user.name,

--- a/wire-ios/WireUITests/AccountManagementTests.swift
+++ b/wire-ios/WireUITests/AccountManagementTests.swift
@@ -138,19 +138,15 @@ final class AccountManagementTests: WireUITestCase {
         // 7 instances to register 7 clients
         let deviceNames = (1 ... 7).map { "device-\($0)" }
 
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            for deviceName in deviceNames {
-                group.addTask {
-                    _ = try await self.testServicesClient.getInstanceId(
-                        email: user.email,
-                        password: user.password,
-                        name: user.name,
-                        verificationCode: nil,
-                        deviceName: deviceName
-                    )
-                }
-            }
-            try await group.waitForAll()
+        for deviceName in deviceNames {
+            _ = try await testServicesClient.getInstanceId(
+                email: user.email,
+                password: user.password,
+                name: user.name,
+                verificationCode: nil,
+                deviceName: deviceName,
+                useCache: false
+            )
         }
 
         // WHEN

--- a/wire-ios/WireUITests/AccountManagementTests.swift
+++ b/wire-ios/WireUITests/AccountManagementTests.swift
@@ -135,31 +135,29 @@ final class AccountManagementTests: WireUITestCase {
     func testDeleteDeviceWhenClientLimitReached_TC_8973() async throws {
         // GIVEN
         let user = try await UserHelper.default.createPersonalUser()
-        let deviceNames = (1 ... 7).map { "device-limit-\($0)" }
+        // 7 instances to register 7 clients
+        let deviceNames = (1 ... 7).map { "device-\($0)" }
 
-        for deviceName in deviceNames {
-            _ = try await testServicesClient.createInstance(
-                email: user.email,
-                password: user.password,
-                name: user.name,
-                verificationCode: nil,
-                deviceName: deviceName
-            )
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for deviceName in deviceNames {
+                group.addTask {
+                    _ = try await self.testServicesClient.createInstance(
+                        email: user.email,
+                        password: user.password,
+                        name: user.name,
+                        verificationCode: nil,
+                        deviceName: deviceName
+                    )
+                }
+            }
+            try await group.waitForAll()
         }
 
         // WHEN
-        _ = try WelcomePage()
-            .enterEmailOrSSO(user.email)
-            .enterPassword(user.password)
-            .acceptFirstTimeAlert()
-
-        let conversationsPage = try ManagedDevicesPage()
-            .removeFirstDeviceAndContinue(password: user.password)
+        _ = try app.loginUser(email: user.email, password: user.password)
 
         // THEN
-        XCTAssertTrue(
-            conversationsPage.conversationsButton.exists,
-            "Conversations tab did not appear after removing a device"
-        )
+        _ = try ManagedDevicesPage()
+            .removeFirstDeviceAndContinue(password: user.password)
     }
 }

--- a/wire-ios/WireUITests/Helper/TestServicesClient.swift
+++ b/wire-ios/WireUITests/Helper/TestServicesClient.swift
@@ -80,24 +80,6 @@ class TestServicesClient {
             return cachedInstanceId
         }
 
-        let instanceId = try await createInstance(
-            email: email,
-            password: password,
-            name: name,
-            verificationCode: verificationCode,
-            deviceName: deviceName
-        )
-        instanceCache[email] = instanceId
-        return instanceId
-    }
-
-    func createInstance(
-        email: String,
-        password: String,
-        name: String,
-        verificationCode: String?,
-        deviceName: String = "device\(Int.random(in: 10_000 ... 99_999))"
-    ) async throws -> String {
         let url = URL(string: "\(testServiceURL)/api/v1/instance")
         guard let requestUrl = url else { fatalError() }
 
@@ -126,6 +108,7 @@ class TestServicesClient {
             CreateInstanceResponse.self,
             from: responseData
         )
+        instanceCache[email] = instanceResponse.instanceId
         await createdInstances.add(instanceResponse.instanceId)
         return instanceResponse.instanceId
     }

--- a/wire-ios/WireUITests/Helper/TestServicesClient.swift
+++ b/wire-ios/WireUITests/Helper/TestServicesClient.swift
@@ -73,10 +73,11 @@ class TestServicesClient {
         password: String,
         name: String,
         verificationCode: String?,
-        deviceName: String = "device\(Int.random(in: 10_000 ... 99_999))"
+        deviceName: String = "device\(Int.random(in: 10_000 ... 99_999))",
+        useCache: Bool = true
     ) async throws -> String {
 
-        if let cachedInstanceId = instanceCache[email] {
+        if useCache, let cachedInstanceId = instanceCache[email] {
             return cachedInstanceId
         }
 
@@ -108,7 +109,9 @@ class TestServicesClient {
             CreateInstanceResponse.self,
             from: responseData
         )
-        instanceCache[email] = instanceResponse.instanceId
+        if useCache {
+            instanceCache[email] = instanceResponse.instanceId
+        }
         await createdInstances.add(instanceResponse.instanceId)
         return instanceResponse.instanceId
     }

--- a/wire-ios/WireUITests/Helper/TestServicesClient.swift
+++ b/wire-ios/WireUITests/Helper/TestServicesClient.swift
@@ -80,6 +80,24 @@ class TestServicesClient {
             return cachedInstanceId
         }
 
+        let instanceId = try await createInstance(
+            email: email,
+            password: password,
+            name: name,
+            verificationCode: verificationCode,
+            deviceName: deviceName
+        )
+        instanceCache[email] = instanceId
+        return instanceId
+    }
+
+    func createInstance(
+        email: String,
+        password: String,
+        name: String,
+        verificationCode: String?,
+        deviceName: String = "device\(Int.random(in: 10_000 ... 99_999))"
+    ) async throws -> String {
         let url = URL(string: "\(testServiceURL)/api/v1/instance")
         guard let requestUrl = url else { fatalError() }
 
@@ -108,7 +126,6 @@ class TestServicesClient {
             CreateInstanceResponse.self,
             from: responseData
         )
-        instanceCache[email] = instanceResponse.instanceId
         await createdInstances.add(instanceResponse.instanceId)
         return instanceResponse.instanceId
     }

--- a/wire-ios/WireUITests/Pages/ManagedDevicesPage.swift
+++ b/wire-ios/WireUITests/Pages/ManagedDevicesPage.swift
@@ -29,6 +29,10 @@ class ManagedDevicesPage: PageModel {
         app.buttons[Locators.ManageDevicesPage.manageDevices.rawValue].firstMatch
     }
 
+    var passwordField: XCUIElement {
+        app.secureTextFields.firstMatch
+    }
+
     static func removeDeviceAndContinueIfShown(app: XCUIApplication) throws -> ConversationsPage {
         let manageDevicesButton = app.buttons[Locators.ManageDevicesPage.manageDevices.rawValue].firstMatch
 
@@ -37,15 +41,32 @@ class ManagedDevicesPage: PageModel {
             return try ConversationsPage()
         }
 
+        return try removeFirstDeviceAndContinue(app: app, manageDevicesButton: manageDevicesButton)
+    }
+
+    func removeDeviceAndContinueIfShown() throws -> ConversationsPage {
+        try Self.removeDeviceAndContinueIfShown(app: app)
+    }
+
+    func removeFirstDeviceAndContinue(password: String) throws -> ConversationsPage {
+        manageDevicesButton.tap()
+        app.images[Locators.ManageDevicesPage.removeDevice.rawValue].firstMatch.waitAndTap()
+        app.buttons[Locators.ManageDevicesPage.deleteDevice.rawValue].firstMatch.waitAndTap()
+        try passwordField.tapIfKeyboardNotFocused().typeText(password)
+        app.buttons[Locators.ManageDevicesPage.ok.rawValue].firstMatch.waitAndTap()
+
+        return try ConversationsPage()
+    }
+
+    private static func removeFirstDeviceAndContinue(
+        app: XCUIApplication,
+        manageDevicesButton: XCUIElement
+    ) throws -> ConversationsPage {
         manageDevicesButton.tap()
         app.images[Locators.ManageDevicesPage.removeDevice.rawValue].firstMatch.waitAndTap()
         app.buttons[Locators.ManageDevicesPage.deleteDevice.rawValue].firstMatch.waitAndTap()
 
         return try ConversationsPage()
-    }
-
-    func removeDeviceAndContinueIfShown() throws -> ConversationsPage {
-        try Self.removeDeviceAndContinueIfShown(app: app)
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24967" title="WPB-24967" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24967</a>  [iOS] Automation - TC-8973 - As a user, I am able to delete if device client limit reached(too many devices)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

UITest - to manage device when limit of 7 devices reached and deleting one device will let user enter the app after login.

### Changes
Using testServices, same user being instance created for 7 devices and then attempting to login on UI to see this limit reached screen.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._
Local run


https://github.com/user-attachments/assets/7bdcc600-fdbf-4a67-b8cc-fe89185015ba







---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
