### PR TITLE
fix: Wire Gov landing page - WPB-26207

### DIFF
--- a/wire-ios/Wire-iOS Tests/ReferenceImages/NoDefaultBackendViewControllerTests/testThatItShowsAnErrorMessage.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/NoDefaultBackendViewControllerTests/testThatItShowsAnErrorMessage.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:884098dccbba5101c1ea4df68ea7ab2d43c6c4baf4b4899a71b7fce1ef4c1564
-size 145172
+oid sha256:74bdefbef184fff19992b4fcd2dfa74132fb6ebeeed48e6f7e165b7d553beff9
+size 145117

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/NoDefaultBackendViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/NoDefaultBackendViewController.swift
@@ -154,6 +154,7 @@ final class NoDefaultBackendViewController: UIViewController, AuthenticationCoor
         configureSubviews()
         createConstraints()
         configureObservers()
+        setUpDeepLinkHandling()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -320,6 +321,13 @@ final class NoDefaultBackendViewController: UIViewController, AuthenticationCoor
 
         scrollView.contentInset.bottom = overlap
         scrollView.verticalScrollIndicatorInsets.bottom = overlap
+    }
+
+    private func setUpDeepLinkHandling() {
+        authenticationCoordinator?.unauthenticatedSession.appendURLActionProcessors { [weak self] configURL in
+            self?.configurationTextField.text = configURL.absoluteString
+            self?.updateConfigureButtonEnabled()
+        }
     }
 
     // MARK: - QR scanner

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/NoDefaultBackendViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/NoDefaultBackendViewController.swift
@@ -95,7 +95,7 @@ final class NoDefaultBackendViewController: UIViewController, AuthenticationCoor
     // (via SecurityFlag.clipboard).
     //
     // This is the landing page for the Wire Gov edition, but we want
-    // to be allow the user to paste in the configuration link. Therefore
+    // to allow the user to paste in the configuration link. Therefore
     // we override the SecurityFlag.clipboard setting and allow the
     // context menu here.
     private let configurationTextField = ValidatedTextField(

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/NoDefaultBackendViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/NoDefaultBackendViewController.swift
@@ -123,7 +123,7 @@ final class NoDefaultBackendViewController: UIViewController, AuthenticationCoor
         let label = UILabel()
         label.font = AuthenticationStepController.errorMessageFont
         label.textColor = SemanticColors.Label.textErrorDefault
-        label.textAlignment = .center
+        label.textAlignment = .natural
         label.numberOfLines = 0
         label.isHidden = true
         label.accessibilityIdentifier = "validation-failure"

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/NoDefaultBackendViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/NoDefaultBackendViewController.swift
@@ -90,7 +90,19 @@ final class NoDefaultBackendViewController: UIViewController, AuthenticationCoor
         return label
     }()
 
-    private let configurationTextField = ValidatedTextField(kind: .unknown, style: .default)
+    // Exceptional case: in the Wire Gov edition, the context menu
+    // (including copy/paste actions) is disabled app wide
+    // (via SecurityFlag.clipboard).
+    //
+    // This is the landing page for the Wire Gov edition, but we want
+    // to be allow the user to paste in the configuration link. Therefore
+    // we override the SecurityFlag.clipboard setting and allow the
+    // context menu here.
+    private let configurationTextField = ValidatedTextField(
+        kind: .unknown,
+        style: .default,
+        overrideIsContextMenuAllowed: true
+    )
 
     private let qrCodeButton: IconButton = {
         let button = IconButton()

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
@@ -127,13 +127,16 @@ final class ValidatedTextField: AccessoryTextField, TextContainer {
     ///   - kind: the type of text field
     ///   - leftInset: placeholder left inset
     ///   - cornerRadius: optional corner radius override
+    ///   - overrideIsContextMenuAllowed: if true, the context menu will be enabled despite SecurityFlag settings.
+    ///                                   This should only be used in exceptional cases.
     init(
         kind: Kind = .unknown,
         leftInset: CGFloat = 8,
         accessoryTrailingInset: CGFloat = 16,
         cornerRadius: CGFloat? = nil,
         setNewColors: Bool = false,
-        style: TextFieldStyle
+        style: TextFieldStyle,
+        overrideIsContextMenuAllowed: Bool = false
     ) {
 
         self.textFieldValidator = TextFieldValidator()
@@ -164,7 +167,7 @@ final class ValidatedTextField: AccessoryTextField, TextContainer {
             leftInset: leftInset,
             accessoryTrailingInset: accessoryTrailingInset,
             textFieldAttributes: textFieldAttributes,
-            isContextMenuAllowed: SecurityFlags.clipboard.isEnabled
+            isContextMenuAllowed: overrideIsContextMenuAllowed || SecurityFlags.clipboard.isEnabled
         )
         setupTextFieldProperties()
 

--- a/wire-ios/Wire-iOS/Sources/URLActionRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/URLActionRouter.swift
@@ -210,7 +210,9 @@ extension URLActionRouter: PresentationDelegate {
                 presentLocalizedErrorAlert(localizedError)
             }
 
-            if DeveloperFlag.useWireAuthentication.isOn {
+            // This action is handled in WireAuthentication,
+            // or in NoDefaultBackendViewcontroller for Wire Gov
+            if DeveloperFlag.useWireAuthentication.isOn || Bundle.backendBundle == nil {
                 decisionHandler(SecurityFlags.customBackend.isEnabled)
             } else {
                 // Switching backend is handled below, so pass false here.

--- a/wire-ios/Wire-iOS/Sources/URLActionRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/URLActionRouter.swift
@@ -211,7 +211,7 @@ extension URLActionRouter: PresentationDelegate {
             }
 
             // This action is handled in WireAuthentication,
-            // or in NoDefaultBackendViewcontroller for Wire Gov
+            // or in NoDefaultBackendViewController for Wire Gov
             if DeveloperFlag.useWireAuthentication.isOn || Bundle.backendBundle == nil {
                 decisionHandler(SecurityFlags.customBackend.isEnabled)
             } else {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26207" title="WPB-26207" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26207</a>  [iOS] Landing screen for Gov edition, support URLs and E-Mail
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue
This PR address the following Wire Gov issues:

- The configuration link text field could not be pasted
  - **cause**: Wire Gov has the SecurityFlag.clipboard set to disabled
  - **solution**: make an exception because the is the landing page and it's unreasonable to expect the user to manually type a long url.
- Error label text alignment does not match design specs
  -  **cause**: text alignment is centered
  - **solution**: align text to `natural`
- Opening app with backend switch deep link causes landing page to reappear
  - **cause**: default handling of the link switches the backend and restarts authentication
  - **solution**: bypass default handling, provide new url action processor to paste the config link in the text field so the user can submit it. 

### Testing

To test copy paste:
1. Copy a deep link to your clipboard
2. Launch Wire Gov
3. Verify you can paste in the input field on the landing page

To test error text alignment:
1. Launch Wire Gov
2. Enter an invalid link
3. Verify the text is left aligned

To test deep link handling
1. Copy a backend switch deep link to the clipboard
2. Paste it in Safari and enter
3. Verify Wire Gov launches and the configuration link is entered in the input field

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
