### PR TITLE
fix: Increasing timeout for manual run to 150m as test cancelling - WPB-27693

### DIFF
--- a/.github/workflows/critical_flows.yaml
+++ b/.github/workflows/critical_flows.yaml
@@ -66,5 +66,5 @@ jobs:
       ui_test_tags: ${{ inputs.run_uitests && inputs.ui_test_scope != '' && format('critical,{0}', inputs.ui_test_scope) || inputs.run_uitests && 'critical' || inputs.ui_test_scope }}
       testiny_run_name: ${{ inputs.testiny_run_name }}
       notify: always
-      timeout_minutes: 120
+      timeout_minutes: 150
     secrets: inherit


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-27693

<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue
timeout cancelling run for manually running all tests on release4.24

Changes: Increased timeout to 150minutes.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
