### PR TITLE
fix: regex parsing for Testiny test execution + Testcase count - WPB-27707

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -81,10 +81,8 @@ custom_rules:
     name: "XCUITest requires Testiny TC ID"
     included:
       - "WireUITests"
-    # Matches only real XCTest methods: non-private, no parameters. Attributes and
-    # modifiers may sit on the same line (@MainActor func testFoo...).
     regex: '^\s*(?:(?:@\w+|internal|public|open|final|nonisolated|override)\s+)*func\s+(?!test(?:(?!_TC_)[A-Za-z0-9_])*_TC_\d+(?:_\d+)*\s*\(\s*\))test[A-Za-z0-9_]*\s*\(\s*\)'
-    message: "Use Testiny TC suffix as testABC_TC_1234 if one OR testABC_TC_1234_2222_3333 if multiple"
+    message: "Please use Testiny TC suffix as testABC_TC_1234 if one OR testABC_TC_1234_2222_3333 if multiple"
     severity: error
 
 excluded:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -81,8 +81,10 @@ custom_rules:
     name: "XCUITest requires Testiny TC ID"
     included:
       - "WireUITests"
-    regex: '^\s*func\s+test(?![A-Za-z0-9_]*_TC_\d+(?:_\d+)*)[A-Za-z0-9_]*\s*\('
-    message: "WireUITests test methods must include a Testiny TC ID suffix, for example: testLogin_TC_1234"
+    # Matches only real XCTest methods: non-private, no parameters. Attributes and
+    # modifiers may sit on the same line (@MainActor func testFoo...).
+    regex: '^\s*(?:(?:@\w+|internal|public|open|final|nonisolated|override)\s+)*func\s+(?!test(?:(?!_TC_)[A-Za-z0-9_])*_TC_\d+(?:_\d+)*\s*\(\s*\))test[A-Za-z0-9_]*\s*\(\s*\)'
+    message: "Use Testiny TC suffix as testABC_TC_1234 if one OR testABC_TC_1234_2222_3333 if multiple"
     severity: error
 
 excluded:

--- a/scripts/extract-summary.sh
+++ b/scripts/extract-summary.sh
@@ -225,17 +225,19 @@ TESTINY_FAILED="$(jq -r '.testiny_failed' <<< "$SUMMARY")"
 TESTINY_SKIPPED="$(jq -r '.testiny_skipped' <<< "$SUMMARY")"
 FAILED_DETAILS="$(jq -r '.failed_details | if length == 0 then "None" else join("\n") end' <<< "$SUMMARY")"
 
-REPORT_MESSAGE="--------------------------------------
-**XCTest Methods:** total ${TOTAL} | passed ${PASSED} | failed ${FAILED} | skipped ${SKIPPED}
---------------------------------------"
-
 if [ "$TESTINY_TOTAL" -gt 0 ]; then
-  REPORT_MESSAGE="${REPORT_MESSAGE}
+  REPORT_MESSAGE="**XCTest Methods:** Total ${TOTAL} | Passed ${PASSED} | Failed ${FAILED} | Skipped ${SKIPPED}
 
 **Total Testiny Test Cases:** ${TESTINY_TOTAL}
 ✅ **Passed:** ${TESTINY_PASSED}
 ❌ **Failed:** ${TESTINY_FAILED}
 ⏭️ **Skipped:** ${TESTINY_SKIPPED}
+--------------------------------------"
+else
+  REPORT_MESSAGE="**Total Tests:** ${TOTAL}
+✅ **Passed:** ${PASSED}
+❌ **Failed:** ${FAILED}
+⏭️ **Skipped:** ${SKIPPED}
 --------------------------------------"
 fi
 

