### PR TITLE
fix: call kit crash (hopefully) - WPB-27604

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
@@ -374,12 +374,12 @@ public class CallKitManager: NSObject, CallKitManagerInterface {
     ) {
         logger.info("report incoming call preemptively", attributes: .safePublic)
 
-        guard !callRegister.callExists(for: handle) else {
-            logger.critical("fail: report incoming call preemptively: call doesn't exist", attributes: .safePublic)
-            return
+        let existingCall = callRegister.lookupCall(by: handle)
+        if existingCall != nil {
+            logger.warn("report incoming call preemptively: call already exists. Re-reporting", attributes: .safePublic)
         }
 
-        let call = callRegister.registerNewCall(with: handle)
+        let call = existingCall ?? callRegister.registerNewCall(with: handle)
 
         let update = CXCallUpdate()
         update.localizedCallerName = callerName
@@ -397,9 +397,14 @@ public class CallKitManager: NSObject, CallKitManagerInterface {
             with: call.id,
             update: update
         ) { [weak self] error in
-            if let error {
-                self?.logger.error("fail: report incoming call preemptively: \(error)", attributes: .safePublic)
-                self?.callRegister.unregisterCall(call)
+            guard let error, let self else { return }
+
+            switch error {
+            case CXErrorCodeIncomingCallError.callUUIDAlreadyExists:
+                logger.warn("reported new incoming call again, ignoring error", attributes: .safePublic)
+            default:
+                logger.error("fail: report incoming call preemptively: \(error)", attributes: .safePublic)
+                callRegister.unregisterCall(call)
             }
         }
     }

--- a/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
@@ -396,8 +396,8 @@ public class CallKitManager: NSObject, CallKitManagerInterface {
         provider.reportNewIncomingCall(
             with: call.id,
             update: update
-        ) { [weak self] error in
-            guard let error, let self else { return }
+        ) { [logger, callRegister] error in
+            guard let error else { return }
 
             switch error {
             case CXErrorCodeIncomingCallError.callUUIDAlreadyExists:

--- a/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
+++ b/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
@@ -123,9 +123,7 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
             let callerName = payload["callerName"] as? String,
             let hasVideo = payload["hasVideo"] as? Bool
         else {
-            Self.logger.critical("error: processing NSE push: invalid payload - \(payload)")
-            completion()
-            return
+            fatalError("error: processing NSE push: invalid payload - \(payload)")
         }
 
         backgroundActivityFactory.resume()


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

This is a possible partial fix for one of our most common crashes:

`PushKit: -[PKPushRegistry _terminateAppIfThereAreUnhandledVoIPPushes]`.

When the NSE determines that we need CallKit to ring / stop ringing it wakes the main app by calling `CXProvider.reportNewIncomingVoIPPushPayload(_ dictionaryPayload:)`. From the main app we need to respond to the push in `VoIPPushManager.processNSEPush(payload:completion:)` - here we **must** call `CXProvider.reportNewIncomingCall(with:update:completion:)` or we risk a crash. 

This code fixes an early return where we attempt to avoid multiple calls to `CXProvider.reportNewIncomingCall(with:update:completion:)`. However this is incorrect behavior - it is fine to call this method multiple times... subsequent calls respond with an error.

See https://wearezeta.atlassian.net/browse/WPB-23464?focusedCommentId=168159 for more details

### Testing

1. Manual testing of calling to check nothing is broken.
2. Observing crashes in TestFlight to see if numbers have dropped.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

