### PR TITLE
fix: failure collecting simulator diagnostics - WPB-27452

### DIFF
--- a/wire-ios-data-model/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-data-model/Tests/TestPlans/AllTests.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "commandLineArgumentEntries" : [
       {
         "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"

--- a/wire-ios-images/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-images/Tests/TestPlans/AllTests.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "environmentVariableEntries" : [
 
     ],

--- a/wire-ios-mocktransport/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-mocktransport/Tests/TestPlans/AllTests.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "commandLineArgumentEntries" : [
       {
         "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"

--- a/wire-ios-request-strategy/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-request-strategy/Tests/TestPlans/AllTests.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "commandLineArgumentEntries" : [
       {
         "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"

--- a/wire-ios-share-engine/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-share-engine/Tests/TestPlans/AllTests.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "environmentVariableEntries" : [
 
     ],

--- a/wire-ios-testing/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-testing/Tests/TestPlans/AllTests.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "environmentVariableEntries" : [
 
     ],

--- a/wire-ios-transport/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-transport/Tests/TestPlans/AllTests.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "environmentVariableEntries" : [
 
     ],

--- a/wire-ios-utilities/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-utilities/Tests/TestPlans/AllTests.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "environmentVariableEntries" : [
 
     ],

--- a/wire-ios/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios/Tests/TestPlans/AllTests.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "commandLineArgumentEntries" : [
       {
         "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27452" title="WPB-27452" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27452</a>  [iOS] CI timeout due to issue collecting simulator logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Sometimes our CI/CD gets stuck for 10 minutes getting simulator diagnostics. We see the following in the GitHub action logs.

> DETestOperationsObserverDebug: Failure collecting diagnostics from simulator: Timed out after 600.0 seconds while waiting for a response from the invoked process

This is preventing https://github.com/wireapp/wire-ios/pull/5040 from merging to develop because in the merge queue test don't complete within the required timeout where it gets stuck for 20 or 30 min with the above error (the issue is somewhat inconsistant)

I believe this issue can arise when code coverage is enabled (see https://github.com/fastlane/fastlane/issues/21461) and code coverage isn't working due to the following error which is visible in the xcresult files:

> Failed to merge raw profiles in directory /Users/admin/actions-runner/_work/wire-ios/wire-ios/DerivedData/Build/ProfileData/44598927-6FE6-4C5A-BF22-95DA47BFF081 to destination /Users/admin/actions-runner/_work/wire-ios/wire-ios/DerivedData/Build/ProfileData/44598927-6FE6-4C5A-BF22-95DA47BFF081/Coverage.profdata: Aggregation tool '/Applications/Xcode_26.1.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-profdata' failed with exit code 1: warning: /Users/admin/actions-runner/_work/wire-ios/wire-ios/DerivedData/Build/ProfileData/44598927-6FE6-4C5A-BF22-95DA47BFF081/81D31753-460A-4154-81BD-3A0325C68082-16110.profraw: raw profile version mismatch: Profile uses raw profile format version = 8; expected version = 10
PLEASE update this tool to version in the raw profile, or regenerate raw profile with expected version.
error: no profile can be merged

According to https://developer.apple.com/forums/thread/770289 this is likely because some of our dependencies are built with an old version of Xcode - my suspicion is wireapp/ocmock which is built with Xcode 14.

Looking through our targets which have ocmock as a dependency we see that while code coverage is enabled it is not working... We see the above error and visually in Xcode it looks like:

<img width="2032" height="2241" alt="Screenshot 2026-07-24 at 15 51 52" src="https://github.com/user-attachments/assets/2defec88-44cb-41ab-981b-96b5f651dc40" />

This PR is a workaround. It removes code coverage from targets where it is broken. Currently I'm running tests [here](https://github.com/wireapp/wire-ios/actions/runs/30099645223/job/89502181791) which has this fix applied to @acv-w 's PR. If that test run doesn't contain the above simulator issue I suspect this fix has worked. 

I will create another ticket to address the broken code coverage.

### Testing

Check output of https://github.com/wireapp/wire-ios/actions/runs/30099645223/job/89502181791 has no:

> DETestOperationsObserverDebug: Failure collecting diagnostics from simulator: Timed out after 600.0 seconds while waiting for a response from the invoked process

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.