--- a/scripts/extract-summary.sh
+++ b/scripts/extract-summary.sh
@@ -73,6 +73,32 @@ for XCRESULT in "${XCRESULTS[@]}"; do
       def failed_test_cases:
         test_cases | map(select((.result? // "" | ascii_downcase) == "failed"));
 
+      def testiny_ids_from_text:
+        (tostring | gsub("[^A-Za-z0-9_]"; "_")) as $text
+        | ($text | (capture("_TC_+(?<chain>.*)$"; "i")? // {}).chain? // "") as $chain
+        | if $chain == "" then []
+          else
+            (
+              reduce ($chain | split("_")[]) as $part (
+                {active: true, ids: []};
+                if .active == false then .
+                elif ($part | ascii_downcase) == "tc" then .
+                elif ($part | test("^\\d+$")) then .ids += [$part]
+                elif $part == "" then .
+                else .active = false
+                end
+              )
+              | .ids
+              | unique
+            )
+          end;
+
+      def testiny_ids:
+        [(.name? // ""), (.nodeIdentifier? // ""), (.nodeIdentifierURL? // "")]
+        | map(testiny_ids_from_text)
+        | add
+        | unique;
+
       def failure_message:
         ((.children // [])
           | map(select(.nodeType? == "Failure Message") | .name?)
@@ -106,6 +132,9 @@ for XCRESULT in "${XCRESULTS[@]}"; do
         passed: (test_cases | map(select((.result? // "" | ascii_downcase) == "passed")) | length),
         failed: (failed_test_cases | length),
         skipped: (test_cases | map(select((.result? // "" | ascii_downcase) | test("skipped|expected"))) | length),
+        testiny_passed_ids: (test_cases | map(select((.result? // "" | ascii_downcase) == "passed") | testiny_ids) | add // [] | unique),
+        testiny_failed_ids: (failed_test_cases | map(testiny_ids) | add // [] | unique),
+        testiny_skipped_ids: (test_cases | map(select((.result? // "" | ascii_downcase) | test("skipped|expected")) | testiny_ids) | add // [] | unique),
         failed_details: (
           failed_test_cases
           | map("  ❌ " + test_title + ": " + (failure_message | normalize))
@@ -150,6 +179,9 @@ for XCRESULT in "${XCRESULTS[@]}"; do
       passed: (.passedTests // 0),
       failed: (.failedTests // 0),
       skipped: ((.skippedTests // 0) + (.expectedFailures // 0)),
+      testiny_passed_ids: [],
+      testiny_failed_ids: [],
+      testiny_skipped_ids: [],
       failed_details: (
         failures
         | map("  ❌ " + failure_title + ": " + ((.failureText? // "No failure message available") | normalize))
@@ -165,11 +197,20 @@ if [ ! -s "$SUMMARY_FILE" ]; then
 fi
 
 SUMMARY="$(jq -s -c '
-  {
+  (map(.testiny_failed_ids // []) | add // [] | unique) as $testiny_failed
+  | (map(.testiny_passed_ids // []) | add // [] | unique) as $testiny_passed
+  | (map(.testiny_skipped_ids // []) | add // [] | unique) as $testiny_skipped
+  | ($testiny_passed - $testiny_failed) as $testiny_passed_only
+  | ($testiny_skipped - $testiny_failed - $testiny_passed) as $testiny_skipped_only
+  | {
     total: (map(.total) | add // 0),
     passed: (map(.passed) | add // 0),
     failed: (map(.failed) | add // 0),
     skipped: (map(.skipped) | add // 0),
+    testiny_total: (($testiny_failed + $testiny_passed_only + $testiny_skipped_only) | length),
+    testiny_passed: ($testiny_passed_only | length),
+    testiny_failed: ($testiny_failed | length),
+    testiny_skipped: ($testiny_skipped_only | length),
     failed_details: ([.[].failed_details[]] | unique | .[:20])
   }
 ' "$SUMMARY_FILE")"
@@ -178,14 +219,25 @@ TOTAL="$(jq -r '.total' <<< "$SUMMARY")"
 PASSED="$(jq -r '.passed' <<< "$SUMMARY")"
 FAILED="$(jq -r '.failed' <<< "$SUMMARY")"
 SKIPPED="$(jq -r '.skipped' <<< "$SUMMARY")"
+TESTINY_TOTAL="$(jq -r '.testiny_total' <<< "$SUMMARY")"
+TESTINY_PASSED="$(jq -r '.testiny_passed' <<< "$SUMMARY")"
+TESTINY_FAILED="$(jq -r '.testiny_failed' <<< "$SUMMARY")"
+TESTINY_SKIPPED="$(jq -r '.testiny_skipped' <<< "$SUMMARY")"
 FAILED_DETAILS="$(jq -r '.failed_details | if length == 0 then "None" else join("\n") end' <<< "$SUMMARY")"
 
 REPORT_MESSAGE="--------------------------------------
-**Total Tests:** ${TOTAL}
-✅ **Passed:** ${PASSED}
-❌ **Failed:** ${FAILED}
-⏭️ **Skipped:** ${SKIPPED}
+**XCTest Methods:** total ${TOTAL} | passed ${PASSED} | failed ${FAILED} | skipped ${SKIPPED}
 --------------------------------------"
+
+if [ "$TESTINY_TOTAL" -gt 0 ]; then
+  REPORT_MESSAGE="${REPORT_MESSAGE}
+
+**Total Testiny Test Cases:** ${TESTINY_TOTAL}
+✅ **Passed:** ${TESTINY_PASSED}
+❌ **Failed:** ${TESTINY_FAILED}
+⏭️ **Skipped:** ${TESTINY_SKIPPED}
+--------------------------------------"
+fi
 
 if [ "$FAILED" -gt 0 ] && [ "$FAILED_DETAILS" != "None" ]; then
   REPORT_MESSAGE="${REPORT_MESSAGE}

--- a/scripts/send_xcresult_to_testiny.py
+++ b/scripts/send_xcresult_to_testiny.py
@@ -49,25 +49,54 @@ class PendingResult:
     status: str
 
 
+class TestinyAPIError(RuntimeError):
+    """A Testiny API call failed. `status` is the HTTP status, or None for network errors."""
+
+    def __init__(self, message: str, status: int | None = None):
+        super().__init__(message)
+        self.status = status
+
+
+# The first `_TC_` marks where the ID chain starts, so digits earlier in the name
+# (test_2FA_TC_1234) are never read as case IDs.
+TC_CHAIN_START_RE = re.compile(r'_TC_+(?=\d)', re.IGNORECASE)
+# One `<id>` link of the chain, with an optional repeated `TC_` prefix.
+TC_ID_RE = re.compile(r'(?:TC_+)?(\d+)(?:_+|$)', re.IGNORECASE)
+
+
 def extract_tc_keys(test_name: str) -> List[str]:
     """
     Extract all TC IDs from function name.
+
+    Only the leading ID chain is read: scanning stops at the first segment that is
+    not an ID, so trailing text (test_TC_1234_retry_2) never yields a bogus TC-2.
     Supports:
         test_TC_1234
         test_TC_1234_1111_2222
         test_TC_1234_TC_1111_TC_2222
-        test_TC_1234_1111_TC_2222
+        test_TC_1234_TC__1111
     """
-    matches = re.findall(r'_TC_(\d+)', test_name, re.IGNORECASE)
-    if not matches:
+    name = test_name.strip().rstrip("()")
+    chain_start = TC_CHAIN_START_RE.search(name)
+    if chain_start is None:
         return []
 
+    chain = name[chain_start.end():]
     seen = set()
     keys: List[str] = []
-    for m in matches:
-        if m not in seen:
-            seen.add(m)
-            keys.append(f"TC-{m}")
+    pos = 0
+    while pos < len(chain):
+        match = TC_ID_RE.match(chain, pos)
+        if match is None:
+            break
+        tc_id = match.group(1)
+        if tc_id not in seen:
+            seen.add(tc_id)
+            keys.append(f"TC-{tc_id}")
+        pos = match.end()
+
+    if pos < len(chain):
+        print(f"[WARN] Ignoring trailing text '{chain[pos:]}' in test name '{test_name}'")
 
     return keys
 
@@ -213,11 +242,12 @@ def call_testiny_api(method: str, endpoint: str, body=None):
         with urllib.request.urlopen(req, timeout=30) as resp:
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
-        raise RuntimeError(
-            f"Testiny {method} {endpoint} -> {e.code}: {e.read().decode()}"
+        raise TestinyAPIError(
+            f"Testiny {method} {endpoint} -> {e.code}: {e.read().decode()}",
+            status=e.code,
         )
     except urllib.error.URLError as e:
-        raise RuntimeError(f"Network error calling {endpoint}: {e.reason}")
+        raise TestinyAPIError(f"Network error calling {endpoint}: {e.reason}")
 
 def append_ci_summary(run_id: int, run_name: str) -> None:
     github_server = os.environ.get("GITHUB_SERVER_URL")
@@ -282,14 +312,22 @@ def resolve_run(title: str, require_existing: bool) -> int:
 
 
 def find_testiny_id(tc_key: str) -> int | None:
+    """
+    Resolve a TC key to a Testiny test case id.
+
+    Returns None when the case does not exist (HTTP 404). Any other failure raises,
+    so a Testiny outage or a bad API key is not silently reported as "not found".
+    """
     numeric = re.sub(r'^TC-', '', tc_key, flags=re.IGNORECASE)
     if not numeric.isdigit():
         return None
     try:
         tc = call_testiny_api("GET", f"/testcase/{numeric}")
-        return tc["id"]
-    except Exception:
-        return None
+    except TestinyAPIError as e:
+        if e.status == 404:
+            return None
+        raise
+    return tc.get("id")
 
 
 def bulk_send(results: List[PendingResult]) -> None:
@@ -305,26 +343,33 @@ def bulk_send(results: List[PendingResult]) -> None:
 
 def resolve_test_cases(tests: List[FlatTest], run_id: int):
     results_to_upload = []
-    skipped_no_tag = 0
-    skipped_missing = 0
+    untagged: List[str] = []
+    missing: List[str] = []
+    lookup_errors = 0
 
     for t in tests:
         if not t.tc_keys:
-            skipped_no_tag += 1
+            untagged.append(t.name)
             continue
 
         status = map_status(t.status)
 
         for key in t.tc_keys:
-            tc_id = find_testiny_id(key)
+            try:
+                tc_id = find_testiny_id(key)
+            except TestinyAPIError as e:
+                print(f"[ERROR] Lookup of {key} ({t.name}) failed: {e}", file=sys.stderr)
+                lookup_errors += 1
+                continue
+
             if tc_id is None:
-                print(f"[WARN] {key} not found in Testiny")
-                skipped_missing += 1
+                print(f"[WARN] {key} not found in Testiny ({t.name})")
+                missing.append(key)
                 continue
 
             results_to_upload.append(PendingResult(run_id, tc_id, status))
 
-    return results_to_upload, skipped_no_tag, skipped_missing
+    return results_to_upload, untagged, missing, lookup_errors
 
 
 def parse_args():
@@ -355,7 +400,15 @@ def main():
 
     run_id = resolve_run(args.run_name, args.require_existing_run)
 
-    pending, skipped_no_tag, skipped_missing = resolve_test_cases(tests, run_id)
+    pending, untagged, missing, lookup_errors = resolve_test_cases(tests, run_id)
+
+    if untagged:
+        print(f"[WARN] {len(untagged)} test(s) without a usable TC id, not reported to Testiny:")
+        for name in untagged:
+            print(f"         {name}")
+
+    if missing:
+        print(f"[WARN] {len(missing)} TC id(s) not found in Testiny: {', '.join(missing)}")
 
     dedup = {}
     for r in pending:
@@ -374,6 +427,16 @@ def main():
             exit_code = 1
     else:
         print("[INFO] No results to send")
+
+    # Missing cases only warn, but a lookup that failed for another reason means
+    # results were dropped without anybody knowing, so fail the run.
+    if lookup_errors:
+        print(
+            f"[ERROR] {lookup_errors} test case lookup(s) failed (not a 'not found'); "
+            "those results were not uploaded",
+            file=sys.stderr,
+        )
+        exit_code = 1
 
     append_ci_summary(run_id, args.run_name)
     sys.exit(exit_code)

--- a/wire-ios/WireUITests/AccountManagementTests.swift
+++ b/wire-ios/WireUITests/AccountManagementTests.swift
@@ -25,7 +25,7 @@ final class AccountManagementTests: WireUITestCase {
     var teamMember: UserInfo!
 
     @MainActor
-    func testUpdateNameAndUsernameInfo_TC_8932_TC_8934() async throws {
+    func testUpdateNameAndUsernameInfo_TC_8932_8934() async throws {
 
         let user = try await UserHelper.default.createPersonalUser()
 
@@ -74,7 +74,7 @@ final class AccountManagementTests: WireUITestCase {
     }
 
     @MainActor
-    func testAccountManagementUpdateEmailAndResetPassword_TC_8933_TC_8931() async throws {
+    func testAccountManagementUpdateEmailAndResetPassword_TC_8933_8931() async throws {
 
         let updatedUserDetails = UserGenerator.generateUniqueUserInfo()
 

--- a/wire-ios/WireUITests/BackupRestoreHistoryTests.swift
+++ b/wire-ios/WireUITests/BackupRestoreHistoryTests.swift
@@ -24,7 +24,7 @@ final class BackupRestoreHistoryTests: WireUITestCase {
 
     /// [critical]
     @MainActor
-    func testCreateBackupAndRestoreHistoryWithPassword_TC_8928_TC_8930_TC_8805() async throws {
+    func testCreateBackupAndRestoreHistoryWithPassword_TC_8928_8930_8805() async throws {
         var (messageFromOwner, teamOwner, activeConversationPage) = try await createTeamConversationAndSendMessage()
 
         let creatingBackupPage = try activeConversationPage.goBackToConversationPage()

--- a/wire-ios/WireUITests/SSOTests.swift
+++ b/wire-ios/WireUITests/SSOTests.swift
@@ -44,7 +44,7 @@ final class SSOTests: WireUITestCase {
 
     /// [critical]
     @MainActor
-    func testSSOLoginWithSSOCodeAndNoResetPassword_TC_8966_TC_10850() async throws {
+    func testSSOLoginWithSSOCodeAndNoResetPassword_TC_8966_10850() async throws {
         // GIVEN
         let ssoUser = try await createSSOUser()
         let ssoCode = try ssoHelper.getSSOCode()

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -90,7 +90,7 @@ final class ZCallingTests: WireUITestCase {
     /// Team Owner creates group conversation and initiates a group call with members via calling service
     /// [critical]
     @MainActor
-    func testMultipleUsersJoiningGroupCall_TC_8910_TC_8880() async throws {
+    func testMultipleUsersJoiningGroupCall_TC_8910_8880() async throws {
 
         let teamAndGroupCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 3)
 
@@ -244,7 +244,7 @@ final class ZCallingTests: WireUITestCase {
     /// Call participant switches from audio call to video call and back
     /// [critical]
     @MainActor
-    func testSwitchBetweenAudioAndVideoCallAndShowsParticipantVideo_TC_8888_TC_9497() async throws {
+    func testSwitchBetweenAudioAndVideoCallAndShowsParticipantVideo_TC_8888_9497() async throws {
 
         let teamAndGroupCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27707" title="WPB-27707" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27707</a>  [iOS] fix regex parsing of testcase for the integration of xcresult to Testiny 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

1. While running all tests, test function having like testABC_TC_1111_2222_3333 -> Following tests 2222 and 3333 were not getting parsed correctly.
2. Test functions were showing up in place of actual testcase in case of UItests


### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

<img width="1676" height="968" alt="image" src="https://github.com/user-attachments/assets/ab980fb4-99ed-4624-b780-0070ca3bc0f6" />


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
